### PR TITLE
[visit] add FilterNode impls for &FixedBitSet and &HashSet

### DIFF
--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -56,6 +56,25 @@ impl<N, S> FilterNode<N> for HashSet<N, S>
     }
 }
 
+// Can't express these as a generic impl over all references since that would conflict with the
+// impl for Fn.
+impl<N> FilterNode<N> for &FixedBitSet
+    where FixedBitSet: VisitMap<N>
+{
+    fn include_node(&self, n: N) -> bool {
+        self.is_visited(&n)
+    }
+}
+
+impl<N, S> FilterNode<N> for &HashSet<N, S>
+    where HashSet<N, S>: VisitMap<N>,
+{
+    fn include_node(&self, n: N) -> bool {
+        self.is_visited(&n)
+    }
+}
+
+
 /// A node-filtering graph adaptor.
 #[derive(Copy, Clone, Debug)]
 pub struct NodeFiltered<G, F>(pub G, pub F);


### PR DESCRIPTION
It's sometimes easier to pass in a reference to a bitset or hashset while
using it as a temporary node filter. Previously the only other way to do
this was to use a closure.