### PR TITLE
Include self loops in incoming edges

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -348,6 +348,7 @@ impl<N, E, Ty> GraphMap<N, E, Ty>
                 Some(neigh) => neigh.iter(),
                 None => [].iter(),
             },
+            start_node: a,
             dir: dir,
             ty: self.ty,
         }
@@ -531,6 +532,7 @@ pub struct NeighborsDirected<'a, N, Ty>
           Ty: EdgeType,
 {
     iter: Iter<'a, (N, CompactDirection)>,
+    start_node: N,
     dir: Direction,
     ty: PhantomData<Ty>,
 }
@@ -543,8 +545,9 @@ impl<'a, N, Ty> Iterator for NeighborsDirected<'a, N, Ty>
     fn next(&mut self) -> Option<N> {
         if Ty::is_directed() {
             let self_dir = self.dir;
+            let start_node = self.start_node;
             (&mut self.iter)
-                .filter_map(move |&(n, dir)| if dir == self_dir {
+                .filter_map(move |&(n, dir)| if dir == self_dir || n == start_node {
                     Some(n)
                 } else { None })
                 .next()

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -300,14 +300,39 @@ fn test_all_edges_mut() {
     }
 }
 
-
 #[test]
 fn neighbors_incoming_includes_self_loops() {
-    // From issue #281
     let mut graph = DiGraphMap::new();
 
     let node = graph.add_node(());
     graph.add_edge(node, node, ());
 
-    assert_eq!(graph.neighbors_directed(node, Incoming).next(), Some(node));
+    let mut neighbors = graph.neighbors_directed(node, Incoming);
+    assert_eq!(neighbors.next(), Some(node));
+    assert_eq!(neighbors.next(), None);
+}
+
+#[test]
+fn undirected_neighbors_includes_self_loops() {
+    let mut graph = UnGraphMap::new();
+
+    let node = graph.add_node(());
+    graph.add_edge(node, node, ());
+
+    let mut neighbors = graph.neighbors(node);
+    assert_eq!(neighbors.next(), Some(node));
+    assert_eq!(neighbors.next(), None);
+}
+
+#[test]
+fn self_loops_can_be_removed() {
+    let mut graph = DiGraphMap::new();
+
+    let node = graph.add_node(());
+    graph.add_edge(node, node, ());
+
+    graph.remove_edge(node, node);
+
+    assert_eq!(graph.neighbors_directed(node, Outgoing).next(), None);
+    assert_eq!(graph.neighbors_directed(node, Incoming).next(), None);
 }

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -299,3 +299,15 @@ fn test_all_edges_mut() {
         assert_eq!((start + end) * 2, *weight);
     }
 }
+
+
+#[test]
+fn neighbors_incoming_includes_self_loops() {
+    // From issue #281
+    let mut graph = DiGraphMap::new();
+
+    let node = graph.add_node(());
+    graph.add_edge(node, node, ());
+
+    assert_eq!(graph.neighbors_directed(node, Incoming).next(), Some(node));
+}


### PR DESCRIPTION
Make sure self loops are included correctly in GraphMap::neighbors_directed.

Similar to Graph iterators, we have a special case for self loops in the iterator.

Thanks to @jmcomets for writing the tests in this change, I've transferred them from #282.

Fixes #281 
