### PR TITLE
No_std feature switch 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ jobs:
     - rust: nightly
     - rust: nightly
       env:
+      - FEATURES='no_std'
+    - rust: nightly
+      env:
        - FEATURES='unstable quickcheck'
        - BENCH=1
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,24 @@ jobs:
     - rust: 1.37.0
       env:
       - ALL=' '
+      - FEATURES='default'
     - rust: stable
       env:
-        - FEATURES='unstable quickcheck'
+        - FEATURES='unstable quickcheck default'
         - CHECKFMT=1
     - rust: beta
-    - rust: nightly
+      env:
+       - FEATURES='default'
     - rust: nightly
       env:
-      - FEATURES='no_std'
+        - FEATURES='default'
     - rust: nightly
       env:
-       - FEATURES='unstable quickcheck'
+       - ALL='--package petgraph'
+       - FEATURES='no_std'
+    - rust: nightly
+      env:
+       - FEATURES='unstable quickcheck default'
        - BENCH=1
 branches:
   only:
@@ -27,11 +33,10 @@ before_script:
       fi
 script:
   - |
-      cargo build --verbose --no-default-features &&
-      cargo test --verbose --no-default-features &&
-      cargo build --verbose --features "$FEATURES" &&
-      cargo test ${ALL:---all} --verbose --features "$FEATURES" &&
+      cargo build --verbose --no-default-features --features "$FEATURES" &&
+      cargo test ${ALL:---all} --verbose --no-default-features --features "$FEATURES" &&
       if [ "${CHECKFMT}" == "1"]; then
         cargo +stable fmt -- --check
       fi
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ defmac = "0.1"
 itertools = { version = "0.8", default-features = false }
 
 [features]
-default = ["graphmap", "stable_graph", "matrix_graph"]
+default = ["graphmap", "stable_graph", "matrix_graph", "std"]
+std = []
 graphmap = []
 serde-1 = ["serde/default", "serde_derive"]
 serde-1-no_std = ["serde", "serde_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.5.1"
 license = "MIT/Apache-2.0"
 authors = [
 "bluss",
-"mitchmindtree",
+"mitchmindtree"
 ]
 
 description = "Graph data structure library. Provides graph types and graph algorithms."
@@ -31,7 +31,7 @@ debug = true
 fixedbitset = { version = "0.3.0", default-features = false }
 quickcheck = { optional = true, version = "0.8", default-features = false }
 indexmap = { version = "1.0.2" }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false }
 serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
@@ -43,9 +43,12 @@ itertools = { version = "0.8", default-features = false }
 [features]
 default = ["graphmap", "stable_graph", "matrix_graph"]
 graphmap = []
-serde-1 = ["serde", "serde_derive"]
+serde-1 = ["serde/default", "serde_derive"]
+serde-1-no_std = ["serde", "serde_derive"]
 stable_graph = []
 matrix_graph = []
+no_std = ["alloc"]
+alloc = []
 
 # For unstable features
 generate = []

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -21,7 +21,7 @@ use alloc::{
 #[cfg(feature = "no_std")]
 use core::{cmp::Ordering, hash::Hash, usize, iter::Iterator};
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
@@ -41,7 +41,7 @@ where
     dominators: HashMap<N, N>,
 }
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 impl<N> Dominators<N>
 where
     N: Copy + Eq + Hash,
@@ -166,7 +166,7 @@ where
     dominators: &'a Dominators<N>,
     node: Option<N>,
 }
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 impl<'a, N> Iterator for DominatorsIter<'a, N>
 where
     N: 'a + Copy + Eq + Hash,
@@ -222,7 +222,7 @@ const UNDEFINED: usize = usize::MAX;
 /// to ~30,000 vertices.
 ///
 /// [0]: http://www.cs.rice.edu/~keith/EMBED/dom.pdf
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 pub fn simple_fast<G>(graph: G, root: G::NodeId) -> Dominators<G::NodeId>
 where
     G: IntoNeighbors + Visitable,
@@ -394,7 +394,7 @@ fn intersect(dominators: &[usize], mut finger1: usize, mut finger2: usize) -> us
     }
 }
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 fn predecessor_sets_to_idx_vecs<N>(
     post_order: &[N],
     node_to_post_order_idx: &HashMap<N, usize>,
@@ -444,7 +444,7 @@ where
         .collect()
 }
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 fn simple_fast_post_order<G>(
     graph: G,
     root: G::NodeId,

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -12,9 +12,22 @@
 //! strictly dominates **B** and there does not exist any node **C** where **A**
 //! dominates **C** and **C** dominates **B**.
 
-use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet, hash_map::Iter};
-use std::hash::Hash;
+#[cfg(feature = "alloc")]
+use alloc::{
+    collections::{BTreeMap as HashMap, BTreeSet as HashSet, btree_map::Iter},
+    vec::Vec,
+};
+
+#[cfg(feature = "no_std")]
+use core::{cmp::Ordering, hash::Hash, usize, iter::Iterator};
+
+#[cfg(not(feature = "no_std"))]
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    hash::Hash,
+    usize,
+};
 
 use crate::visit::{DfsPostOrder, GraphBase, IntoNeighbors, Visitable, Walker};
 
@@ -28,9 +41,64 @@ where
     dominators: HashMap<N, N>,
 }
 
+#[cfg(not(feature = "alloc"))]
 impl<N> Dominators<N>
 where
     N: Copy + Eq + Hash,
+{
+    /// Get the root node used to construct these dominance relations.
+    pub fn root(&self) -> N {
+        self.root
+    }
+
+    /// Get the immediate dominator of the given node.
+    ///
+    /// Returns `None` for any node that is not reachable from the root, and for
+    /// the root itself.
+    pub fn immediate_dominator(&self, node: N) -> Option<N> {
+        if node == self.root {
+            None
+        } else {
+            self.dominators.get(&node).cloned()
+        }
+    }
+
+    /// Iterate over the given node's that strict dominators.
+    ///
+    /// If the given node is not reachable from the root, then `None` is
+    /// returned.
+    pub fn strict_dominators(&self, node: N) -> Option<DominatorsIter<N>> {
+        if self.dominators.contains_key(&node) {
+            Some(DominatorsIter {
+                dominators: self,
+                node: self.immediate_dominator(node),
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Iterate over all of the given node's dominators (including the given
+    /// node itself).
+    ///
+    /// If the given node is not reachable from the root, then `None` is
+    /// returned.
+    pub fn dominators(&self, node: N) -> Option<DominatorsIter<N>> {
+        if self.dominators.contains_key(&node) {
+            Some(DominatorsIter {
+                dominators: self,
+                node: Some(node),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<N> Dominators<N>
+where
+    N: Copy + Eq + Hash + Ord,
 {
     /// Get the root node used to construct these dominance relations.
     pub fn root(&self) -> N {
@@ -98,7 +166,7 @@ where
     dominators: &'a Dominators<N>,
     node: Option<N>,
 }
-
+#[cfg(not(feature = "alloc"))]
 impl<'a, N> Iterator for DominatorsIter<'a, N>
 where
     N: 'a + Copy + Eq + Hash,
@@ -114,6 +182,7 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 /// Iterator for nodes dominated by a given node.
 pub struct DominatedByIter<'a, N>
 where
@@ -123,6 +192,7 @@ where
     node: N,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a, N> Iterator for DominatedByIter<'a, N>
 where
     N: 'a + Copy + Eq + Hash,
@@ -141,7 +211,7 @@ where
 
 /// The undefined dominator sentinel, for when we have not yet discovered a
 /// node's dominator.
-const UNDEFINED: usize = ::std::usize::MAX;
+const UNDEFINED: usize = usize::MAX;
 
 /// This is an implementation of the engineered ["Simple, Fast Dominance
 /// Algorithm"][0] discovered by Cooper et al.
@@ -152,10 +222,92 @@ const UNDEFINED: usize = ::std::usize::MAX;
 /// to ~30,000 vertices.
 ///
 /// [0]: http://www.cs.rice.edu/~keith/EMBED/dom.pdf
+#[cfg(not(feature = "alloc"))]
 pub fn simple_fast<G>(graph: G, root: G::NodeId) -> Dominators<G::NodeId>
 where
     G: IntoNeighbors + Visitable,
     <G as GraphBase>::NodeId: Eq + Hash,
+{
+    let (post_order, predecessor_sets) = simple_fast_post_order(graph, root);
+    let length = post_order.len();
+    debug_assert!(length > 0);
+    debug_assert!(post_order.last() == Some(&root));
+
+    // From here on out we use indices into `post_order` instead of actual
+    // `NodeId`s wherever possible. This greatly improves the performance of
+    // this implementation, but we have to pay a little bit of upfront cost to
+    // convert our data structures to play along first.
+
+    // Maps a node to its index into `post_order`.
+    let node_to_post_order_idx: HashMap<_, _> = post_order
+        .iter()
+        .enumerate()
+        .map(|(idx, &node)| (node, idx))
+        .collect();
+
+    // Maps a node's `post_order` index to its set of predecessors's indices
+    // into `post_order` (as a vec).
+    let idx_to_predecessor_vec =
+        predecessor_sets_to_idx_vecs(&post_order, &node_to_post_order_idx, predecessor_sets);
+
+    let mut dominators = vec![UNDEFINED; length];
+    dominators[length - 1] = length - 1;
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+
+        // Iterate in reverse post order, skipping the root.
+
+        for idx in (0..length - 1).rev() {
+            debug_assert!(post_order[idx] != root);
+
+            // Take the intersection of every predecessor's dominator set; that
+            // is the current best guess at the immediate dominator for this
+            // node.
+
+            let new_idom_idx = {
+                let mut predecessors = idx_to_predecessor_vec[idx]
+                    .iter()
+                    .filter(|&&p| dominators[p] != UNDEFINED);
+                let new_idom_idx = predecessors.next().expect(
+                    "Because the root is initialized to dominate itself, and is the \
+                     first node in every path, there must exist a predecessor to this \
+                     node that also has a dominator",
+                );
+                predecessors.fold(*new_idom_idx, |new_idom_idx, &predecessor_idx| {
+                    intersect(&dominators, new_idom_idx, predecessor_idx)
+                })
+            };
+
+            debug_assert!(new_idom_idx < length);
+
+            if new_idom_idx != dominators[idx] {
+                dominators[idx] = new_idom_idx;
+                changed = true;
+            }
+        }
+    }
+
+    // All done! Translate the indices back into proper `G::NodeId`s.
+
+    debug_assert!(!dominators.iter().any(|&dom| dom == UNDEFINED));
+
+    Dominators {
+        root: root,
+        dominators: dominators
+            .into_iter()
+            .enumerate()
+            .map(|(idx, dom_idx)| (post_order[idx], post_order[dom_idx]))
+            .collect(),
+    }
+}
+
+#[cfg(feature = "alloc")]
+pub fn simple_fast<G>(graph: G, root: G::NodeId) -> Dominators<G::NodeId>
+where
+    G: IntoNeighbors + Visitable,
+    <G as GraphBase>::NodeId: Eq + Hash + Ord,
 {
     let (post_order, predecessor_sets) = simple_fast_post_order(graph, root);
     let length = post_order.len();
@@ -242,6 +394,7 @@ fn intersect(dominators: &[usize], mut finger1: usize, mut finger2: usize) -> us
     }
 }
 
+#[cfg(not(feature = "alloc"))]
 fn predecessor_sets_to_idx_vecs<N>(
     post_order: &[N],
     node_to_post_order_idx: &HashMap<N, usize>,
@@ -266,6 +419,32 @@ where
         .collect()
 }
 
+#[cfg(feature = "alloc")]
+fn predecessor_sets_to_idx_vecs<N>(
+    post_order: &[N],
+    node_to_post_order_idx: &HashMap<N, usize>,
+    mut predecessor_sets: HashMap<N, HashSet<N>>,
+) -> Vec<Vec<usize>>
+where
+    N: Copy + Eq + Hash + Ord,
+{
+    post_order
+        .iter()
+        .map(|node| {
+            predecessor_sets
+                .remove(node)
+                .map(|predecessors| {
+                    predecessors
+                        .into_iter()
+                        .map(|p| *node_to_post_order_idx.get(&p).unwrap())
+                        .collect()
+                })
+                .unwrap_or_else(Vec::new)
+        })
+        .collect()
+}
+
+#[cfg(not(feature = "alloc"))]
 fn simple_fast_post_order<G>(
     graph: G,
     root: G::NodeId,
@@ -291,7 +470,34 @@ where
     (post_order, predecessor_sets)
 }
 
+#[cfg(feature = "alloc")]
+fn simple_fast_post_order<G>(
+    graph: G,
+    root: G::NodeId,
+) -> (Vec<G::NodeId>, HashMap<G::NodeId, HashSet<G::NodeId>>)
+where
+    G: IntoNeighbors + Visitable,
+    <G as GraphBase>::NodeId: Eq + Hash + Ord,
+{
+    let mut post_order = vec![];
+    let mut predecessor_sets = HashMap::new();
+
+    for node in DfsPostOrder::new(graph, root).iter(graph) {
+        post_order.push(node);
+
+        for successor in graph.neighbors(node) {
+            predecessor_sets
+                .entry(successor)
+                .or_insert_with(HashSet::new)
+                .insert(node);
+        }
+    }
+
+    (post_order, predecessor_sets)
+}
+
 #[cfg(test)]
+#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
 

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -95,6 +95,15 @@ where
             None
         }
     }
+
+    /// Iterate over all nodes immediately dominated by the given node (not
+    /// including the given node itself).
+    pub fn immediately_dominated_by(&self, node: N) -> DominatedByIter<N> {
+        DominatedByIter {
+            iter: self.dominators.iter(),
+            node: node
+        }
+    }
 }
 
 /// Iterator for a node's dominators.
@@ -121,7 +130,6 @@ where
     }
 }
 
-#[cfg(feature = "alloc")]
 /// Iterator for nodes dominated by a given node.
 pub struct DominatedByIter<'a, N>
 where
@@ -131,7 +139,6 @@ where
     node: N,
 }
 
-#[cfg(feature = "alloc")]
 impl<'a, N> Iterator for DominatedByIter<'a, N>
 where
     N: 'a + Copy + Eq + Hash,

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -6,7 +6,7 @@
 
 pub mod dominators;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{cmp::min, collections::{BinaryHeap, HashMap, VecDeque}, fmt::Debug, ops::Add};
 
 #[cfg(feature = "no_std")]

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -6,8 +6,14 @@
 
 pub mod dominators;
 
-use std::cmp::min;
-use std::collections::{BinaryHeap, HashMap};
+#[cfg(not(feature = "no_std"))]
+use std::{cmp::min, collections::{BinaryHeap, HashMap, VecDeque}, fmt::Debug, ops::Add};
+
+#[cfg(feature = "no_std")]
+use core::{cmp::min, fmt::Debug, ops::Add};
+
+#[cfg(feature = "alloc")]
+use alloc::{collections::{BinaryHeap, BTreeMap as HashMap}, vec::Vec, collections::vec_deque::VecDeque};
 
 use crate::prelude::*;
 
@@ -839,14 +845,14 @@ where
 pub fn is_bipartite_undirected<G, N, VM>(g: G, start: N) -> bool
 where
     G: GraphRef + Visitable<NodeId = N, Map = VM> + IntoNeighbors<NodeId = N>,
-    N: Copy + PartialEq + std::fmt::Debug,
+    N: Copy + PartialEq + Debug,
     VM: VisitMap<N>,
 {
     let mut red = g.visit_map();
     red.visit(start);
     let mut blue = g.visit_map();
 
-    let mut stack = ::std::collections::VecDeque::new();
+    let mut stack = VecDeque::new();
     stack.push_front(start);
 
     while let Some(node) = stack.pop_front() {
@@ -885,9 +891,6 @@ where
 
     true
 }
-
-use std::fmt::Debug;
-use std::ops::Add;
 
 /// Associated data that can be used for measures (such as length).
 pub trait Measure: Debug + PartialOrd + Add<Self, Output = Self> + Default + Clone {}

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -1,7 +1,23 @@
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::{BinaryHeap, HashMap};
+#[cfg(not(feature = "alloc"))]
+use std::collections::{
+    hash_map::Entry::{Occupied, Vacant},
+    BinaryHeap, HashMap,
+};
 
+#[cfg(not(feature = "no_std"))]
 use std::hash::Hash;
+
+#[cfg(feature = "alloc")]
+use alloc::{
+    collections::{
+        btree_map::Entry::{Occupied, Vacant},
+        BTreeMap as HashMap, BinaryHeap,
+    },
+    vec::Vec,
+};
+
+#[cfg(feature = "no_std")]
+use core::hash::Hash;
 
 use super::visit::{EdgeRef, GraphBase, IntoEdges, VisitMap, Visitable};
 use crate::scored::MinScored;
@@ -63,6 +79,7 @@ use crate::algo::Measure;
 ///
 /// Returns the total cost + the path of subsequent `NodeId` from start to finish, if one was
 /// found.
+#[cfg(not(feature = "alloc"))]
 pub fn astar<G, F, H, K, IsGoal>(
     graph: G,
     start: G::NodeId,
@@ -136,6 +153,80 @@ where
     None
 }
 
+#[cfg(feature = "alloc")]
+pub fn astar<G, F, H, K, IsGoal>(
+    graph: G,
+    start: G::NodeId,
+    mut is_goal: IsGoal,
+    mut edge_cost: F,
+    mut estimate_cost: H,
+) -> Option<(K, Vec<G::NodeId>)>
+where
+    G: IntoEdges + Visitable,
+    IsGoal: FnMut(G::NodeId) -> bool,
+    G::NodeId: Eq + Hash + Ord,
+    F: FnMut(G::EdgeRef) -> K,
+    H: FnMut(G::NodeId) -> K,
+    K: Measure + Copy,
+{
+    let mut visited = graph.visit_map();
+    let mut visit_next = BinaryHeap::new();
+    let mut scores = HashMap::new();
+    let mut path_tracker = PathTracker::<G>::new();
+
+    let zero_score = K::default();
+    scores.insert(start, zero_score);
+    visit_next.push(MinScored(estimate_cost(start), start));
+
+    while let Some(MinScored(_, node)) = visit_next.pop() {
+        if is_goal(node) {
+            let path = path_tracker.reconstruct_path_to(node);
+            let cost = scores[&node];
+            return Some((cost, path));
+        }
+
+        // Don't visit the same node several times, as the first time it was visited it was using
+        // the shortest available path.
+        if !visited.visit(node) {
+            continue;
+        }
+
+        // This lookup can be unwrapped without fear of panic since the node was necessarily scored
+        // before adding him to `visit_next`.
+        let node_score = scores[&node];
+
+        for edge in graph.edges(node) {
+            let next = edge.target();
+            if visited.is_visited(&next) {
+                continue;
+            }
+
+            let mut next_score = node_score + edge_cost(edge);
+
+            match scores.entry(next) {
+                Occupied(ent) => {
+                    let old_score = *ent.get();
+                    if next_score < old_score {
+                        *ent.into_mut() = next_score;
+                        path_tracker.set_predecessor(next, node);
+                    } else {
+                        next_score = old_score;
+                    }
+                }
+                Vacant(ent) => {
+                    ent.insert(next_score);
+                    path_tracker.set_predecessor(next, node);
+                }
+            }
+
+            let next_estimate_score = next_score + estimate_cost(next);
+            visit_next.push(MinScored(next_estimate_score, next));
+        }
+    }
+
+    None
+}
+
 struct PathTracker<G>
 where
     G: GraphBase,
@@ -143,11 +234,42 @@ where
 {
     came_from: HashMap<G::NodeId, G::NodeId>,
 }
-
+#[cfg(not(feature = "alloc"))]
 impl<G> PathTracker<G>
 where
     G: GraphBase,
     G::NodeId: Eq + Hash,
+{
+    fn new() -> PathTracker<G> {
+        PathTracker {
+            came_from: HashMap::new(),
+        }
+    }
+
+    fn set_predecessor(&mut self, node: G::NodeId, previous: G::NodeId) {
+        self.came_from.insert(node, previous);
+    }
+
+    fn reconstruct_path_to(&self, last: G::NodeId) -> Vec<G::NodeId> {
+        let mut path = vec![last];
+
+        let mut current = last;
+        while let Some(&previous) = self.came_from.get(&current) {
+            path.push(previous);
+            current = previous;
+        }
+
+        path.reverse();
+
+        path
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<G> PathTracker<G>
+where
+    G: GraphBase,
+    G::NodeId: Eq + Hash + Ord,
 {
     fn new() -> PathTracker<G> {
         PathTracker {

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -1,10 +1,10 @@
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 use std::collections::{
     hash_map::Entry::{Occupied, Vacant},
     BinaryHeap, HashMap,
 };
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::hash::Hash;
 
 #[cfg(feature = "alloc")]
@@ -79,7 +79,7 @@ use crate::algo::Measure;
 ///
 /// Returns the total cost + the path of subsequent `NodeId` from start to finish, if one was
 /// found.
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 pub fn astar<G, F, H, K, IsGoal>(
     graph: G,
     start: G::NodeId,
@@ -234,7 +234,7 @@ where
 {
     came_from: HashMap<G::NodeId, G::NodeId>,
 }
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 impl<G> PathTracker<G>
 where
     G: GraphBase,

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1,6 +1,6 @@
 //! Compressed Sparse Row (CSR) is a sparse adjacency matrix graph.
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{
     cmp::{max, Ordering},
     iter::{Enumerate, Zip},
@@ -772,7 +772,7 @@ mod tests {
         m.add_edge(0, 2, ());
         m.add_edge(1, 0, ());
         m.add_edge(1, 1, ());
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
         assert_eq!(&m.column, &[0, 2, 0, 1, 2, 2]);
         assert_eq!(&m.row, &[0, 2, 5, 6]);
@@ -800,7 +800,7 @@ mod tests {
         m.add_edge(0, 2, ());
         m.add_edge(1, 2, ());
         m.add_edge(2, 2, ());
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
         assert_eq!(&m.column, &[0, 2, 2, 0, 1, 2]);
         assert_eq!(&m.row, &[0, 2, 3, 6]);
@@ -813,7 +813,7 @@ mod tests {
     fn csr_from_error_1() {
         // not sorted in source
         let m: Csr = Csr::from_sorted_edges(&[(0, 1), (1, 0), (0, 2)]).unwrap();
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
     }
 
@@ -822,7 +822,7 @@ mod tests {
     fn csr_from_error_2() {
         // not sorted in target
         let m: Csr = Csr::from_sorted_edges(&[(0, 1), (1, 0), (1, 2), (1, 1)]).unwrap();
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
     }
 
@@ -830,7 +830,7 @@ mod tests {
     fn csr_from() {
         let m: Csr =
             Csr::from_sorted_edges(&[(0, 1), (0, 2), (1, 0), (1, 1), (2, 2), (2, 4)]).unwrap();
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
         assert_eq!(m.neighbors_slice(0), &[1, 2]);
         assert_eq!(m.neighbors_slice(1), &[0, 1]);
@@ -853,7 +853,7 @@ mod tests {
             (4, 5),
         ])
         .unwrap();
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
         let mut dfs = Dfs::new(&m, 0);
         while let Some(_) = dfs.next(&m) {}
@@ -864,7 +864,7 @@ mod tests {
         assert!(!dfs.discovered[5]);
 
         m.add_edge(1, 4, ());
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
 
         dfs.reset(&m);
@@ -891,10 +891,10 @@ mod tests {
             (5, 2),
         ])
         .unwrap();
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
         let tarjan = tarjan_scc(&m);
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", tarjan);
     }
 
@@ -914,10 +914,10 @@ mod tests {
             (7, 8, 3.),
         ])
         .unwrap();
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", m);
         let result = bellman_ford(&m, 0).unwrap();
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", result);
         let answer = [0., 0.5, 1.5, 1.5];
         assert_eq!(&answer, &result.0[..4]);
@@ -961,7 +961,7 @@ mod tests {
         let mut copy = Vec::new();
         for e in m.edge_references() {
             copy.push((e.source(), e.target(), *e.weight()));
-            #[cfg(not(feature = "no_std"))]
+            #[cfg(feature = "std")]
             println!("{:?}", e);
         }
         let m2: Csr<(), _> = Csr::from_sorted_edges(&copy).unwrap();
@@ -981,7 +981,7 @@ mod tests {
         assert!(g.add_edge(b, c, ()));
         assert!(g.add_edge(c, a, ()));
 
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", g);
 
         assert_eq!(g.node_count(), 3);
@@ -1003,7 +1003,7 @@ mod tests {
 
         let c = g.add_node(());
 
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{:?}", g);
 
         assert_eq!(g.node_count(), 3);

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1,10 +1,27 @@
 //! Compressed Sparse Row (CSR) is a sparse adjacency matrix graph.
 
-use std::cmp::{max, Ordering};
-use std::iter::{Enumerate, Zip};
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut, Range};
-use std::slice::Windows;
+#[cfg(not(feature = "no_std"))]
+use std::{
+    cmp::{max, Ordering},
+    iter::{Enumerate, Zip},
+    marker::PhantomData,
+    ops::{Index, IndexMut, Range},
+    slice::Iter as SliceIter,
+    slice::Windows,
+};
+
+#[cfg(feature = "no_std")]
+use core::{
+    cmp::{max, Ordering},
+    iter::{Enumerate, Zip},
+    marker::PhantomData,
+    ops::{Index, IndexMut, Range},
+    slice::Iter as SliceIter,
+    slice::Windows,
+};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use crate::visit::{Data, GraphProp, IntoEdgeReferences, NodeCount};
 use crate::visit::{EdgeRef, GraphBase, IntoEdges, IntoNeighbors, NodeIndexable};
@@ -583,8 +600,6 @@ where
     }
 }
 
-use std::slice::Iter as SliceIter;
-
 #[derive(Clone, Debug)]
 pub struct Neighbors<'a, Ix: 'a = DefaultIx> {
     iter: SliceIter<'a, NodeIndex<Ix>>,
@@ -736,12 +751,14 @@ Column: [0, 2, 0, 1, 2, 2]
 Row   : [0, 2, 5]   <- value index of row start
 
  * */
-
+#[allow(unused_variables)]
 #[cfg(test)]
 mod tests {
     use super::Csr;
     use crate::algo::bellman_ford;
     use crate::algo::tarjan_scc;
+    #[cfg(feature = "alloc")]
+    use alloc::vec::Vec;
     use crate::visit::Dfs;
     use crate::visit::VisitMap;
     use crate::Undirected;
@@ -755,6 +772,7 @@ mod tests {
         m.add_edge(0, 2, ());
         m.add_edge(1, 0, ());
         m.add_edge(1, 1, ());
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
         assert_eq!(&m.column, &[0, 2, 0, 1, 2, 2]);
         assert_eq!(&m.row, &[0, 2, 5, 6]);
@@ -782,6 +800,7 @@ mod tests {
         m.add_edge(0, 2, ());
         m.add_edge(1, 2, ());
         m.add_edge(2, 2, ());
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
         assert_eq!(&m.column, &[0, 2, 2, 0, 1, 2]);
         assert_eq!(&m.row, &[0, 2, 3, 6]);
@@ -794,6 +813,7 @@ mod tests {
     fn csr_from_error_1() {
         // not sorted in source
         let m: Csr = Csr::from_sorted_edges(&[(0, 1), (1, 0), (0, 2)]).unwrap();
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
     }
 
@@ -802,6 +822,7 @@ mod tests {
     fn csr_from_error_2() {
         // not sorted in target
         let m: Csr = Csr::from_sorted_edges(&[(0, 1), (1, 0), (1, 2), (1, 1)]).unwrap();
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
     }
 
@@ -809,6 +830,7 @@ mod tests {
     fn csr_from() {
         let m: Csr =
             Csr::from_sorted_edges(&[(0, 1), (0, 2), (1, 0), (1, 1), (2, 2), (2, 4)]).unwrap();
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
         assert_eq!(m.neighbors_slice(0), &[1, 2]);
         assert_eq!(m.neighbors_slice(1), &[0, 1]);
@@ -831,6 +853,7 @@ mod tests {
             (4, 5),
         ])
         .unwrap();
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
         let mut dfs = Dfs::new(&m, 0);
         while let Some(_) = dfs.next(&m) {}
@@ -841,6 +864,7 @@ mod tests {
         assert!(!dfs.discovered[5]);
 
         m.add_edge(1, 4, ());
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
 
         dfs.reset(&m);
@@ -867,8 +891,11 @@ mod tests {
             (5, 2),
         ])
         .unwrap();
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
-        println!("{:?}", tarjan_scc(&m));
+        let tarjan = tarjan_scc(&m);
+        #[cfg(not(feature = "no_std"))]
+        println!("{:?}", tarjan);
     }
 
     #[test]
@@ -887,8 +914,10 @@ mod tests {
             (7, 8, 3.),
         ])
         .unwrap();
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", m);
         let result = bellman_ford(&m, 0).unwrap();
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", result);
         let answer = [0., 0.5, 1.5, 1.5];
         assert_eq!(&answer, &result.0[..4]);
@@ -932,6 +961,7 @@ mod tests {
         let mut copy = Vec::new();
         for e in m.edge_references() {
             copy.push((e.source(), e.target(), *e.weight()));
+            #[cfg(not(feature = "no_std"))]
             println!("{:?}", e);
         }
         let m2: Csr<(), _> = Csr::from_sorted_edges(&copy).unwrap();
@@ -951,6 +981,7 @@ mod tests {
         assert!(g.add_edge(b, c, ()));
         assert!(g.add_edge(c, a, ()));
 
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", g);
 
         assert_eq!(g.node_count(), 3);
@@ -972,6 +1003,7 @@ mod tests {
 
         let c = g.add_node(());
 
+        #[cfg(not(feature = "no_std"))]
         println!("{:?}", g);
 
         assert_eq!(g.node_count(), 3);

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,5 +1,8 @@
 //! Graph traits for associated data and graph construction.
 
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 use crate::graph::IndexType;
 #[cfg(feature = "graphmap")]
 use crate::graphmap::{GraphMap, NodeTrait};

--- a/src/dijkstra.rs
+++ b/src/dijkstra.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 use std::collections::{
     hash_map::Entry::{Occupied, Vacant},
     BinaryHeap, HashMap,
@@ -10,7 +10,7 @@ use alloc::collections::{
     BTreeMap as HashMap, BinaryHeap,
 };
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::hash::Hash;
 
 #[cfg(feature = "no_std")]
@@ -82,7 +82,7 @@ use crate::scored::MinScored;
 /// assert_eq!(res, expected_res);
 /// // z is not inside res because there is not path from b to z.
 /// ```
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 pub fn dijkstra<G, F, K>(
     graph: G,
     start: G::NodeId,

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,5 +1,5 @@
 //! Simple graphviz dot file format output.
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::fmt::{self, Display, Write};
 
 #[cfg(feature = "no_std")]

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,6 +1,12 @@
 //! Simple graphviz dot file format output.
-
+#[cfg(not(feature = "no_std"))]
 use std::fmt::{self, Display, Write};
+
+#[cfg(feature = "no_std")]
+use core::fmt::{self, Display, Write};
+
+#[cfg(feature= "alloc")]
+use alloc::string::{String, ToString};
 
 use crate::visit::{
     Data, EdgeRef, GraphBase, GraphProp, GraphRef, IntoEdgeReferences, IntoNodeReferences,
@@ -262,7 +268,15 @@ mod test {
     use super::{Config, Dot, Escaper};
     use crate::prelude::Graph;
     use crate::visit::NodeRef;
+
+    #[cfg(feature= "std")]
     use std::fmt::Write;
+
+    #[cfg(feature= "no_std")]
+    use core::fmt::Write;
+
+    #[cfg(feature= "alloc")]
+    use alloc::string::String;
 
     #[test]
     fn test_escape() {

--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "no_std"))]
 use std::ops::{Deref, Index, IndexMut};
+
+#[cfg(feature = "no_std")]
+use core::ops::{Deref, Index, IndexMut};
 
 use super::Frozen;
 use crate::data::{DataMap, DataMapMut};

--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::ops::{Deref, Index, IndexMut};
 
 #[cfg(feature = "no_std")]

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1,11 +1,29 @@
-use std::cmp;
-use std::fmt;
-use std::hash::Hash;
-use std::iter;
-use std::marker::PhantomData;
-use std::mem::size_of;
-use std::ops::{Index, IndexMut, Range};
-use std::slice;
+#[cfg(not(feature = "no_std"))]
+use std::{
+    cmp::{self, max},
+    fmt,
+    hash::Hash,
+    iter,
+    marker::PhantomData,
+    mem::size_of,
+    ops::{Index, IndexMut, Range},
+    slice, u16, u32, u8, usize,
+};
+
+#[cfg(feature = "no_std")]
+use core::{
+    cmp::{self, max},
+    fmt,
+    hash::Hash,
+    iter,
+    marker::PhantomData,
+    mem::size_of,
+    ops::{Index, IndexMut, Range},
+    slice, u16, u32, u8, usize,
+};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use crate::{Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected};
 
@@ -47,7 +65,7 @@ unsafe impl IndexType for usize {
     }
     #[inline(always)]
     fn max() -> Self {
-        ::std::usize::MAX
+        usize::MAX
     }
 }
 
@@ -62,7 +80,7 @@ unsafe impl IndexType for u32 {
     }
     #[inline(always)]
     fn max() -> Self {
-        ::std::u32::MAX
+        u32::MAX
     }
 }
 
@@ -77,7 +95,7 @@ unsafe impl IndexType for u16 {
     }
     #[inline(always)]
     fn max() -> Self {
-        ::std::u16::MAX
+        u16::MAX
     }
 }
 
@@ -92,7 +110,7 @@ unsafe impl IndexType for u8 {
     }
     #[inline(always)]
     fn max() -> Self {
-        ::std::u8::MAX
+        u8::MAX
     }
 }
 
@@ -417,8 +435,6 @@ enum Pair<T> {
     One(T),
     None,
 }
-
-use std::cmp::max;
 
 /// Get mutable references at index `a` and `b`.
 fn index_twice<T>(slc: &mut [T], a: usize, b: usize) -> Pair<&mut T> {
@@ -1718,7 +1734,7 @@ where
 
 /// Iterator yielding mutable access to all node weights.
 pub struct NodeWeightsMut<'a, N: 'a, Ix: IndexType = DefaultIx> {
-    nodes: ::std::slice::IterMut<'a, Node<N, Ix>>,
+    nodes: slice::IterMut<'a, Node<N, Ix>>,
 }
 
 impl<'a, N, Ix> Iterator for NodeWeightsMut<'a, N, Ix>
@@ -1738,7 +1754,7 @@ where
 
 /// Iterator yielding mutable access to all edge weights.
 pub struct EdgeWeightsMut<'a, E: 'a, Ix: IndexType = DefaultIx> {
-    edges: ::std::slice::IterMut<'a, Edge<E, Ix>>,
+    edges: slice::IterMut<'a, Edge<E, Ix>>,
 }
 
 impl<'a, E, Ix> Iterator for EdgeWeightsMut<'a, E, Ix>

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{
     cmp::{self, max},
     fmt,

--- a/src/graph_impl/serialization.rs
+++ b/src/graph_impl/serialization.rs
@@ -1,6 +1,12 @@
 use serde::de::Error;
 
+#[cfg(feature = "no_std")]
+use core::marker::PhantomData;
+#[cfg(not(feature = "no_std"))]
 use std::marker::PhantomData;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use crate::prelude::*;
 

--- a/src/graph_impl/serialization.rs
+++ b/src/graph_impl/serialization.rs
@@ -2,7 +2,7 @@ use serde::de::Error;
 
 #[cfg(feature = "no_std")]
 use core::marker::PhantomData;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::marker::PhantomData;
 
 #[cfg(feature = "alloc")]

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -2,15 +2,23 @@
 //!
 //! Depends on `feature = "stable_graph"`.
 //!
+#[cfg(not(feature = "no_std"))]
+use std::{
+    cmp, fmt, iter,
+    marker::PhantomData,
+    mem::{replace, size_of},
+    ops::{Index, IndexMut},
+    slice,
+};
 
-use std::cmp;
-use std::fmt;
-use std::iter;
-use std::marker::PhantomData;
-use std::mem::replace;
-use std::mem::size_of;
-use std::ops::{Index, IndexMut};
-use std::slice;
+#[cfg(feature = "no_std")]
+use core::{
+    cmp, fmt, iter,
+    marker::PhantomData,
+    mem::{replace, size_of},
+    ops::{Index, IndexMut},
+    slice,
+};
 
 use crate::{Directed, Direction, EdgeType, Graph, Incoming, Outgoing, Undirected};
 
@@ -1734,6 +1742,7 @@ impl<'a, E, Ix: IndexType> DoubleEndedIterator for EdgeIndices<'a, E, Ix> {
     }
 }
 
+#[allow(unused_variables)]
 #[test]
 fn stable_graph() {
     let mut gr = StableGraph::<_, _>::with_capacity(0, 0);
@@ -1741,29 +1750,37 @@ fn stable_graph() {
     let b = gr.add_node(1);
     let c = gr.add_node(2);
     let _ed = gr.add_edge(a, b, 1);
+    #[cfg(not(feature = "no_std"))]
     println!("{:?}", gr);
     gr.remove_node(b);
+    #[cfg(not(feature = "no_std"))]
     println!("{:?}", gr);
     let d = gr.add_node(3);
+    #[cfg(not(feature = "no_std"))]
     println!("{:?}", gr);
     gr.check_free_lists();
     gr.remove_node(a);
     gr.check_free_lists();
     gr.remove_node(c);
     gr.check_free_lists();
+    #[cfg(not(feature = "no_std"))]
     println!("{:?}", gr);
     gr.add_edge(d, d, 2);
+    #[cfg(not(feature = "no_std"))]
     println!("{:?}", gr);
 
     let e = gr.add_node(4);
     gr.add_edge(d, e, 3);
+    #[cfg(not(feature = "no_std"))]
     println!("{:?}", gr);
     for neigh in gr.neighbors(d) {
+        #[cfg(not(feature = "no_std"))]
         println!("edge {:?} -> {:?}", d, neigh);
     }
     gr.check_free_lists();
 }
 
+#[allow(unused_variables)]
 #[test]
 fn dfs() {
     use crate::visit::Dfs;
@@ -1780,10 +1797,12 @@ fn dfs() {
     gr.add_edge(c, d, 5);
     gr.add_edge(d, b, 6);
     gr.add_edge(c, b, 7);
+    #[cfg(not(feature = "no_std"))]
     println!("{:?}", gr);
 
     let mut dfs = Dfs::new(&gr, a);
     while let Some(next) = dfs.next(&gr) {
+        #[cfg(not(feature = "no_std"))]
         println!("dfs visit => {:?}, weight={:?}", next, &gr[next]);
     }
 }

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Depends on `feature = "stable_graph"`.
 //!
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{
     cmp, fmt, iter,
     marker::PhantomData,
@@ -1750,31 +1750,31 @@ fn stable_graph() {
     let b = gr.add_node(1);
     let c = gr.add_node(2);
     let _ed = gr.add_edge(a, b, 1);
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     println!("{:?}", gr);
     gr.remove_node(b);
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     println!("{:?}", gr);
     let d = gr.add_node(3);
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     println!("{:?}", gr);
     gr.check_free_lists();
     gr.remove_node(a);
     gr.check_free_lists();
     gr.remove_node(c);
     gr.check_free_lists();
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     println!("{:?}", gr);
     gr.add_edge(d, d, 2);
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     println!("{:?}", gr);
 
     let e = gr.add_node(4);
     gr.add_edge(d, e, 3);
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     println!("{:?}", gr);
     for neigh in gr.neighbors(d) {
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("edge {:?} -> {:?}", d, neigh);
     }
     gr.check_free_lists();
@@ -1797,12 +1797,12 @@ fn dfs() {
     gr.add_edge(c, d, 5);
     gr.add_edge(d, b, 6);
     gr.add_edge(c, b, 7);
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     println!("{:?}", gr);
 
     let mut dfs = Dfs::new(&gr, a);
     while let Some(next) = dfs.next(&gr) {
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("dfs visit => {:?}, weight={:?}", next, &gr[next]);
     }
 }

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -1,7 +1,14 @@
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+#[cfg(not(feature = "no_std"))]
 use std::marker::PhantomData;
+
+#[cfg(feature = "no_std")]
+use core::marker::PhantomData;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use crate::prelude::*;
 

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -1,7 +1,7 @@
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::marker::PhantomData;
 
 #[cfg(feature = "no_std")]

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -1,17 +1,34 @@
 //! `GraphMap<N, E, Ty>` is a graph datastructure where node values are mapping
 //! keys.
 
+#[cfg(not(feature = "no_std"))]
+use std::{
+    cmp::Ordering,
+    fmt,
+    hash::{self, Hash},
+    iter::{Cloned, DoubleEndedIterator, FromIterator},
+    marker::PhantomData,
+    ops::{Deref, Index, IndexMut},
+    slice::Iter,
+};
+
+#[cfg(feature = "no_std")]
+use core::{
+    cmp::Ordering,
+    fmt,
+    hash::{self, Hash},
+    iter::{Cloned, DoubleEndedIterator, FromIterator},
+    marker::PhantomData,
+    ops::{Deref, Index, IndexMut},
+    slice::Iter,
+};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 use indexmap::map::Keys;
 use indexmap::map::{Iter as IndexMapIter, IterMut as IndexMapIterMut};
 use indexmap::IndexMap;
-use std::cmp::Ordering;
-use std::fmt;
-use std::hash::{self, Hash};
-use std::iter::FromIterator;
-use std::iter::{Cloned, DoubleEndedIterator};
-use std::marker::PhantomData;
-use std::ops::{Deref, Index, IndexMut};
-use std::slice::Iter;
 
 use crate::{Directed, Direction, EdgeType, Incoming, Outgoing, Undirected};
 

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -1,7 +1,7 @@
 //! `GraphMap<N, E, Ty>` is a graph datastructure where node values are mapping
 //! keys.
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{
     cmp::Ordering,
     fmt,

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::marker;
 
 #[cfg(feature = "no_std")]

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -1,5 +1,13 @@
-use fixedbitset::FixedBitSet;
+#[cfg(not(feature = "no_std"))]
 use std::marker;
+
+#[cfg(feature = "no_std")]
+use core::marker;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+use fixedbitset::FixedBitSet;
 
 use super::graph::{Graph, IndexType, NodeIndex};
 use super::{EdgeType, Incoming};

--- a/src/iter_format.rs
+++ b/src/iter_format.rs
@@ -1,5 +1,5 @@
 //! Formatting utils
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{cell::RefCell, fmt};
 
 #[cfg(feature = "no_std")]

--- a/src/iter_format.rs
+++ b/src/iter_format.rs
@@ -1,7 +1,9 @@
 //! Formatting utils
+#[cfg(not(feature = "no_std"))]
+use std::{cell::RefCell, fmt};
 
-use std::cell::RefCell;
-use std::fmt;
+#[cfg(feature = "no_std")]
+use core::{cell::RefCell, fmt};
 
 /// Format the iterator like a map
 pub struct DebugMap<F>(pub F);

--- a/src/k_shortest_path.rs
+++ b/src/k_shortest_path.rs
@@ -1,14 +1,16 @@
 #[cfg(feature = "alloc")]
 use alloc::{
-    collections::{BinaryHeap, BTreeMap as HashMap},
+    collections::BinaryHeap,
     vec::Vec,
 };
 
 #[cfg(feature = "std")]
 use std::{
-    hash::Hash,
-    collections::{BinaryHeap, HashMap}
+    collections::BinaryHeap,
+    hash::Hash
 };
+
+use indexmap::IndexMap;
 
 #[cfg(feature = "no_std")]
 use core::hash::Hash;
@@ -69,7 +71,7 @@ use crate::{
 /// // |       v       |       v
 /// // d <---- c       h <---- g
 ///
-/// let expected_res: HashMap<NodeIndex, usize> = [
+/// let expected_res: IndexMap<NodeIndex, usize> = [
 ///      (a, 7),
 ///      (b, 4),
 ///      (c, 5),
@@ -89,7 +91,7 @@ pub fn k_shortest_path<G, F, K>(
     goal: Option<G::NodeId>,
     k: usize,
     mut edge_cost: F,
-) -> HashMap<G::NodeId, K>
+) -> IndexMap<G::NodeId, K>
 where
     G: IntoEdges + Visitable + NodeCount + NodeIndexable,
     G::NodeId: Eq + Hash + Ord,
@@ -97,7 +99,7 @@ where
     K: Measure + Copy,
 {
     let mut counter: Vec<usize> = vec![0; graph.node_count()];
-    let mut scores = HashMap::new();
+    let mut scores = IndexMap::new();
     let mut visit_next = BinaryHeap::new();
     let zero_score = K::default();
 

--- a/src/k_shortest_path.rs
+++ b/src/k_shortest_path.rs
@@ -1,10 +1,23 @@
-use std::collections::{BinaryHeap, HashMap};
+#[cfg(feature = "alloc")]
+use alloc::{
+    collections::{BinaryHeap, BTreeMap as HashMap},
+    vec::Vec,
+};
 
-use std::hash::Hash;
+#[cfg(feature = "std")]
+use std::{
+    hash::Hash,
+    collections::{BinaryHeap, HashMap}
+};
+
+#[cfg(feature = "no_std")]
+use core::hash::Hash;
 
 use super::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
-use crate::algo::Measure;
-use crate::scored::MinScored;
+use crate::{
+    algo::Measure,
+    scored::MinScored
+};
 
 /// \[Generic\] k'th shortest path algorithm.
 ///
@@ -79,7 +92,7 @@ pub fn k_shortest_path<G, F, K>(
 ) -> HashMap<G::NodeId, K>
 where
     G: IntoEdges + Visitable + NodeCount + NodeIndexable,
-    G::NodeId: Eq + Hash,
+    G::NodeId: Eq + Hash + Ord,
     F: FnMut(G::EdgeRef) -> K,
     K: Measure + Copy,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,10 @@
 //!   Defaults on. Enables [`MatrixGraph`](./matrix_graph/struct.MatrixGraph.html).
 //!
 #![doc(html_root_url = "https://docs.rs/petgraph/0.4/")]
+#![cfg_attr(feature = "no_std", no_std)]
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
 
 extern crate fixedbitset;
 #[cfg(feature = "graphmap")]

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -1,6 +1,6 @@
 //! `MatrixGraph<N, E, Ty, NullN, NullE, Ix>` is a graph datastructure backed by an adjacency matrix.
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{
     cmp,
     marker::PhantomData,

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -1,10 +1,23 @@
 //! `MatrixGraph<N, E, Ty, NullN, NullE, Ix>` is a graph datastructure backed by an adjacency matrix.
 
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+#[cfg(not(feature = "no_std"))]
+use std::{
+    cmp,
+    marker::PhantomData,
+    mem,
+    ops::{Index, IndexMut},
+};
 
-use std::cmp;
-use std::mem;
+#[cfg(feature = "no_std")]
+use core::{
+    cmp,
+    marker::PhantomData,
+    mem,
+    ops::{Index, IndexMut},
+};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use indexmap::IndexSet;
 

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -2,6 +2,10 @@ extern crate quickcheck;
 use self::quickcheck::{Arbitrary, Gen};
 
 use crate::graph::{node_index, IndexType};
+
+#[cfg(feature = "alloc")]
+use alloc::{boxed::Box, vec::Vec};
+
 #[cfg(feature = "stable_graph")]
 use crate::stable_graph::StableGraph;
 use crate::{EdgeType, Graph};

--- a/src/scored.rs
+++ b/src/scored.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "no_std"))]
 use std::cmp::Ordering;
+
+#[cfg(feature = "no_std")]
+use core::cmp::Ordering;
 
 /// `MinScored<K, T>` holds a score `K` and a scored object `T` in
 /// a pair for use with a `BinaryHeap`.

--- a/src/scored.rs
+++ b/src/scored.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::cmp::Ordering;
 
 #[cfg(feature = "no_std")]

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{fmt, marker::PhantomData};
 
 #[cfg(feature = "no_std")]

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -1,7 +1,14 @@
+#[cfg(not(feature = "no_std"))]
+use std::{fmt, marker::PhantomData};
+
+#[cfg(feature = "no_std")]
+use core::{fmt, marker::PhantomData};
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
 use serde::de::{Deserialize, Error, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
-use std::fmt;
-use std::marker::PhantomData;
 
 /// Map to serializeable representation
 pub trait IntoSerializable {

--- a/src/simple_paths.rs
+++ b/src/simple_paths.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{
     hash::Hash,
     iter::{from_fn, FromIterator},
@@ -91,13 +91,13 @@ where
 
 #[cfg(test)]
 mod test {
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     use std::iter::FromIterator;
 
     #[cfg(feature = "no_std")]
     use core::iter::FromIterator;
 
-    #[cfg(not(feature = "alloc"))]
+    #[cfg(feature = "std")]
     use std::{collections::HashSet};
 
     #[cfg(feature = "alloc")]
@@ -107,7 +107,7 @@ mod test {
 
     use crate::prelude::DiGraph;
 
-    #[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     use crate::dot::Dot;
 
     use super::all_simple_paths;
@@ -141,7 +141,7 @@ mod test {
             vec![0, 3, 4, 5],
         ];
 
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_5: HashSet<Vec<_>> =
             all_simple_paths(&graph, 0u32.into(), 5u32.into(), 0, None)
@@ -159,7 +159,7 @@ mod test {
         let graph = DiGraph::<i32, i32, _>::from_edges(&[(0, 1), (2, 1)]);
 
         let expexted_simple_paths_0_to_1 = &[vec![0usize, 1]];
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_1: Vec<Vec<_>> =
             all_simple_paths(&graph, 0u32.into(), 1u32.into(), 0, None)
@@ -174,7 +174,7 @@ mod test {
     fn test_no_simple_paths() {
         let graph = DiGraph::<i32, i32, _>::from_edges(&[(0, 1), (2, 1)]);
 
-        #[cfg(not(feature = "no_std"))]
+        #[cfg(feature = "std")]
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_2: Vec<Vec<_>> =
             all_simple_paths(&graph, 0u32.into(), 2u32.into(), 0, None)

--- a/src/simple_paths.rs
+++ b/src/simple_paths.rs
@@ -1,4 +1,11 @@
+#[cfg(not(feature = "no_std"))]
 use std::{
+    hash::Hash,
+    iter::{from_fn, FromIterator},
+};
+
+#[cfg(feature = "no_std")]
+use core::{
     hash::Hash,
     iter::{from_fn, FromIterator},
 };
@@ -84,11 +91,24 @@ where
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashSet, iter::FromIterator};
+    #[cfg(not(feature = "no_std"))]
+    use std::iter::FromIterator;
+
+    #[cfg(feature = "no_std")]
+    use core::iter::FromIterator;
+
+    #[cfg(not(feature = "alloc"))]
+    use std::{collections::HashSet};
+
+    #[cfg(feature = "alloc")]
+    use alloc::{collections::BTreeSet as HashSet, vec::Vec};
 
     use itertools::assert_equal;
 
-    use crate::{dot::Dot, prelude::DiGraph};
+    use crate::prelude::DiGraph;
+
+    #[cfg(not(feature = "no_std"))]
+    use crate::dot::Dot;
 
     use super::all_simple_paths;
 
@@ -121,6 +141,7 @@ mod test {
             vec![0, 3, 4, 5],
         ];
 
+        #[cfg(not(feature = "no_std"))]
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_5: HashSet<Vec<_>> =
             all_simple_paths(&graph, 0u32.into(), 5u32.into(), 0, None)
@@ -138,6 +159,7 @@ mod test {
         let graph = DiGraph::<i32, i32, _>::from_edges(&[(0, 1), (2, 1)]);
 
         let expexted_simple_paths_0_to_1 = &[vec![0usize, 1]];
+        #[cfg(not(feature = "no_std"))]
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_1: Vec<Vec<_>> =
             all_simple_paths(&graph, 0u32.into(), 1u32.into(), 0, None)
@@ -152,6 +174,7 @@ mod test {
     fn test_no_simple_paths() {
         let graph = DiGraph::<i32, i32, _>::from_edges(&[(0, 1), (2, 1)]);
 
+        #[cfg(not(feature = "no_std"))]
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_2: Vec<Vec<_>> =
             all_simple_paths(&graph, 0u32.into(), 2u32.into(), 0, None)

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use super::graph::IndexType;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::cmp::Ordering;
 
 #[cfg(feature = "no_std")]

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,7 +1,14 @@
 //! `UnionFind<K>` is a disjoint-set data structure.
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use super::graph::IndexType;
+
+#[cfg(not(feature = "no_std"))]
 use std::cmp::Ordering;
+
+#[cfg(feature = "no_std")]
+use core::cmp::Ordering;
 
 /// `UnionFind<K>` is a disjoint-set data structure. It tracks set membership of *n* elements
 /// indexed from *0* to *n - 1*. The scalar type is `K` which must be an unsigned integer type.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "no_std"))]
 use std::iter;
+
+#[cfg(feature = "no_std")]
+use core::iter;
 
 pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
 where

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::iter;
 
 #[cfg(feature = "no_std")]

--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 #[cfg(feature = "no_std")]
 use core::marker::PhantomData;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{collections::HashSet, marker::PhantomData};
 
 #[cfg(feature = "alloc")]
@@ -44,7 +44,7 @@ where
 }
 
 /// This filter includes the nodes that are contained in the set.
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl<N, S> FilterNode<N> for HashSet<N, S>
 where
     HashSet<N, S>: VisitMap<N>,

--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -1,8 +1,14 @@
 use crate::prelude::*;
 
+#[cfg(feature = "no_std")]
+use core::marker::PhantomData;
+#[cfg(not(feature = "no_std"))]
+use std::{collections::HashSet, marker::PhantomData};
+
+#[cfg(feature = "alloc")]
+use alloc::collections::BTreeSet as HashSet;
+
 use fixedbitset::FixedBitSet;
-use std::collections::HashSet;
-use std::marker::PhantomData;
 
 use crate::data::DataMap;
 use crate::visit::{Data, NodeCompactIndexable, NodeCount};
@@ -38,9 +44,20 @@ where
 }
 
 /// This filter includes the nodes that are contained in the set.
+#[cfg(not(feature = "no_std"))]
 impl<N, S> FilterNode<N> for HashSet<N, S>
 where
     HashSet<N, S>: VisitMap<N>,
+{
+    fn include_node(&self, n: N) -> bool {
+        self.is_visited(&n)
+    }
+}
+
+#[cfg(feature = "no_std")]
+impl<N> FilterNode<N> for HashSet<N>
+where
+    HashSet<N>: VisitMap<N>,
 {
     fn include_node(&self, n: N) -> bool {
         self.is_visited(&n)
@@ -57,7 +74,7 @@ where
         self.is_visited(&n)
     }
 }
-
+#[cfg(feature = "std")]
 impl<N, S> FilterNode<N> for &HashSet<N, S>
 where
     HashSet<N, S>: VisitMap<N>,

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -52,7 +52,7 @@ pub use self::traversal::*;
 
 use fixedbitset::FixedBitSet;
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::{
     collections::HashSet,
     hash::{BuildHasher, Hash},
@@ -612,7 +612,7 @@ where
     }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 impl<N, S> VisitMap<N> for HashSet<N, S>
 where
     N: Hash + Eq,

--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -1,7 +1,12 @@
 use super::{GraphRef, IntoNodeIdentifiers, Reversed};
 use super::{IntoNeighbors, IntoNeighborsDirected, VisitMap, Visitable};
 use crate::Incoming;
+
+#[cfg(not(feature = "alloc"))]
 use std::collections::VecDeque;
+
+#[cfg(feature = "alloc")]
+use alloc::{collections::VecDeque, vec::Vec};
 
 /// Visit nodes of a graph in a depth-first-search (DFS) emitting nodes in
 /// preorder (when they are first discovered).

--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -2,7 +2,7 @@ use super::{GraphRef, IntoNodeIdentifiers, Reversed};
 use super::{IntoNeighbors, IntoNeighborsDirected, VisitMap, Visitable};
 use crate::Incoming;
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 use std::collections::VecDeque;
 
 #[cfg(feature = "alloc")]

--- a/tests/k_shortest_path.rs
+++ b/tests/k_shortest_path.rs
@@ -2,11 +2,7 @@ use petgraph::algo::k_shortest_path;
 use petgraph::prelude::*;
 use petgraph::Graph;
 
-#[cfg(not(feature = "alloc"))]
-use std::collections::HashMap;
-
-#[cfg(feature = "alloc")]
-use alloc::collections::BTreeMap as HashMap;
+use indexmap::IndexMap;
 
 #[test]
 fn second_shortest_path() {
@@ -50,7 +46,7 @@ fn second_shortest_path() {
 
     let res = k_shortest_path(&graph, a, None, 2, |_| 1);
 
-    let expected_res: HashMap<NodeIndex, usize> = [
+    let expected_res: IndexMap<NodeIndex, usize> = [
         (e, 7),
         (g, 3),
         (h, 4),

--- a/tests/k_shortest_path.rs
+++ b/tests/k_shortest_path.rs
@@ -1,7 +1,12 @@
 use petgraph::algo::k_shortest_path;
 use petgraph::prelude::*;
 use petgraph::Graph;
+
+#[cfg(not(feature = "alloc"))]
 use std::collections::HashMap;
+
+#[cfg(feature = "alloc")]
+use alloc::collections::BTreeMap as HashMap;
 
 #[test]
 fn second_shortest_path() {


### PR DESCRIPTION
Using this feature switch will also turn on alloc feature switch which
is used to determine if the collections used in the library should be
imported from the alloc library or not.

Most notable change in no_std is that instead of a HashMap and Set
a BTreeMap and Set are used.

**Benchmarks**

***Standard***
```
running 6 tests
test bench_praust_mst          ... bench:         446 ns/iter (+/- 19)
test full_iso_bench            ... bench:       1,758 ns/iter (+/- 75)
test petersen_iso_bench        ... bench:       1,332 ns/iter (+/- 103)
test petersen_undir_iso_bench  ... bench:         977 ns/iter (+/- 42)
test praust_dir_no_iso_bench   ... bench:   1,115,236 ns/iter (+/- 89,176)
test praust_undir_no_iso_bench ... bench:   1,116,010 ns/iter (+/- 90,303)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out

     Running target/release/deps/ograph-0a0ed0f5ec42a012

running 3 tests
test bench_add_edge ... bench:         489 ns/iter (+/- 13)
test bench_inser    ... bench:           4 ns/iter (+/- 1)
test bench_remove   ... bench:         221 ns/iter (+/- 13)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out

     Running target/release/deps/stable_graph-5231646bce1ffe18

running 12 tests
test full_edges_default        ... bench:          10 ns/iter (+/- 0)
test full_edges_in             ... bench:          11 ns/iter (+/- 0)
test full_edges_out            ... bench:          10 ns/iter (+/- 0)
test graph_map                 ... bench:         272 ns/iter (+/- 13)
test neighbors_default         ... bench:           6 ns/iter (+/- 0)
test neighbors_in              ... bench:          10 ns/iter (+/- 0)
test neighbors_out             ... bench:           8 ns/iter (+/- 1)
test sccs_graph                ... bench:       3,119 ns/iter (+/- 246)
test sccs_stable_graph         ... bench:       3,221 ns/iter (+/- 230)
test stable_graph_map          ... bench:         389 ns/iter (+/- 36)
test stable_graph_retain_edges ... bench:         415 ns/iter (+/- 17)
test stable_graph_retain_nodes ... bench:          63 ns/iter (+/- 3)

test result: ok. 0 passed; 0 failed; 0 ignored; 12 measured; 0 filtered out
```

***No_std***
```
running 6 tests
test bench_praust_mst          ... bench:         460 ns/iter (+/- 34)
test full_iso_bench            ... bench:       1,801 ns/iter (+/- 196)
test petersen_iso_bench        ... bench:       1,414 ns/iter (+/- 71)
test petersen_undir_iso_bench  ... bench:       1,032 ns/iter (+/- 68)
test praust_dir_no_iso_bench   ... bench:   1,178,403 ns/iter (+/- 75,966)
test praust_undir_no_iso_bench ... bench:   1,126,183 ns/iter (+/- 32,324)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out

     Running target/release/deps/ograph-d02ac07c0a8c3a51

running 3 tests
test bench_add_edge ... bench:         512 ns/iter (+/- 52)
test bench_inser    ... bench:           4 ns/iter (+/- 0)
test bench_remove   ... bench:         237 ns/iter (+/- 9)

test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured; 0 filtered out

     Running target/release/deps/stable_graph-10f377a07b8dfc8a

running 12 tests
test full_edges_default        ... bench:          10 ns/iter (+/- 0)
test full_edges_in             ... bench:          10 ns/iter (+/- 0)
test full_edges_out            ... bench:          10 ns/iter (+/- 0)
test graph_map                 ... bench:         254 ns/iter (+/- 9)
test neighbors_default         ... bench:           6 ns/iter (+/- 0)
test neighbors_in              ... bench:          10 ns/iter (+/- 0)
test neighbors_out             ... bench:           8 ns/iter (+/- 1)
test sccs_graph                ... bench:       2,971 ns/iter (+/- 285)
test sccs_stable_graph         ... bench:       3,127 ns/iter (+/- 410)
test stable_graph_map          ... bench:         377 ns/iter (+/- 46)
test stable_graph_retain_edges ... bench:         405 ns/iter (+/- 12)
test stable_graph_retain_nodes ... bench:          61 ns/iter (+/- 3)

test result: ok. 0 passed; 0 failed; 0 ignored; 12 measured; 0 filtered out
```