### PR TITLE
Dijkstra optimization

### DIFF
--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -1,0 +1,33 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use petgraph::prelude::*;
+use std::cmp::{ max, min };
+use test::Bencher;
+
+use petgraph::algo::dijkstra;
+
+#[bench]
+fn dijkstra_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 10_000;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).into_iter().map(|i| g.add_node(i)).collect();
+    for i in 0..NODE_COUNT {
+        let n1 = nodes[i];
+        let neighbour_count = i % 8 + 3;
+        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
+        let j_to = min(NODE_COUNT, j_from + neighbour_count);
+        for j in j_from..j_to {
+            let n2  = nodes[j];
+            let distance = (i + 3) % 10;
+            g.add_edge(n1, n2, distance);
+        }
+    }
+
+    bench.iter(|| {
+        let _scores = dijkstra(&g, nodes[0], None, |e| *e.weight());
+    });
+}
+

--- a/src/dijkstra.rs
+++ b/src/dijkstra.rs
@@ -100,22 +100,21 @@ where
             if visited.is_visited(&next) {
                 continue;
             }
-            let mut next_score = node_score + edge_cost(edge);
+            let next_score = node_score + edge_cost(edge);
             match scores.entry(next) {
                 Occupied(ent) => {
                     if next_score < *ent.get() {
                         *ent.into_mut() = next_score;
-                    //predecessor.insert(next.clone(), node.clone());
-                    } else {
-                        next_score = *ent.get();
+                        visit_next.push(MinScored(next_score, next));
+                        //predecessor.insert(next.clone(), node.clone());
                     }
                 }
                 Vacant(ent) => {
                     ent.insert(next_score);
+                    visit_next.push(MinScored(next_score, next));
                     //predecessor.insert(next.clone(), node.clone());
                 }
             }
-            visit_next.push(MinScored(next_score, next));
         }
         visited.visit(node);
     }


### PR DESCRIPTION
Adding a node to the `visit_next` heap should not be needed when the calculated distance is not shorter than the existing one.

This change improves the performance of the Dijkstra algorithm by avoiding a heap insertion in such cases. According to the (new) benchmark:
- from 3,338,159 ns/iter (+/- 210,817)
- to 2,312,579 ns/iter (+/- 93,191)

(please check the above assumption as I'm not a graph specialist ;)).