### PR TITLE
Update fixedbitset to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bench = false
 debug = true
 
 [dependencies]
-fixedbitset = { version = "0.1.4" }
+fixedbitset = { version = "0.2.0", default-features = false }
 quickcheck = { optional = true, version = "0.8", default-features = false }
 indexmap = { version = "1.0.2", optional = true }
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
No relevant feature updates for now, but it's the latest version and it supports opting out of std. Which furthers things related to #238 