### PR TITLE
Add `equiv()` function for more easily readable equivalence testing

### DIFF
--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -92,6 +92,12 @@ impl<K> UnionFind<K>
         }
     }
 
+    /// Returns `true` if the given elements belong to the same set, and returns
+    /// `false` otherwise.
+    pub fn equiv(&self, x: K, y: K) -> bool {
+        self.find(x) == self.find(y)        
+    }
+
 
     /// Unify the two sets containing `x` and `y`.
     ///

--- a/tests/unionfind.rs
+++ b/tests/unionfind.rs
@@ -34,6 +34,34 @@ fn uf_test() {
 }
 
 #[test]
+fn uf_test_with_equiv() {
+    let n = 8;
+    let mut u = UnionFind::new(n);
+    for i in 0..n {
+        assert_eq!(u.find(i), i);
+        assert_eq!(u.find_mut(i), i);
+        assert!(u.equiv(i, i));
+    }
+
+    u.union(0, 1);
+    assert!(u.equiv(0, 1));
+    u.union(1, 3);
+    u.union(1, 4);
+    u.union(4, 7);
+    assert!(u.equiv(0, 7));
+    assert!(u.equiv(1, 3));
+    assert!(!u.equiv(0, 2));
+    assert!(u.equiv(7, 0));
+    u.union(5, 6);
+    assert!(u.equiv(6, 5));
+    assert!(!u.equiv(6, 7));
+
+    // check that there are now 3 disjoint sets
+    let set = (0..n).map(|i| u.find(i)).collect::<HashSet<_>>();
+    assert_eq!(set.len(), 3);
+}
+
+#[test]
 fn uf_rand() {
     let n = 1 << 14;
     let mut rng = ChaChaRng::from_rng(thread_rng()).unwrap();


### PR DESCRIPTION
A [different union-find implementation](https://docs.rs/disjoint-sets/0.4.2/disjoint_sets/struct.UnionFind.html#method.equiv) has a method called `equiv()` for determining whether two elements are equivalent (that is, they belong to the same set.) 

I think this is a useful addition to the library:

 - It is more easily readable than its implementation, and it's more immediately obvious what it does
 - It usefully abstracts exactly how it is implemented
 - Unlike `union()`, which already implements this, it has no side-effects and is named more consistently with that functionality

There's a test that simply duplicates the test above it, just using `equiv()` instead of `assert_eq!`