### PR TITLE
Add basic benches for algorithms using UnionFind

### DIFF
--- a/benches/unionfind.rs
+++ b/benches/unionfind.rs
@@ -1,0 +1,331 @@
+#![feature(test)]
+
+extern crate test;
+extern crate petgraph;
+
+use petgraph::prelude::*;
+use petgraph::{
+    EdgeType,
+};
+use petgraph::graph::{
+    node_index,
+};
+
+use petgraph::algo::{connected_components, is_cyclic_undirected, min_spanning_tree};
+
+/// Petersen A and B are isomorphic
+///
+/// http://www.dharwadker.org/tevet/isomorphism/
+const PETERSEN_A: &'static str = "
+ 0 1 0 0 1 0 1 0 0 0 
+ 1 0 1 0 0 0 0 1 0 0 
+ 0 1 0 1 0 0 0 0 1 0 
+ 0 0 1 0 1 0 0 0 0 1 
+ 1 0 0 1 0 1 0 0 0 0 
+ 0 0 0 0 1 0 0 1 1 0 
+ 1 0 0 0 0 0 0 0 1 1 
+ 0 1 0 0 0 1 0 0 0 1 
+ 0 0 1 0 0 1 1 0 0 0 
+ 0 0 0 1 0 0 1 1 0 0
+";
+
+const PETERSEN_B: &'static str = "
+ 0 0 0 1 0 1 0 0 0 1 
+ 0 0 0 1 1 0 1 0 0 0 
+ 0 0 0 0 0 0 1 1 0 1 
+ 1 1 0 0 0 0 0 1 0 0
+ 0 1 0 0 0 0 0 0 1 1 
+ 1 0 0 0 0 0 1 0 1 0 
+ 0 1 1 0 0 1 0 0 0 0 
+ 0 0 1 1 0 0 0 0 1 0 
+ 0 0 0 0 1 1 0 1 0 0 
+ 1 0 1 0 1 0 0 0 0 0
+";
+
+/// An almost full set, isomorphic
+const FULL_A: &'static str = "
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 0 1 1 1 0 1 
+ 1 1 1 1 1 1 1 1 1 1
+";
+
+const FULL_B: &'static str = "
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 0 1 1 1 0 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1 
+ 1 1 1 1 1 1 1 1 1 1
+";
+
+/// Praust A and B are not isomorphic
+const PRAUST_A: &'static str = "
+ 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 
+ 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 
+ 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 
+ 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 
+ 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 0 0 0 
+ 0 1 0 0 1 0 1 1 0 0 0 0 0 1 0 0 0 0 0 0 
+ 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 
+ 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 
+ 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 
+ 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0 
+ 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 
+ 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 
+ 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0 
+ 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0 
+ 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 
+ 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 
+ 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1 
+ 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1 
+ 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1 
+ 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
+";
+
+const PRAUST_B: &'static str = "
+ 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 
+ 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 
+ 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 
+ 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 
+ 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 0 0 0 
+ 0 1 0 0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0 1 
+ 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 
+ 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 1 0 0 
+ 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0
+ 0 1 0 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 0 
+ 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 
+ 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 
+ 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 0 0 1 0 1 
+ 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 1 1 0 1 0 
+ 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 1 0 1 
+ 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1 0 1 0 1 0 
+ 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 1 0 1 1 0 
+ 0 0 0 0 0 0 0 1 0 0 0 0 1 0 1 0 1 0 0 1 
+ 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 0 0 1 
+ 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 1 1 0 
+";
+
+/// Parse a text adjacency matrix format into a graph
+fn parse_graph<Ty: EdgeType>(s: &str) -> Graph<(), (), Ty> {
+    let mut gr = Graph::with_capacity(0, 0);
+    let s = s.trim();
+    let lines = s.lines().filter(|l| !l.is_empty());
+    for (row, line) in lines.enumerate() {
+        for (col, word) in line.split(' ')
+                                .filter(|s| s.len() > 0)
+                                .enumerate()
+        {
+            let has_edge = word.parse::<i32>().unwrap();
+            assert!(has_edge == 0 || has_edge == 1);
+            if has_edge == 0 {
+                continue;
+            }
+            while col >= gr.node_count() || row >= gr.node_count() {
+                gr.add_node(());
+            }
+            gr.update_edge(node_index(row), node_index(col), ());
+        }
+    }
+    gr
+}
+
+/// Parse a text adjacency matrix format into a *undirected* graph
+fn str_to_ungraph(s: &str) -> Graph<(), (), Undirected> {
+    parse_graph(s)
+}
+
+/// Parse a text adjacency matrix format into a *directed* graph
+fn str_to_digraph(s: &str) -> Graph<(), (), Directed> {
+    parse_graph(s)
+}
+
+#[bench]
+fn connected_components_praust_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(PRAUST_A);
+    let b = str_to_ungraph(PRAUST_B);
+
+    bench.iter(|| {
+        (connected_components(&a), connected_components(&b))
+    });
+}
+
+#[bench]
+fn connected_components_praust_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(PRAUST_A);
+    let b = str_to_digraph(PRAUST_B);
+
+    bench.iter(|| {
+        (connected_components(&a), connected_components(&b))
+    });
+}
+
+#[bench]
+fn connected_components_full_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(FULL_A);
+    let b = str_to_ungraph(FULL_B);
+
+    bench.iter(|| {
+        (connected_components(&a), connected_components(&b))
+    });
+}
+
+#[bench]
+fn connected_components_full_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(FULL_A);
+    let b = str_to_digraph(FULL_B);
+
+    bench.iter(|| {
+        (connected_components(&a), connected_components(&b))
+    });
+}
+
+#[bench]
+fn connected_components_petersen_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(PETERSEN_A);
+    let b = str_to_ungraph(PETERSEN_B);
+
+    bench.iter(|| {
+        (connected_components(&a), connected_components(&b))
+    });
+}
+
+#[bench]
+fn connected_components_petersen_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(PETERSEN_A);
+    let b = str_to_digraph(PETERSEN_B);
+
+    bench.iter(|| {
+        (connected_components(&a), connected_components(&b))
+    });
+}
+
+#[bench]
+fn is_cyclic_undirected_praust_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(PRAUST_A);
+    let b = str_to_ungraph(PRAUST_B);
+
+    bench.iter(|| {
+        (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
+    });
+}
+
+#[bench]
+fn is_cyclic_undirected_praust_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(PRAUST_A);
+    let b = str_to_digraph(PRAUST_B);
+
+    bench.iter(|| {
+        (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
+    });
+}
+
+#[bench]
+fn is_cyclic_undirected_full_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(FULL_A);
+    let b = str_to_ungraph(FULL_B);
+
+    bench.iter(|| {
+        (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
+    });
+}
+
+#[bench]
+fn is_cyclic_undirected_full_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(FULL_A);
+    let b = str_to_digraph(FULL_B);
+
+    bench.iter(|| {
+        (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
+    });
+}
+
+#[bench]
+fn is_cyclic_undirected_petersen_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(PETERSEN_A);
+    let b = str_to_ungraph(PETERSEN_B);
+
+    bench.iter(|| {
+        (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
+    });
+}
+
+#[bench]
+fn is_cyclic_undirected_petersen_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(PETERSEN_A);
+    let b = str_to_digraph(PETERSEN_B);
+
+    bench.iter(|| {
+        (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
+    });
+}
+
+#[bench]
+fn min_spanning_tree_praust_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(PRAUST_A);
+    let b = str_to_ungraph(PRAUST_B);
+
+    bench.iter(|| {
+        (min_spanning_tree(&a), min_spanning_tree(&b))
+    });
+}
+
+#[bench]
+fn min_spanning_tree_praust_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(PRAUST_A);
+    let b = str_to_digraph(PRAUST_B);
+
+    bench.iter(|| {
+        (min_spanning_tree(&a), min_spanning_tree(&b))
+    });
+}
+
+#[bench]
+fn min_spanning_tree_full_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(FULL_A);
+    let b = str_to_ungraph(FULL_B);
+
+    bench.iter(|| {
+        (min_spanning_tree(&a), min_spanning_tree(&b))
+    });
+}
+
+#[bench]
+fn min_spanning_tree_full_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(FULL_A);
+    let b = str_to_digraph(FULL_B);
+
+    bench.iter(|| {
+        (min_spanning_tree(&a), min_spanning_tree(&b))
+    });
+}
+
+#[bench]
+fn min_spanning_tree_petersen_undir_bench(bench: &mut test::Bencher) {
+    let a = str_to_ungraph(PETERSEN_A);
+    let b = str_to_ungraph(PETERSEN_B);
+
+    bench.iter(|| {
+        (min_spanning_tree(&a), min_spanning_tree(&b))
+    });
+}
+
+#[bench]
+fn min_spanning_tree_petersen_dir_bench(bench: &mut test::Bencher) {
+    let a = str_to_digraph(PETERSEN_A);
+    let b = str_to_digraph(PETERSEN_B);
+
+    bench.iter(|| {
+        (min_spanning_tree(&a), min_spanning_tree(&b))
+    });
+}


### PR DESCRIPTION
Initially written for #274, these benchmarks cover the three algorithms currently using `UnionFind`.

Copying my comment from there:
```rust
#[bench]
fn connected_components_$graph_$direction_bench(bench: &mut test::Bencher) {
    let a: Graph<(), (), $direction> = parse_graph($graph_a);
    let b: Graph<(), (), $direction> = parse_graph($graph_b);

    bench.iter(|| {
        (connected_components(&a), connected_components(&b))
    });
}

#[bench]
fn is_cyclic_undirected_$graph_$direction_bench(bench: &mut test::Bencher) {
    let a: Graph<(), (), $direction> = parse_graph($graph_a);
    let b: Graph<(), (), $direction> = parse_graph($graph_b);

    bench.iter(|| {
        (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
    });
}

#[bench]
fn min_spanning_tree_$graph_$direction_bench(bench: &mut test::Bencher) {
    let a: Graph<(), (), $direction> = parse_graph($graph_a);
    let b: Graph<(), (), $direction> = parse_graph($graph_b);

    bench.iter(|| {
        (min_spanning_tree(&a), min_spanning_tree(&b))
    });
}
```
- `$graph` being one of `PRAUST`, `FULL`, `PETERSEN`, taken from the [isomorphism benchmarks][]
- `$direction` being one of `Directed`, `Undirected`

Latest run on my workstation (including the changes from #278):

```
test connected_components_full_dir_bench       ... bench:         934 ns/iter (+/- 7)
test connected_components_full_undir_bench     ... bench:         650 ns/iter (+/- 7)
test connected_components_petersen_dir_bench   ... bench:         523 ns/iter (+/- 7)
test connected_components_petersen_undir_bench ... bench:         527 ns/iter (+/- 71)
test connected_components_praust_dir_bench     ... bench:       1,084 ns/iter (+/- 463)
test connected_components_praust_undir_bench   ... bench:         824 ns/iter (+/- 22)
test is_cyclic_undirected_full_dir_bench       ... bench:         237 ns/iter (+/- 3)
test is_cyclic_undirected_full_undir_bench     ... bench:         237 ns/iter (+/- 3)
test is_cyclic_undirected_petersen_dir_bench   ... bench:         304 ns/iter (+/- 4)
test is_cyclic_undirected_petersen_undir_bench ... bench:         322 ns/iter (+/- 4)
test is_cyclic_undirected_praust_dir_bench     ... bench:         293 ns/iter (+/- 4)
test is_cyclic_undirected_praust_undir_bench   ... bench:         292 ns/iter (+/- 5)
test min_spanning_tree_full_dir_bench          ... bench:         695 ns/iter (+/- 5)
test min_spanning_tree_full_undir_bench        ... bench:         538 ns/iter (+/- 4)
test min_spanning_tree_petersen_dir_bench      ... bench:         456 ns/iter (+/- 5)
test min_spanning_tree_petersen_undir_bench    ... bench:         412 ns/iter (+/- 8)
test min_spanning_tree_praust_dir_bench        ... bench:         708 ns/iter (+/- 163)
test min_spanning_tree_praust_undir_bench      ... bench:         536 ns/iter (+/- 9)
```

Side note: I'd be in favor of sharing the set of sample graphs that these type of benchmarks run on.