### PR TITLE
Use factories to run benches on sample graphs

### DIFF
--- a/benches/factories.rs
+++ b/benches/factories.rs
@@ -1,0 +1,251 @@
+use std::marker::PhantomData;
+
+use petgraph::prelude::*;
+use petgraph::visit::NodeIndexable;
+use petgraph::data::Build;
+
+use petgraph::EdgeType;
+
+/// Petersen A and B are isomorphic
+///
+/// http://www.dharwadker.org/tevet/isomorphism/
+const PETERSEN_A: &'static str = "
+ 0 1 0 0 1 0 1 0 0 0
+ 1 0 1 0 0 0 0 1 0 0
+ 0 1 0 1 0 0 0 0 1 0
+ 0 0 1 0 1 0 0 0 0 1
+ 1 0 0 1 0 1 0 0 0 0
+ 0 0 0 0 1 0 0 1 1 0
+ 1 0 0 0 0 0 0 0 1 1
+ 0 1 0 0 0 1 0 0 0 1
+ 0 0 1 0 0 1 1 0 0 0
+ 0 0 0 1 0 0 1 1 0 0
+";
+
+const PETERSEN_B: &'static str = "
+ 0 0 0 1 0 1 0 0 0 1
+ 0 0 0 1 1 0 1 0 0 0
+ 0 0 0 0 0 0 1 1 0 1
+ 1 1 0 0 0 0 0 1 0 0
+ 0 1 0 0 0 0 0 0 1 1
+ 1 0 0 0 0 0 1 0 1 0
+ 0 1 1 0 0 1 0 0 0 0
+ 0 0 1 1 0 0 0 0 1 0
+ 0 0 0 0 1 1 0 1 0 0
+ 1 0 1 0 1 0 0 0 0 0
+";
+
+/// An almost full set, isomorphic
+const FULL_A: &'static str = "
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 0 1 1 1 0 1
+ 1 1 1 1 1 1 1 1 1 1
+";
+
+const FULL_B: &'static str = "
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 0 1 1 1 0 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+ 1 1 1 1 1 1 1 1 1 1
+";
+
+/// Praust A and B are not isomorphic
+const PRAUST_A: &'static str = "
+ 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
+ 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
+ 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0
+ 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0
+ 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 0 0 0
+ 0 1 0 0 1 0 1 1 0 0 0 0 0 1 0 0 0 0 0 0
+ 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0
+ 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0
+ 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0
+ 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0
+ 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0
+ 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1
+ 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0
+ 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0
+ 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1
+ 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0
+ 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1
+ 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1
+ 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1
+ 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
+";
+
+const PRAUST_B: &'static str = "
+ 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
+ 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
+ 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0
+ 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0
+ 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 0 0 0
+ 0 1 0 0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0 1
+ 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0
+ 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 1 0 0
+ 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0
+ 0 1 0 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 0
+ 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0
+ 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0
+ 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 0 0 1 0 1
+ 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 1 1 0 1 0
+ 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 1 0 1
+ 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1 0 1 0 1 0
+ 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 1 0 1 1 0
+ 0 0 0 0 0 0 0 1 0 0 0 0 1 0 1 0 1 0 0 1
+ 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 0 0 1
+ 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 1 1 0
+";
+
+const BIGGER: &'static str = "
+ 0 0 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 1 1 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 1 0 0 0 1 1 0 0 0 0 0 0 0 1 0 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
+ 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0
+ 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0
+ 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1
+ 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1
+ 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 1 0 1 1 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1
+ 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
+ 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
+ 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 1 1 0 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+ 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0
+ 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0
+ 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0
+ 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0
+ 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0
+ 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1
+ 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0
+ 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0
+ 0 1 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1
+ 0 1 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0
+ 0 1 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1
+ 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1
+ 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1
+ 0 1 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
+";
+
+/// Parse a text adjacency matrix format into a directed graph
+fn parse_graph<Ty, G>(s: &str) -> G
+    where Ty: EdgeType,
+          G: Default + Build<NodeWeight=(), EdgeWeight=()> + NodeIndexable,
+{
+    let mut g: G = Default::default();
+    let s = s.trim();
+    let lines = s.lines().filter(|l| !l.is_empty());
+    for (row, line) in lines.enumerate() {
+        for (col, word) in line.split(' ')
+                                .filter(|s| s.len() > 0)
+                                .enumerate()
+        {
+            let has_edge = word.parse::<i32>().unwrap();
+            assert!(has_edge == 0 || has_edge == 1);
+            if has_edge == 0 {
+                continue;
+            }
+            while col >= g.node_count() || row >= g.node_count() {
+                g.add_node(());
+            }
+            let a = g.from_index(row);
+            let b = g.from_index(col);
+            g.update_edge(a, b, ());
+        }
+    }
+    g
+}
+
+pub struct GraphFactory<Ty, G = Graph<(), (), Ty>> {
+    ty: PhantomData<Ty>,
+    g: PhantomData<G>,
+}
+
+impl<Ty, G> GraphFactory<Ty, G>
+    where Ty: EdgeType,
+          G: Default + Build<NodeWeight=(), EdgeWeight=()> + NodeIndexable,
+{
+    fn new() -> Self {
+        GraphFactory {
+            ty: PhantomData,
+            g: PhantomData,
+        }
+    }
+
+    pub fn petersen_a(self) -> G {
+        parse_graph::<Ty, _>(PETERSEN_A)
+    }
+
+    pub fn petersen_b(self) -> G {
+        parse_graph::<Ty, _>(PETERSEN_B)
+    }
+
+    pub fn full_a(self) -> G {
+        parse_graph::<Ty, _>(FULL_A)
+    }
+
+    pub fn full_b(self) -> G {
+        parse_graph::<Ty, _>(FULL_B)
+    }
+
+    pub fn praust_a(self) -> G {
+        parse_graph::<Ty, _>(PRAUST_A)
+    }
+
+    pub fn praust_b(self) -> G {
+        parse_graph::<Ty, _>(PRAUST_B)
+    }
+
+    pub fn bigger(self) -> G {
+        parse_graph::<Ty, _>(BIGGER)
+    }
+}
+
+pub fn graph<Ty: EdgeType>() -> GraphFactory<Ty, Graph<(), (), Ty>> {
+    GraphFactory::new()
+}
+
+pub fn ungraph() -> GraphFactory<Undirected, Graph<(), (), Undirected>> {
+    graph()
+}
+
+pub fn digraph() -> GraphFactory<Directed, Graph<(), (), Directed>> {
+    graph()
+}
+
+pub fn stable_graph<Ty: EdgeType>() -> GraphFactory<Ty, StableGraph<(), (), Ty>> {
+    GraphFactory::new()
+}
+
+pub fn stable_ungraph() -> GraphFactory<Undirected, StableGraph<(), (), Undirected>> {
+    stable_graph()
+}
+
+pub fn stable_digraph() -> GraphFactory<Directed, StableGraph<(), (), Directed>> {
+    stable_graph()
+}

--- a/benches/iso.rs
+++ b/benches/iso.rs
@@ -3,222 +3,49 @@
 extern crate test;
 extern crate petgraph;
 
-use petgraph::prelude::*;
-use petgraph::{
-    EdgeType,
-};
-use petgraph::graph::{
-    node_index,
-};
+use test::Bencher;
 
-/// Petersen A and B are isomorphic
-///
-/// http://www.dharwadker.org/tevet/isomorphism/
-const PETERSEN_A: &'static str = "
- 0 1 0 0 1 0 1 0 0 0 
- 1 0 1 0 0 0 0 1 0 0 
- 0 1 0 1 0 0 0 0 1 0 
- 0 0 1 0 1 0 0 0 0 1 
- 1 0 0 1 0 1 0 0 0 0 
- 0 0 0 0 1 0 0 1 1 0 
- 1 0 0 0 0 0 0 0 1 1 
- 0 1 0 0 0 1 0 0 0 1 
- 0 0 1 0 0 1 1 0 0 0 
- 0 0 0 1 0 0 1 1 0 0
-";
+mod factories;
+use factories::*;
 
-const PETERSEN_B: &'static str = "
- 0 0 0 1 0 1 0 0 0 1 
- 0 0 0 1 1 0 1 0 0 0 
- 0 0 0 0 0 0 1 1 0 1 
- 1 1 0 0 0 0 0 1 0 0
- 0 1 0 0 0 0 0 0 1 1 
- 1 0 0 0 0 0 1 0 1 0 
- 0 1 1 0 0 1 0 0 0 0 
- 0 0 1 1 0 0 0 0 1 0 
- 0 0 0 0 1 1 0 1 0 0 
- 1 0 1 0 1 0 0 0 0 0
-";
-
-/// An almost full set, isomorphic
-const FULL_A: &'static str = "
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 0 1 1 1 0 1 
- 1 1 1 1 1 1 1 1 1 1
-";
-
-const FULL_B: &'static str = "
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 0 1 1 1 0 1 1 1 
- 1 1 1 1 1 1 1 1 1 1
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1
-";
-
-/// Praust A and B are not isomorphic
-const PRAUST_A: &'static str = "
- 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 
- 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 
- 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 
- 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 
- 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 0 0 0 
- 0 1 0 0 1 0 1 1 0 0 0 0 0 1 0 0 0 0 0 0 
- 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 
- 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 
- 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 
- 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0 
- 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 
- 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 
- 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0 
- 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0 
- 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 
- 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 
- 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1 
- 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1 
- 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1 
- 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
-";
-
-const PRAUST_B: &'static str = "
- 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 
- 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 
- 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 
- 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 
- 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 0 0 0 
- 0 1 0 0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0 1 
- 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 
- 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 1 0 0 
- 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0
- 0 1 0 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 0 
- 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 
- 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 
- 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 0 0 1 0 1 
- 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 1 1 0 1 0 
- 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 1 0 1 
- 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1 0 1 0 1 0 
- 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 1 0 1 1 0 
- 0 0 0 0 0 0 0 1 0 0 0 0 1 0 1 0 1 0 0 1 
- 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 0 0 1 
- 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 1 1 0 
-";
-
-/// Parse a text adjacency matrix format into a directed graph
-fn parse_graph<Ty: EdgeType>(s: &str) -> Graph<(), (), Ty>
-{
-    let mut gr = Graph::with_capacity(0, 0);
-    let s = s.trim();
-    let lines = s.lines().filter(|l| !l.is_empty());
-    for (row, line) in lines.enumerate() {
-        for (col, word) in line.split(' ')
-                                .filter(|s| s.len() > 0)
-                                .enumerate()
-        {
-            let has_edge = word.parse::<i32>().unwrap();
-            assert!(has_edge == 0 || has_edge == 1);
-            if has_edge == 0 {
-                continue;
-            }
-            while col >= gr.node_count() || row >= gr.node_count() {
-                gr.add_node(());
-            }
-            gr.update_edge(node_index(row), node_index(col), ());
-        }
-    }
-    gr
-}
-
-fn str_to_graph(s: &str) -> Graph<(), (), Undirected> {
-    parse_graph(s)
-}
-
-fn str_to_digraph(s: &str) -> Graph<(), (), Directed> {
-    parse_graph(s)
-}
-
-/*
-fn graph_to_ad_matrix<N, E, Ty: EdgeType>(g: &Graph<N,E,Ty>)
-{
-    let n = g.node_count();
-    for i in (0..n) {
-        for j in (0..n) {
-            let ix = NodeIndex::new(i);
-            let jx = NodeIndex::new(j);
-            let out = match g.find_edge(ix, jx) {
-                None => "0",
-                Some(_) => "1",
-            };
-            print!("{} ", out);
-        }
-        println!("");
-    }
-}
-*/
+use petgraph::algo::is_isomorphic;
 
 #[bench]
-fn petersen_iso_bench(bench: &mut test::Bencher)
-{
-    let a = str_to_digraph(PETERSEN_A);
-    let b = str_to_digraph(PETERSEN_B);
+fn petersen_iso_bench(bench: &mut Bencher) {
+    let a = digraph().petersen_a();
+    let b = digraph().petersen_b();
 
-    bench.iter(|| petgraph::algo::is_isomorphic(&a, &b));
+    bench.iter(|| is_isomorphic(&a, &b));
 }
 
 #[bench]
-fn petersen_undir_iso_bench(bench: &mut test::Bencher)
-{
-    let a = str_to_graph(PETERSEN_A);
-    let b = str_to_graph(PETERSEN_B);
+fn petersen_undir_iso_bench(bench: &mut Bencher) {
+    let a = ungraph().petersen_a();
+    let b = ungraph().petersen_b();
 
-    bench.iter(|| petgraph::algo::is_isomorphic(&a, &b));
+    bench.iter(|| is_isomorphic(&a, &b));
 }
 
 #[bench]
-fn full_iso_bench(bench: &mut test::Bencher)
-{
-    let a = str_to_graph(FULL_A);
-    let b = str_to_graph(FULL_B);
+fn full_iso_bench(bench: &mut Bencher) {
+    let a = ungraph().full_a();
+    let b = ungraph().full_b();
 
-    bench.iter(|| petgraph::algo::is_isomorphic(&a, &b));
+    bench.iter(|| is_isomorphic(&a, &b));
 }
 
 #[bench]
-fn praust_dir_no_iso_bench(bench: &mut test::Bencher)
-{
-    let a = str_to_digraph(PRAUST_A);
-    let b = str_to_digraph(PRAUST_B);
+fn praust_dir_no_iso_bench(bench: &mut Bencher) {
+    let a = digraph().praust_a();
+    let b = digraph().praust_b();
 
-    bench.iter(|| petgraph::algo::is_isomorphic(&a, &b));
+    bench.iter(|| is_isomorphic(&a, &b));
 }
 
 #[bench]
-fn praust_undir_no_iso_bench(bench: &mut test::Bencher)
-{
-    let a = str_to_graph(PRAUST_A);
-    let b = str_to_graph(PRAUST_B);
+fn praust_undir_no_iso_bench(bench: &mut Bencher) {
+    let a = ungraph().praust_a();
+    let b = ungraph().praust_b();
 
-    bench.iter(|| petgraph::algo::is_isomorphic(&a, &b));
-}
-
-#[bench]
-fn bench_praust_mst(bb: &mut test::Bencher)
-{
-    let a = str_to_digraph(PRAUST_A);
-    let b = str_to_digraph(PRAUST_B);
-
-    bb.iter(|| {
-        (petgraph::algo::min_spanning_tree(&a),
-        petgraph::algo::min_spanning_tree(&b))
-    });
+    bench.iter(|| is_isomorphic(&a, &b));
 }

--- a/benches/stable_graph.rs
+++ b/benches/stable_graph.rs
@@ -6,201 +6,80 @@ extern crate test;
 use test::Bencher;
 use petgraph::prelude::*;
 
-use petgraph::{EdgeType};
-use petgraph::stable_graph::{
-    node_index,
-};
+#[allow(dead_code)]
+mod factories;
+use factories::*;
 
-/// An almost full set
-const FULL_A: &'static str = "
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 0 1 1 1 0 1 
- 1 1 1 1 1 1 1 1 1 1
-";
-
-const BIGGER: &'static str = "
- 0 0 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 1 1 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 1 0 0 0 1 1 0 0 0 0 0 0 0 1 0 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
- 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0
- 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 1 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0
- 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0
- 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1
- 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 1 1 0 1 1 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1
- 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 1 0 1 1 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1
- 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
- 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
- 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 1 1 0 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
- 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0
- 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0
- 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0
- 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0
- 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0
- 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1
- 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0
- 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0
- 0 1 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1
- 0 1 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0
- 0 1 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1
- 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1
- 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1
- 0 1 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
-";
+use petgraph::stable_graph::node_index;
 
 #[bench]
-fn full_edges_default(bench: &mut Bencher)
-{
-    let a = parse_stable_graph::<Directed>(FULL_A);
-
+fn full_edges_default(bench: &mut Bencher) {
+    let a = stable_digraph().full_a();
     bench.iter(|| a.edges(node_index(1)).count())
 }
 
 #[bench]
-fn full_edges_out(bench: &mut Bencher)
-{
-    let a = parse_stable_graph::<Directed>(FULL_A);
+fn full_edges_out(bench: &mut Bencher) {
+    let a = stable_digraph().full_a();
     bench.iter(|| a.edges_directed(node_index(1), Outgoing).count())
 }
-#[bench]
-fn full_edges_in(bench: &mut Bencher)
-{
-    let a = parse_stable_graph::<Directed>(FULL_A);
 
+#[bench]
+fn full_edges_in(bench: &mut Bencher) {
+    let a = stable_digraph().full_a();
     bench.iter(|| a.edges_directed(node_index(1), Incoming).count())
 }
 
 #[bench]
-fn neighbors_default(bench: &mut Bencher)
-{
-    let a = parse_stable_graph::<Directed>(FULL_A);
-
+fn neighbors_default(bench: &mut Bencher) {
+    let a = stable_digraph().full_a();
     bench.iter(|| a.neighbors(node_index(1)).count())
 }
 
 #[bench]
-fn neighbors_out(bench: &mut Bencher)
-{
-    let a = parse_stable_graph::<Directed>(FULL_A);
+fn neighbors_out(bench: &mut Bencher) {
+    let a = stable_digraph().full_a();
     bench.iter(|| a.neighbors_directed(node_index(1), Outgoing).count())
 }
-#[bench]
-fn neighbors_in(bench: &mut Bencher)
-{
-    let a = parse_stable_graph::<Directed>(FULL_A);
 
+#[bench]
+fn neighbors_in(bench: &mut Bencher) {
+    let a = stable_digraph().full_a();
     bench.iter(|| a.neighbors_directed(node_index(1), Incoming).count())
 }
 
 #[bench]
-fn sccs_stable_graph(bench: &mut Bencher)
-{
-    let a = parse_stable_graph::<Directed>(BIGGER);
+fn sccs_stable_graph(bench: &mut Bencher) {
+    let a = stable_digraph().bigger();
     bench.iter(|| petgraph::algo::kosaraju_scc(&a));
 }
 
 #[bench]
-fn sccs_graph(bench: &mut Bencher)
-{
-    let a = parse_graph::<Directed>(BIGGER);
+fn sccs_graph(bench: &mut Bencher) {
+    let a = digraph().bigger();
     bench.iter(|| petgraph::algo::kosaraju_scc(&a));
 }
 
-/// Parse a text adjacency matrix format into a directed graph
-fn parse_stable_graph<Ty: EdgeType>(s: &str) -> StableGraph<(), (), Ty>
-{
-    let mut gr = StableGraph::default();
-    let s = s.trim();
-    let lines = s.lines().filter(|l| !l.is_empty());
-    for (row, line) in lines.enumerate() {
-        for (col, word) in line.split(' ')
-                                .filter(|s| s.len() > 0)
-                                .enumerate()
-        {
-            let has_edge = word.parse::<i32>().unwrap();
-            assert!(has_edge == 0 || has_edge == 1);
-            if has_edge == 0 {
-                continue;
-            }
-            while col >= gr.node_count() || row >= gr.node_count() {
-                gr.add_node(());
-            }
-            gr.update_edge(node_index(row), node_index(col), ());
-        }
-    }
-    gr
-}
-
-/// Parse a text adjacency matrix format into a directed graph
-fn parse_graph<Ty: EdgeType>(s: &str) -> Graph<(), (), Ty>
-{
-    let mut gr = Graph::with_capacity(0, 0);
-    let s = s.trim();
-    let lines = s.lines().filter(|l| !l.is_empty());
-    for (row, line) in lines.enumerate() {
-        for (col, word) in line.split(' ')
-                                .filter(|s| s.len() > 0)
-                                .enumerate()
-        {
-            let has_edge = word.parse::<i32>().unwrap();
-            assert!(has_edge == 0 || has_edge == 1);
-            if has_edge == 0 {
-                continue;
-            }
-            while col >= gr.node_count() || row >= gr.node_count() {
-                gr.add_node(());
-            }
-            gr.update_edge(node_index(row), node_index(col), ());
-        }
-    }
-    gr
-}
-
-
 #[bench]
-fn stable_graph_map(bench: &mut Bencher)
-{
-    let a = parse_stable_graph::<Directed>(BIGGER);
+fn stable_graph_map(bench: &mut Bencher) {
+    let a = stable_digraph().bigger();
     bench.iter(|| a.map(|i, _| i, |i, _| i));
 }
 
 #[bench]
-fn graph_map(bench: &mut Bencher)
-{
-    let a = parse_graph::<Directed>(BIGGER);
+fn graph_map(bench: &mut Bencher) {
+    let a = digraph().bigger();
     bench.iter(|| a.map(|i, _| i, |i, _| i));
 }
 
 #[bench]
-fn stable_graph_retain_nodes(bench: &mut Bencher)
-{
-    let mut a = parse_stable_graph::<Directed>(BIGGER);
+fn stable_graph_retain_nodes(bench: &mut Bencher) {
+    let mut a = stable_digraph().bigger();
     bench.iter(|| a.retain_nodes(|_gr, i| (i.index() + 1) % 3700 != 0));
 }
 
 #[bench]
-fn stable_graph_retain_edges(bench: &mut Bencher)
-{
-    let mut a = parse_stable_graph::<Directed>(BIGGER);
+fn stable_graph_retain_edges(bench: &mut Bencher) {
+    let mut a = stable_digraph().bigger();
     bench.iter(|| a.retain_edges(|_gr, i| (i.index() + 1) % 3700 != 0));
 }

--- a/benches/unionfind.rs
+++ b/benches/unionfind.rs
@@ -3,157 +3,17 @@
 extern crate test;
 extern crate petgraph;
 
-use petgraph::prelude::*;
-use petgraph::{
-    EdgeType,
-};
-use petgraph::graph::{
-    node_index,
-};
+use test::Bencher;
+
+mod factories;
+use factories::*;
 
 use petgraph::algo::{connected_components, is_cyclic_undirected, min_spanning_tree};
 
-/// Petersen A and B are isomorphic
-///
-/// http://www.dharwadker.org/tevet/isomorphism/
-const PETERSEN_A: &'static str = "
- 0 1 0 0 1 0 1 0 0 0 
- 1 0 1 0 0 0 0 1 0 0 
- 0 1 0 1 0 0 0 0 1 0 
- 0 0 1 0 1 0 0 0 0 1 
- 1 0 0 1 0 1 0 0 0 0 
- 0 0 0 0 1 0 0 1 1 0 
- 1 0 0 0 0 0 0 0 1 1 
- 0 1 0 0 0 1 0 0 0 1 
- 0 0 1 0 0 1 1 0 0 0 
- 0 0 0 1 0 0 1 1 0 0
-";
-
-const PETERSEN_B: &'static str = "
- 0 0 0 1 0 1 0 0 0 1 
- 0 0 0 1 1 0 1 0 0 0 
- 0 0 0 0 0 0 1 1 0 1 
- 1 1 0 0 0 0 0 1 0 0
- 0 1 0 0 0 0 0 0 1 1 
- 1 0 0 0 0 0 1 0 1 0 
- 0 1 1 0 0 1 0 0 0 0 
- 0 0 1 1 0 0 0 0 1 0 
- 0 0 0 0 1 1 0 1 0 0 
- 1 0 1 0 1 0 0 0 0 0
-";
-
-/// An almost full set, isomorphic
-const FULL_A: &'static str = "
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 0 1 1 1 0 1 
- 1 1 1 1 1 1 1 1 1 1
-";
-
-const FULL_B: &'static str = "
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 0 1 1 1 0 1 1 1 
- 1 1 1 1 1 1 1 1 1 1
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1 
- 1 1 1 1 1 1 1 1 1 1
-";
-
-/// Praust A and B are not isomorphic
-const PRAUST_A: &'static str = "
- 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 
- 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 
- 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 
- 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 
- 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 0 0 0 
- 0 1 0 0 1 0 1 1 0 0 0 0 0 1 0 0 0 0 0 0 
- 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 
- 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 1 0 0 0 0 
- 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 
- 0 1 0 0 0 0 0 0 1 0 1 1 0 0 0 0 0 1 0 0 
- 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 
- 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 0 0 0 0 1 
- 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 1 0 1 0 0 
- 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 1 1 0 0 0 
- 0 0 0 0 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 1 
- 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 0 0 1 0 
- 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 1 1 1 
- 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 0 1 0 1 1 
- 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 1 1 0 1 
- 0 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 1 0
-";
-
-const PRAUST_B: &'static str = "
- 0 1 1 1 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 
- 1 0 1 1 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 
- 1 1 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 
- 1 1 1 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 
- 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 0 0 0 
- 0 1 0 0 1 0 1 1 0 0 0 0 0 0 0 0 0 0 0 1 
- 0 0 1 0 1 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 
- 0 0 0 1 1 1 1 0 0 0 0 0 0 0 0 0 0 1 0 0 
- 1 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0
- 0 1 0 0 0 0 0 0 1 0 1 1 0 1 0 0 0 0 0 0 
- 0 0 1 0 0 0 0 0 1 1 0 1 0 0 0 0 0 0 1 0 
- 0 0 0 1 0 0 0 0 1 1 1 0 0 0 0 1 0 0 0 0 
- 0 0 0 0 1 0 0 0 0 0 0 0 0 1 1 0 0 1 0 1 
- 0 0 0 0 0 0 0 0 0 1 0 0 1 0 0 1 1 0 1 0 
- 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 1 0 1 
- 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1 0 1 0 1 0 
- 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 1 0 1 1 0 
- 0 0 0 0 0 0 0 1 0 0 0 0 1 0 1 0 1 0 0 1 
- 0 0 0 0 0 0 0 0 0 0 1 0 0 1 0 1 1 0 0 1 
- 0 0 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 1 1 0 
-";
-
-/// Parse a text adjacency matrix format into a graph
-fn parse_graph<Ty: EdgeType>(s: &str) -> Graph<(), (), Ty> {
-    let mut gr = Graph::with_capacity(0, 0);
-    let s = s.trim();
-    let lines = s.lines().filter(|l| !l.is_empty());
-    for (row, line) in lines.enumerate() {
-        for (col, word) in line.split(' ')
-                                .filter(|s| s.len() > 0)
-                                .enumerate()
-        {
-            let has_edge = word.parse::<i32>().unwrap();
-            assert!(has_edge == 0 || has_edge == 1);
-            if has_edge == 0 {
-                continue;
-            }
-            while col >= gr.node_count() || row >= gr.node_count() {
-                gr.add_node(());
-            }
-            gr.update_edge(node_index(row), node_index(col), ());
-        }
-    }
-    gr
-}
-
-/// Parse a text adjacency matrix format into a *undirected* graph
-fn str_to_ungraph(s: &str) -> Graph<(), (), Undirected> {
-    parse_graph(s)
-}
-
-/// Parse a text adjacency matrix format into a *directed* graph
-fn str_to_digraph(s: &str) -> Graph<(), (), Directed> {
-    parse_graph(s)
-}
-
 #[bench]
-fn connected_components_praust_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(PRAUST_A);
-    let b = str_to_ungraph(PRAUST_B);
+fn connected_components_praust_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().praust_a();
+    let b = ungraph().praust_b();
 
     bench.iter(|| {
         (connected_components(&a), connected_components(&b))
@@ -161,9 +21,9 @@ fn connected_components_praust_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn connected_components_praust_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(PRAUST_A);
-    let b = str_to_digraph(PRAUST_B);
+fn connected_components_praust_dir_bench(bench: &mut Bencher) {
+    let a = digraph().praust_a();
+    let b = digraph().praust_b();
 
     bench.iter(|| {
         (connected_components(&a), connected_components(&b))
@@ -171,9 +31,9 @@ fn connected_components_praust_dir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn connected_components_full_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(FULL_A);
-    let b = str_to_ungraph(FULL_B);
+fn connected_components_full_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().full_a();
+    let b = ungraph().full_b();
 
     bench.iter(|| {
         (connected_components(&a), connected_components(&b))
@@ -181,9 +41,9 @@ fn connected_components_full_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn connected_components_full_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(FULL_A);
-    let b = str_to_digraph(FULL_B);
+fn connected_components_full_dir_bench(bench: &mut Bencher) {
+    let a = digraph().full_a();
+    let b = digraph().full_b();
 
     bench.iter(|| {
         (connected_components(&a), connected_components(&b))
@@ -191,9 +51,9 @@ fn connected_components_full_dir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn connected_components_petersen_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(PETERSEN_A);
-    let b = str_to_ungraph(PETERSEN_B);
+fn connected_components_petersen_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().petersen_a();
+    let b = ungraph().petersen_b();
 
     bench.iter(|| {
         (connected_components(&a), connected_components(&b))
@@ -201,9 +61,9 @@ fn connected_components_petersen_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn connected_components_petersen_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(PETERSEN_A);
-    let b = str_to_digraph(PETERSEN_B);
+fn connected_components_petersen_dir_bench(bench: &mut Bencher) {
+    let a = digraph().petersen_a();
+    let b = digraph().petersen_b();
 
     bench.iter(|| {
         (connected_components(&a), connected_components(&b))
@@ -211,9 +71,9 @@ fn connected_components_petersen_dir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn is_cyclic_undirected_praust_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(PRAUST_A);
-    let b = str_to_ungraph(PRAUST_B);
+fn is_cyclic_undirected_praust_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().praust_a();
+    let b = ungraph().praust_b();
 
     bench.iter(|| {
         (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
@@ -221,9 +81,9 @@ fn is_cyclic_undirected_praust_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn is_cyclic_undirected_praust_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(PRAUST_A);
-    let b = str_to_digraph(PRAUST_B);
+fn is_cyclic_undirected_praust_dir_bench(bench: &mut Bencher) {
+    let a = digraph().praust_a();
+    let b = digraph().praust_b();
 
     bench.iter(|| {
         (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
@@ -231,9 +91,9 @@ fn is_cyclic_undirected_praust_dir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn is_cyclic_undirected_full_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(FULL_A);
-    let b = str_to_ungraph(FULL_B);
+fn is_cyclic_undirected_full_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().full_a();
+    let b = ungraph().full_b();
 
     bench.iter(|| {
         (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
@@ -241,9 +101,9 @@ fn is_cyclic_undirected_full_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn is_cyclic_undirected_full_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(FULL_A);
-    let b = str_to_digraph(FULL_B);
+fn is_cyclic_undirected_full_dir_bench(bench: &mut Bencher) {
+    let a = digraph().full_a();
+    let b = digraph().full_b();
 
     bench.iter(|| {
         (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
@@ -251,9 +111,9 @@ fn is_cyclic_undirected_full_dir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn is_cyclic_undirected_petersen_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(PETERSEN_A);
-    let b = str_to_ungraph(PETERSEN_B);
+fn is_cyclic_undirected_petersen_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().petersen_a();
+    let b = ungraph().petersen_b();
 
     bench.iter(|| {
         (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
@@ -261,9 +121,9 @@ fn is_cyclic_undirected_petersen_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn is_cyclic_undirected_petersen_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(PETERSEN_A);
-    let b = str_to_digraph(PETERSEN_B);
+fn is_cyclic_undirected_petersen_dir_bench(bench: &mut Bencher) {
+    let a = digraph().petersen_a();
+    let b = digraph().petersen_b();
 
     bench.iter(|| {
         (is_cyclic_undirected(&a), is_cyclic_undirected(&b))
@@ -271,9 +131,9 @@ fn is_cyclic_undirected_petersen_dir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn min_spanning_tree_praust_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(PRAUST_A);
-    let b = str_to_ungraph(PRAUST_B);
+fn min_spanning_tree_praust_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().praust_a();
+    let b = ungraph().praust_b();
 
     bench.iter(|| {
         (min_spanning_tree(&a), min_spanning_tree(&b))
@@ -281,9 +141,9 @@ fn min_spanning_tree_praust_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn min_spanning_tree_praust_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(PRAUST_A);
-    let b = str_to_digraph(PRAUST_B);
+fn min_spanning_tree_praust_dir_bench(bench: &mut Bencher) {
+    let a = digraph().praust_a();
+    let b = digraph().praust_b();
 
     bench.iter(|| {
         (min_spanning_tree(&a), min_spanning_tree(&b))
@@ -291,9 +151,9 @@ fn min_spanning_tree_praust_dir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn min_spanning_tree_full_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(FULL_A);
-    let b = str_to_ungraph(FULL_B);
+fn min_spanning_tree_full_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().full_a();
+    let b = ungraph().full_b();
 
     bench.iter(|| {
         (min_spanning_tree(&a), min_spanning_tree(&b))
@@ -301,9 +161,9 @@ fn min_spanning_tree_full_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn min_spanning_tree_full_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(FULL_A);
-    let b = str_to_digraph(FULL_B);
+fn min_spanning_tree_full_dir_bench(bench: &mut Bencher) {
+    let a = digraph().full_a();
+    let b = digraph().full_b();
 
     bench.iter(|| {
         (min_spanning_tree(&a), min_spanning_tree(&b))
@@ -311,9 +171,9 @@ fn min_spanning_tree_full_dir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn min_spanning_tree_petersen_undir_bench(bench: &mut test::Bencher) {
-    let a = str_to_ungraph(PETERSEN_A);
-    let b = str_to_ungraph(PETERSEN_B);
+fn min_spanning_tree_petersen_undir_bench(bench: &mut Bencher) {
+    let a = ungraph().petersen_a();
+    let b = ungraph().petersen_b();
 
     bench.iter(|| {
         (min_spanning_tree(&a), min_spanning_tree(&b))
@@ -321,9 +181,9 @@ fn min_spanning_tree_petersen_undir_bench(bench: &mut test::Bencher) {
 }
 
 #[bench]
-fn min_spanning_tree_petersen_dir_bench(bench: &mut test::Bencher) {
-    let a = str_to_digraph(PETERSEN_A);
-    let b = str_to_digraph(PETERSEN_B);
+fn min_spanning_tree_petersen_dir_bench(bench: &mut Bencher) {
+    let a = digraph().petersen_a();
+    let b = digraph().petersen_b();
 
     bench.iter(|| {
         (min_spanning_tree(&a), min_spanning_tree(&b))


### PR DESCRIPTION
I refactored the benches to use a few factory methods to create basic graphs to run algorithms on. This removes the duplication of `parse_graph()`, `parse_stable_graph()` and the various `PETERSEN_A` (etc) constants. This makes writing benchmarks for algorithms pretty straightforward, but doesn't allow generating benchmarks for a set of sample graphs (although it's a step in that direction IMO).

While I was implementing this on a pretty old machine with barely 1GB RAM, lI also noticed that the benches in [`benches/ograph.rs`](https://github.com/petgraph/petgraph/blob/9a153c2a096c704d8439dd48f655f9e169956b5e/benches/ograph.rs) ran unbounded `add_node)()`/`add_edge()` loops which were crashing due to out-of-memory errors. I'll tackle that in a separate PR.