### PR TITLE
Fix elements emitted by min_spanning_tree on StableGraph

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -6,7 +6,6 @@
 
 pub mod dominators;
 
-use core::hash::Hash;
 use std::collections::{BinaryHeap, HashMap};
 use std::cmp::min;
 
@@ -559,8 +558,7 @@ pub fn condensation<N, E, Ty, Ix>(g: Graph<N, E, Ty, Ix>, make_acyclic: bool) ->
 ///
 /// Use `from_elements` to create a graph from the resulting iterator.
 pub fn min_spanning_tree<G>(g: G) -> MinSpanningTree<G>
-    where G::NodeId: Eq + Hash,
-          G::NodeWeight: Clone,
+    where G::NodeWeight: Clone,
           G::EdgeWeight: Clone + PartialOrd,
           G: IntoNodeReferences + IntoEdgeReferences + NodeIndexable,
 {
@@ -594,23 +592,23 @@ pub struct MinSpanningTree<G>
     node_ids: Option<G::NodeReferences>,
     subgraphs: UnionFind<usize>,
     sort_edges: BinaryHeap<MinScored<G::EdgeWeight, (G::NodeId, G::NodeId)>>,
-    node_map: HashMap<G::NodeId, usize>,
+    node_map: HashMap<usize, usize>,
     node_count: usize,
 }
 
 
 impl<G> Iterator for MinSpanningTree<G>
     where G: IntoNodeReferences + NodeIndexable,
-          G::NodeId: Eq + Hash,
           G::NodeWeight: Clone,
           G::EdgeWeight: PartialOrd,
 {
     type Item = Element<G::NodeWeight, G::EdgeWeight>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let g = self.graph;
         if let Some(ref mut iter) = self.node_ids {
             if let Some(node) = iter.next() {
-                self.node_map.insert(node.id(), self.node_count);
+                self.node_map.insert(g.to_index(node.id()), self.node_count);
                 self.node_count += 1;
                 return Some(Element::Node { weight: node.weight().clone() });
             }
@@ -627,17 +625,17 @@ impl<G> Iterator for MinSpanningTree<G>
         //  b. If the edge connects two disjoint trees in the pre-MST,
         //     add the edge.
         while let Some(MinScored(score, (a, b))) = self.sort_edges.pop() {
-            let g = self.graph;
             // check if the edge would connect two disjoint parts
-            if self.subgraphs.union(g.to_index(a), g.to_index(b)) {
-                let (&aid, &bid) = match (self.node_map.get(&a),
-                                          self.node_map.get(&b)) {
+            let (a_index, b_index) = (g.to_index(a), g.to_index(b));
+            if self.subgraphs.union(a_index, b_index) {
+                let (&a_order, &b_order) = match (self.node_map.get(&a_index),
+                                                  self.node_map.get(&b_index)) {
                     (Some(a_id), Some(b_id)) => (a_id, b_id),
                     _ => panic!("Edge references unknown node"),
                 };
                 return Some(Element::Edge {
-                    source: aid,
-                    target: bid,
+                    source: a_order,
+                    target: b_order,
                     weight: score,
                 });
             }

--- a/tests/stable_graph.rs
+++ b/tests/stable_graph.rs
@@ -7,7 +7,7 @@ extern crate itertools;
 use petgraph::prelude::*;
 use petgraph::stable_graph::node_index as n;
 use petgraph::EdgeType;
-use petgraph::algo::{kosaraju_scc, tarjan_scc};
+use petgraph::algo::{kosaraju_scc, tarjan_scc, min_spanning_tree};
 use petgraph::visit::{
     NodeIndexable,
     IntoNodeReferences,
@@ -342,4 +342,24 @@ fn from() {
     assert!(nodes_eq!(gr5, ans));
     assert!(edgew_eq!(gr5, ans));
     assert!(edges_eq!(gr5, ans));
+}
+
+use petgraph::stable_graph::StableGraph;
+use petgraph::data::FromElements;
+
+#[test]
+fn from_min_spanning_tree() {
+    let mut g = StableGraph::new();
+    let mut nodes = Vec::new();
+    for _ in 0..6 {
+        nodes.push(g.add_node(()));
+    }
+    let es = [(4, 5), (3, 4), (3, 5)];
+    for &(a, b) in es.iter() {
+        g.add_edge(NodeIndex::new(a), NodeIndex::new(b), ());
+    }
+    for i in 0..3 {
+        let _ = g.remove_node(nodes[i]);
+    }
+    let _ = StableGraph::<(),(),Undirected,usize>::from_elements(min_spanning_tree(&g));
 }


### PR DESCRIPTION
Fixes #288 

Currently, when graphs are constructed from `Element` `Iterator`s, it is assumed that the `source` and `target` members of the `Edge` `Element`s refer to the order in which the `Node` `Element`s were emitted by the iterator. That is, if we see an edge with `source=0`, then we add an edge to the graph originating at the first `Node` we got from the current iterator.

This causes a problem when generating `Iterator`s from `StableGraph`s which have had nodes deleted. We have to remember that the index of a particular node as represented by the graph does not necessarily correspond to the order in which the node will be emitted by the iterator.

For instance, if we start with a `StableGraph` described by:
```
Nodes: [0, 1, 2]
Edges: [(0, 1), (1, 2)]
```
and then delete node 0, we end up with:
```
Nodes: [1, 2]
Edges: [(1, 2)]
```
Before this pull request, calling `min_spanning_tree` on this graph would result in the following stream of `Element`s:
```
[Node, Node, Edge { 1, 2 }]
```
Attempting to reconstruct a graph from this iterator would throw an error when trying to add the edge, as it looks for the third (index 2) node added to the graph and is unable to find it.

The solution in this patch is to maintain a mapping of `NodeId` to emitted node index in the `MinSpanningTree` iterator, and to emit `Edge` `Element`s which correctly reference the order in which the node was emitted by the iterator.

Note that it will still be very easy for contributors to make the same mistake as was made in `min_spanning_tree`, by creating `Element` iterators that are unaware of the possibility of missing node indexes from `StableGraph`s.