### PR TITLE
perf: Allow the state in tarjan_scc to be reused

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -402,26 +402,28 @@ impl<N> TarjanScc<N> {
             };
         }
 
-        if node![v].index.is_some() {
+        let node_v = &mut node![v];
+        if node_v.index.is_some() {
             // already visited
             return;
         }
 
         let v_index = self.index;
-        node![v].index = Some(v_index);
-        node![v].lowlink = v_index;
-        node![v].on_stack = true;
+        node_v.index = Some(v_index);
+        node_v.lowlink = v_index;
+        node_v.on_stack = true;
         self.stack.push(v);
         self.index += 1;
 
         for w in g.neighbors(v) {
-            match node![w].index {
+            let node_w = &mut node![w];
+            match node_w.index {
                 None => {
                     self.visit(w, g, f);
                     node![v].lowlink = min(node![v].lowlink, node![w].lowlink);
                 }
                 Some(w_index) => {
-                    if node![w].on_stack {
+                    if node_w.on_stack {
                         // Successor w is in stack S and hence in the current SCC
                         let v_lowlink = &mut node![v].lowlink;
                         *v_lowlink = min(*v_lowlink, w_index);
@@ -431,8 +433,9 @@ impl<N> TarjanScc<N> {
         }
 
         // If v is a root node, pop the stack and generate an SCC
-        if let Some(v_index) = node![v].index {
-            if node![v].lowlink == v_index {
+        let node_v = &mut node![v];
+        if let Some(v_index) = node_v.index {
+            if node_v.lowlink == v_index {
                 let mut iter = TarjanSccIter {
                     tarjan_scc: self,
                     v,

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -828,7 +828,7 @@ fn tarjan_scc() {
     let mut tarjan_scc = petgraph::algo::TarjanScc::new();
 
     let mut result = Vec::new();
-    tarjan_scc.run(&gr, |scc| result.push(scc.collect()));
+    tarjan_scc.run(&gr, |scc| result.push(scc.iter().rev().cloned().collect()));
     assert_sccs_eq(
         result,
         vec![
@@ -847,7 +847,7 @@ fn tarjan_scc() {
     assert!(hr.remove_edge(ed).is_some());
 
     let mut result = Vec::new();
-    tarjan_scc.run(&hr, |scc| result.push(scc.collect()));
+    tarjan_scc.run(&hr, |scc| result.push(scc.iter().rev().cloned().collect()));
     assert_sccs_eq(
         result,
         vec![
@@ -870,7 +870,7 @@ fn tarjan_scc() {
     gr.add_edge(n(1), n(0), ());
 
     let mut result = Vec::new();
-    tarjan_scc.run(&gr, |scc| result.push(scc.collect()));
+    tarjan_scc.run(&gr, |scc| result.push(scc.iter().rev().cloned().collect()));
     assert_sccs_eq(
         result,
         vec![vec![n(0)], vec![n(1)], vec![n(2)], vec![n(3)]],
@@ -883,7 +883,7 @@ fn tarjan_scc() {
     gr.add_node(());
     // no order for the disconnected one
     let mut result = Vec::new();
-    tarjan_scc.run(&gr, |scc| result.push(scc.collect()));
+    tarjan_scc.run(&gr, |scc| result.push(scc.iter().rev().cloned().collect()));
     assert_sccs_eq(
         result,
         vec![vec![n(0)], vec![n(1)], vec![n(2)], vec![n(3)]],

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -825,8 +825,12 @@ fn tarjan_scc() {
         (4, 1),
     ]);
 
+    let mut tarjan_scc = petgraph::algo::TarjanScc::new();
+
+    let mut result = Vec::new();
+    tarjan_scc.run(&gr, |scc| result.push(scc.collect()));
     assert_sccs_eq(
-        petgraph::algo::tarjan_scc(&gr),
+        result,
         vec![
             vec![n(0), n(3), n(6)],
             vec![n(2), n(5), n(8)],
@@ -842,8 +846,10 @@ fn tarjan_scc() {
     let ed = hr.find_edge(n(6), n(8)).unwrap();
     assert!(hr.remove_edge(ed).is_some());
 
+    let mut result = Vec::new();
+    tarjan_scc.run(&hr, |scc| result.push(scc.collect()));
     assert_sccs_eq(
-        petgraph::algo::tarjan_scc(&hr),
+        result,
         vec![
             vec![n(1), n(2), n(4), n(5), n(7), n(8)],
             vec![n(0), n(3), n(6)],
@@ -863,8 +869,10 @@ fn tarjan_scc() {
     gr.add_edge(n(2), n(0), ());
     gr.add_edge(n(1), n(0), ());
 
+    let mut result = Vec::new();
+    tarjan_scc.run(&gr, |scc| result.push(scc.collect()));
     assert_sccs_eq(
-        petgraph::algo::tarjan_scc(&gr),
+        result,
         vec![vec![n(0)], vec![n(1)], vec![n(2)], vec![n(3)]],
         true,
     );
@@ -874,8 +882,10 @@ fn tarjan_scc() {
     gr.extend_with_edges(&[(0, 0), (1, 0), (2, 0), (2, 1), (2, 2)]);
     gr.add_node(());
     // no order for the disconnected one
+    let mut result = Vec::new();
+    tarjan_scc.run(&gr, |scc| result.push(scc.collect()));
     assert_sccs_eq(
-        petgraph::algo::tarjan_scc(&gr),
+        result,
         vec![vec![n(0)], vec![n(1)], vec![n(2)], vec![n(3)]],
         false,
     );


### PR DESCRIPTION
This lets the vectors allocated for `tarjan_scc` be reused as well as lets the caller opt into a closure + iterator based output, avoiding the need to allocate and return `Vec`s.