### PR TITLE
GraphMap: include self loops in incoming edges

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -294,7 +294,7 @@ impl<N, E, Ty> GraphMap<N, E, Ty>
     /// ```
     pub fn remove_edge(&mut self, a: N, b: N) -> Option<E> {
         let exist1 = self.remove_single_edge(&a, &b, Outgoing);
-        let exist2 = if a != b {
+        let exist2 = if a != b || Ty::is_directed() {
             self.remove_single_edge(&b, &a, Incoming)
         } else { exist1 };
         let weight = self.edges.remove(&Self::edge_key(a, b));

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -244,12 +244,13 @@ impl<N, E, Ty> GraphMap<N, E, Ty>
             self.nodes.entry(a)
                       .or_insert_with(|| Vec::with_capacity(1))
                       .push((b, CompactDirection::Outgoing));
-            if a != b {
-                // self loops don't have the Incoming entry
+
+            if a != b || Ty::is_directed() {
                 self.nodes.entry(b)
-                          .or_insert_with(|| Vec::with_capacity(1))
-                          .push((a, CompactDirection::Incoming));
+                    .or_insert_with(|| Vec::with_capacity(1))
+                    .push((a, CompactDirection::Incoming));
             }
+
             None
         }
     }

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -323,3 +323,16 @@ fn undirected_neighbors_includes_self_loops() {
     assert_eq!(neighbors.next(), Some(node));
     assert_eq!(neighbors.next(), None);
 }
+
+#[test]
+fn self_loops_can_be_removed() {
+    let mut graph = DiGraphMap::new();
+
+    let node = graph.add_node(());
+    graph.add_edge(node, node, ());
+
+    graph.remove_edge(node, node);
+
+    assert_eq!(graph.neighbors_directed(node, Outgoing).next(), None);
+    assert_eq!(graph.neighbors_directed(node, Incoming).next(), None);
+}

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -299,3 +299,27 @@ fn test_all_edges_mut() {
         assert_eq!((start + end) * 2, *weight);
     }
 }
+
+#[test]
+fn neighbors_incoming_includes_self_loops() {
+    let mut graph = DiGraphMap::new();
+
+    let node = graph.add_node(());
+    graph.add_edge(node, node, ());
+
+    let mut neighbors = graph.neighbors_directed(node, Incoming);
+    assert_eq!(neighbors.next(), Some(node));
+    assert_eq!(neighbors.next(), None);
+}
+
+#[test]
+fn undirected_neighbors_includes_self_loops() {
+    let mut graph = UnGraphMap::new();
+
+    let node = graph.add_node(());
+    graph.add_edge(node, node, ());
+
+    let mut neighbors = graph.neighbors(node);
+    assert_eq!(neighbors.next(), Some(node));
+    assert_eq!(neighbors.next(), None);
+}


### PR DESCRIPTION
After some fiddling with the tests, I believe the existing test was there to
prevent self loops being added twice for undirected graphs.

Fixes #281