### PR TITLE
GraphMap: add Entry API

### DIFF
--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -121,7 +121,7 @@ impl<'a, N, E: 'a, Ty, Ix> IntoNeighbors for &'a StableGraph<N, E, Ty, Ix>
 
 #[cfg(feature = "graphmap")]
 impl<'a, N: 'a, E, Ty> IntoNeighbors for &'a GraphMap<N, E, Ty>
-    where N: Copy + Ord + Hash,
+    where N: NodeTrait,
           Ty: EdgeType,
 {
     type Neighbors = graphmap::Neighbors<'a, N, Ty>;


### PR DESCRIPTION
This adds an `edge_entry()` method to `GraphMap`'s public interface along with
a thin wrapper over an `IndexMap` entry.

Differences with the wrapped entry:
- `source()`: returns the source edge, replacing `key()`
- `target()`: returns the target edge, replacing `key()`

Note that this enables merging parallel edges, which currently requires quite a
ceremony.

For example, when counting occurrences:

```rust
// before
if let Some(old) = gr.add_edge("x", "y", 1) {
    gr.add_edge("x", "y", old + 1);
}

// after
*gr.edge_entry("x", "y").or_insert(0) += 1;
```