### PR TITLE
add documentation for remove_node in GraphMap

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -184,6 +184,8 @@ where
     }
 
     /// Return `true` if node `n` was removed.
+    ///
+    /// Computes in **O(V)** time, due to the removal of edges with other nodes.
     pub fn remove_node(&mut self, n: N) -> bool {
         let links = match self.nodes.swap_remove(&n) {
             None => return false,


### PR DESCRIPTION
I was asking myself upon reading the documentation, whether `remove_node()` also deletes connected edges. It seems to me that this is the case, so I updated the Documentation similarly to the documentation of the same function in MatrixGraph