### PR TITLE
Implement an edges_connecting(a, b) iterator for Graph

### DIFF
--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -46,7 +46,7 @@ impl<N> Dominators<N>
         }
     }
 
-    /// Iterate over the given node's that strict dominators.
+    /// Iterate over the given node's strict dominators.
     ///
     /// If the given node is not reachable from the root, then `None` is
     /// returned.

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -859,9 +859,9 @@ impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
     /// - `Directed` and `Undirected`: All edges connecting `a` and `b`.
     ///
     /// Iterator element type is `EdgeReference<E, Ix>`.
-    pub fn edges_connecting(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> MultipleEdges<E, Ty, Ix>
+    pub fn edges_connecting(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> EdgesConnecting<E, Ty, Ix>
     {
-        MultipleEdges {
+        EdgesConnecting {
             match_end: b,
             edges: &self.edges,
             next: match self.nodes.get(a.index()) {
@@ -1291,7 +1291,7 @@ impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
                 weight: node_map(NodeIndex::new(i), &node.weight),
                 next: node.next,
             }));
-        g.edges.extend(enumerate(&self.edges).map(|(i, edge)| 
+        g.edges.extend(enumerate(&self.edges).map(|(i, edge)|
             Edge {
                 weight: edge_map(EdgeIndex::new(i), &edge.weight),
                 next: edge.next,
@@ -1611,7 +1611,7 @@ impl<'a, E, Ty, Ix> Iterator for Edges<'a, E, Ty, Ix>
 }
 
 /// Iterator over the multiple edges between two nodes
-pub struct MultipleEdges<'a, E: 'a, Ty, Ix: 'a = DefaultIx>
+pub struct EdgesConnecting<'a, E: 'a, Ty, Ix: 'a = DefaultIx>
     where Ty: EdgeType,
           Ix: IndexType,
 {
@@ -1626,7 +1626,7 @@ pub struct MultipleEdges<'a, E: 'a, Ty, Ix: 'a = DefaultIx>
     ty: PhantomData<Ty>,
 }
 
-impl<'a, E, Ty, Ix> Iterator for MultipleEdges<'a, E, Ty, Ix>
+impl<'a, E, Ty, Ix> Iterator for EdgesConnecting<'a, E, Ty, Ix>
     where Ty: EdgeType,
           Ix: IndexType,
 {
@@ -2002,7 +2002,7 @@ impl<'a, N, Ix> Iterator for NodeReferences<'a, N, Ix>
     type Item = (NodeIndex<Ix>, &'a N);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|(i, node)| 
+        self.iter.next().map(|(i, node)|
             (node_index(i), &node.weight)
         )
     }
@@ -2061,7 +2061,7 @@ impl<'a, E, Ix> Iterator for EdgeReferences<'a, E, Ix>
     type Item = EdgeReference<'a, E, Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|(i, edge)| 
+        self.iter.next().map(|(i, edge)|
             EdgeReference {
                 index: edge_index(i),
                 node: edge.node,

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -854,9 +854,10 @@ impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
         }
     }
 
-    /// Return an iterator over all edges connecting `a` and `b`.
+    /// Return an iterator over all the edges connecting `a` and `b`.
     ///
-    /// - `Directed` and `Undirected`: All edges connecting `a` and `b`.
+    /// - `Directed`: Outgoing edges from `a`.
+    /// - `Undirected`: All edges connected to `a`.
     ///
     /// Iterator element type is `EdgeReference<E, Ix>`.
     pub fn edges_connecting(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> EdgesConnecting<E, Ty, Ix>

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -283,6 +283,25 @@ fn multi() {
     assert_eq!(gr.edge_count(), 2);
 
 }
+
+#[test]
+fn iter_multi_edges() {
+    let mut gr = Graph::new();
+    let a = gr.add_node("a");
+    let b = gr.add_node("b");
+    let c = gr.add_node("c");
+    gr.add_edge(a, b, ());
+    gr.add_edge(a, c, ());
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+
+    let mut iter = gr.edges_connecting(a, b);
+
+    assert_eq!(EdgeIndex::new(2), iter.next().unwrap().id());
+    assert_eq!(EdgeIndex::new(0), iter.next().unwrap().id());
+    assert_eq!(None, iter.next());
+}
+
 #[test]
 fn update_edge()
 {
@@ -1565,7 +1584,7 @@ fn filtered_edge_reverse() {
     assert_eq!(set(po), set(vec![c, d]));
 
     // Now let's test the same graph but undirected
-    
+
     let mut g = Graph::new_undirected();
     let a = g.add_node("A");
     let b = g.add_node("B");

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -290,16 +290,27 @@ fn iter_multi_edges() {
     let a = gr.add_node("a");
     let b = gr.add_node("b");
     let c = gr.add_node("c");
-    gr.add_edge(a, b, ());
+
+    let mut connecting_edges = HashSet::new();
+
+    gr.add_edge(a, a, ());
+    connecting_edges.insert(gr.add_edge(a, b, ()));
     gr.add_edge(a, c, ());
-    gr.add_edge(a, b, ());
-    gr.add_edge(b, c, ());
+    gr.add_edge(c, b, ());
+    connecting_edges.insert(gr.add_edge(a, b, ()));
 
     let mut iter = gr.edges_connecting(a, b);
 
-    assert_eq!(EdgeIndex::new(2), iter.next().unwrap().id());
-    assert_eq!(EdgeIndex::new(0), iter.next().unwrap().id());
+    let edge_id = iter.next().unwrap().id();
+    assert!(connecting_edges.contains(&edge_id));
+    connecting_edges.remove(&edge_id);
+
+    let edge_id = iter.next().unwrap().id();
+    assert!(connecting_edges.contains(&edge_id));
+    connecting_edges.remove(&edge_id);
+
     assert_eq!(None, iter.next());
+    assert!(connecting_edges.is_empty());
 }
 
 #[test]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -298,8 +298,43 @@ fn iter_multi_edges() {
     gr.add_edge(a, c, ());
     gr.add_edge(c, b, ());
     connecting_edges.insert(gr.add_edge(a, b, ()));
+    gr.add_edge(b, a, ());
 
     let mut iter = gr.edges_connecting(a, b);
+
+    let edge_id = iter.next().unwrap().id();
+    assert!(connecting_edges.contains(&edge_id));
+    connecting_edges.remove(&edge_id);
+
+    let edge_id = iter.next().unwrap().id();
+    assert!(connecting_edges.contains(&edge_id));
+    connecting_edges.remove(&edge_id);
+
+    assert_eq!(None, iter.next());
+    assert!(connecting_edges.is_empty());
+}
+
+#[test]
+fn iter_multi_undirected_edges() {
+    let mut gr = Graph::new_undirected();
+    let a = gr.add_node("a");
+    let b = gr.add_node("b");
+    let c = gr.add_node("c");
+
+    let mut connecting_edges = HashSet::new();
+
+    gr.add_edge(a, a, ());
+    connecting_edges.insert(gr.add_edge(a, b, ()));
+    gr.add_edge(a, c, ());
+    gr.add_edge(c, b, ());
+    connecting_edges.insert(gr.add_edge(a, b, ()));
+    connecting_edges.insert(gr.add_edge(b, a, ()));
+
+    let mut iter = gr.edges_connecting(a, b);
+
+    let edge_id = iter.next().unwrap().id();
+    assert!(connecting_edges.contains(&edge_id));
+    connecting_edges.remove(&edge_id);
 
     let edge_id = iter.next().unwrap().id();
     assert!(connecting_edges.contains(&edge_id));


### PR DESCRIPTION
Closes issue #53.

I added a new iterator (`EdgesConnecting`) for the multiple edges between two nodes with type `EdgeReference`.
Given the new iterator, the function requested by the issue has the following signature:

  edges_connecting(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> EdgesConnecting<E, Ty, Ix>

and simply returns a properly constructed iterator.

Fixes #53 
