### PR TITLE
Allow the GraphMap's hasher to be overriden

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -3,6 +3,8 @@
 use crate::graph::IndexType;
 #[cfg(feature = "graphmap")]
 use crate::graphmap::{GraphMap, NodeTrait};
+#[cfg(feature = "graphmap")]
+use std::hash::BuildHasher;
 #[cfg(feature = "stable_graph")]
 use crate::stable_graph::StableGraph;
 use crate::visit::{Data, NodeCount, NodeIndexable, Reversed};
@@ -184,10 +186,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> Build for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> Build for GraphMap<N, E, Ty, S>
 where
-    Ty: EdgeType,
     N: NodeTrait,
+    Ty: EdgeType,
+    S: BuildHasher,
 {
     fn add_node(&mut self, weight: Self::NodeWeight) -> Self::NodeId {
         self.add_node(weight)
@@ -239,10 +242,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> Create for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> Create for GraphMap<N, E, Ty, S>
 where
     Ty: EdgeType,
     N: NodeTrait,
+    S: BuildHasher + Default,
 {
     fn with_capacity(nodes: usize, edges: usize) -> Self {
         Self::with_capacity(nodes, edges)
@@ -350,10 +354,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> FromElements for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> FromElements for GraphMap<N, E, Ty, S>
 where
     Ty: EdgeType,
     N: NodeTrait,
+    S: BuildHasher + Default,
 {
     fn from_elements<I>(iterable: I) -> Self
     where

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -50,7 +50,7 @@ pub type DiGraphMap<N, E> = GraphMap<N, E, Directed, RandomState>;
 /// - `E` can be of arbitrary type.
 /// - Edge type `Ty` that determines whether the graph edges are directed or
 /// undirected.
-/// - TODO Hasher type `S`
+/// - The hasher type `S` is used in the underlying hashtables of nodes & edges.
 ///
 /// You can use the type aliases `UnGraphMap` and `DiGraphMap` for convenience.
 ///

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -7,6 +7,8 @@ use crate::stable_graph::StableGraph;
 use crate::{EdgeType, Graph};
 
 #[cfg(feature = "graphmap")]
+use std::hash::BuildHasher;
+#[cfg(feature = "graphmap")]
 use crate::graphmap::{GraphMap, NodeTrait};
 use crate::visit::NodeIndexable;
 
@@ -176,11 +178,12 @@ where
 ///
 /// Requires crate features `"quickcheck"` and `"graphmap"`
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> Arbitrary for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> Arbitrary for GraphMap<N, E, Ty, S>
 where
     N: NodeTrait + Arbitrary,
     E: Arbitrary,
     Ty: EdgeType + Clone + Send + 'static,
+    S: BuildHasher + Default + Clone + Send + 'static,
 {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let nodes = usize::arbitrary(g);

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -114,10 +114,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<'a, N: 'a, E, Ty> IntoNeighbors for &'a GraphMap<N, E, Ty>
+impl<'a, N: 'a, E, Ty, S> IntoNeighbors for &'a GraphMap<N, E, Ty, S>
 where
     N: Copy + Ord + Hash,
     Ty: EdgeType,
+    S: BuildHasher,
 {
     type Neighbors = graphmap::Neighbors<'a, N, Ty>;
     fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
@@ -200,10 +201,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<'a, N: 'a, E, Ty> IntoNeighborsDirected for &'a GraphMap<N, E, Ty>
+impl<'a, N: 'a, E, Ty, S> IntoNeighborsDirected for &'a GraphMap<N, E, Ty, S>
 where
     N: Copy + Ord + Hash,
     Ty: EdgeType,
+    S: BuildHasher,
 {
     type NeighborsDirected = graphmap::NeighborsDirected<'a, N, Ty>;
     fn neighbors_directed(self, n: N, dir: Direction) -> Self::NeighborsDirected {
@@ -434,7 +436,7 @@ pub trait IntoEdgeReferences : Data + GraphRef {
 IntoEdgeReferences! {delegate_impl [] }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> Data for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> Data for GraphMap<N, E, Ty, S>
 where
     N: Copy + PartialEq,
     Ty: EdgeType,
@@ -477,7 +479,7 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> GraphProp for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> GraphProp for GraphMap<N, E, Ty, S>
 where
     N: NodeTrait,
     Ty: EdgeType,
@@ -691,7 +693,7 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> GraphBase for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> GraphBase for GraphMap<N, E, Ty, S>
 where
     N: Copy + PartialEq,
 {
@@ -700,10 +702,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> Visitable for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> Visitable for GraphMap<N, E, Ty, S>
 where
     N: Copy + Ord + Hash,
     Ty: EdgeType,
+    S: BuildHasher,
 {
     type Map = HashSet<N>;
     fn visit_map(&self) -> HashSet<N> {
@@ -737,10 +740,11 @@ GetAdjacencyMatrix! {delegate_impl []}
 
 #[cfg(feature = "graphmap")]
 /// The `GraphMap` keeps an adjacency matrix internally.
-impl<N, E, Ty> GetAdjacencyMatrix for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> GetAdjacencyMatrix for GraphMap<N, E, Ty, S>
 where
     N: Copy + Ord + Hash,
     Ty: EdgeType,
+    S: BuildHasher,
 {
     type AdjMatrix = ();
     #[inline]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1713,7 +1713,7 @@ fn degree_sequence() {
     degree_sequence.sort_by(|x, y| Ord::cmp(y, x));
     assert_eq!(&degree_sequence, &[5, 3, 3, 2, 2, 1, 0]);
 
-    let mut gr = GraphMap::<_, (), Undirected>::from_edges(&[
+    let mut gr = UnGraphMap::<_, ()>::from_edges(&[
         (0, 1),
         (1, 2),
         (1, 3),

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -84,7 +84,7 @@ fn remov() {
 
 #[test]
 fn remove_directed() {
-    let mut g = GraphMap::<_, _, Directed>::with_capacity(0, 0);
+    let mut g = DiGraphMap::with_capacity(0, 0);
     g.add_edge(1, 2, -1);
     println!("{:?}", g);
 
@@ -167,13 +167,12 @@ fn edge_iterator() {
 
 #[test]
 fn from_edges() {
-    let gr =
-        GraphMap::<_, _, Undirected>::from_edges(&[("a", "b", 1), ("a", "c", 2), ("c", "d", 3)]);
+    let gr = UnGraphMap::from_edges(&[("a", "b", 1), ("a", "c", 2), ("c", "d", 3)]);
     assert_eq!(gr.node_count(), 4);
     assert_eq!(gr.edge_count(), 3);
     assert_eq!(gr[("a", "c")], 2);
 
-    let gr = GraphMap::<_, (), Undirected>::from_edges(&[
+    let gr = UnGraphMap::<_, ()>::from_edges(&[
         (0, 1),
         (0, 2),
         (0, 3),
@@ -232,7 +231,7 @@ where
 
 #[test]
 fn scc() {
-    let gr: GraphMap<_, u32, Directed> = GraphMap::from_edges(&[
+    let gr: DiGraphMap<_, u32> = GraphMap::from_edges(&[
         (6, 0, 0),
         (0, 3, 1),
         (3, 6, 2),
@@ -254,7 +253,7 @@ fn scc() {
 
 #[test]
 fn test_into_graph() {
-    let gr: GraphMap<_, u32, Directed> = GraphMap::from_edges(&[
+    let gr: DiGraphMap<_, u32> = GraphMap::from_edges(&[
         (6, 0, 0),
         (0, 3, 1),
         (3, 6, 2),
@@ -285,8 +284,7 @@ fn test_into_graph() {
 #[test]
 fn test_all_edges_mut() {
     // graph with edge weights equal to in+out
-    let mut graph: GraphMap<_, u32, Directed> =
-        GraphMap::from_edges(&[(0, 1, 1), (1, 2, 3), (2, 0, 2)]);
+    let mut graph: DiGraphMap<_, u32> = GraphMap::from_edges(&[(0, 1, 1), (1, 2, 3), (2, 0, 2)]);
 
     // change it so edge weight is equal to 2 * (in+out)
     for (start, end, weight) in graph.all_edges_mut() {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -15,7 +15,7 @@ use utils::Small;
 
 use odds::prelude::*;
 use std::collections::HashSet;
-use std::hash::Hash;
+use std::hash::{Hash, BuildHasher};
 
 use itertools::assert_equal;
 use itertools::cloned;
@@ -413,10 +413,11 @@ fn stable_graph_add_remove_edges() {
     quickcheck::quickcheck(prop as fn(StableGraph<_, _, Directed>, _) -> bool);
 }
 
-fn assert_graphmap_consistent<N, E, Ty>(g: &GraphMap<N, E, Ty>)
+fn assert_graphmap_consistent<N, E, Ty, S>(g: &GraphMap<N, E, Ty, S>)
 where
     Ty: EdgeType,
     N: NodeTrait + fmt::Debug,
+    S: BuildHasher,
 {
     for (a, b, _weight) in g.all_edges() {
         assert!(
@@ -444,7 +445,7 @@ where
 
 #[test]
 fn graphmap_remove() {
-    fn prop<Ty: EdgeType>(mut g: GraphMap<i8, (), Ty>, a: i8, b: i8) -> bool {
+    fn prop<Ty: EdgeType, S: BuildHasher>(mut g: GraphMap<i8, (), Ty, S>, a: i8, b: i8) -> bool {
         //if g.edge_count() > 20 { return true; }
         assert_graphmap_consistent(&g);
         let contains = g.contains_edge(a, b);


### PR DESCRIPTION
This PR adds a new factory method `with_capacity_and_hasher()`, as well as a
new type parameter. A current limitation is that the hasher should be the same
type for both nodes and edges.

I believe this is a breaking change, since it can break type inference for
`GraphMap::new()` & similar factory methods.

Side note: since this is a big change (though simple), maybe I could use the
opportunity to move the separate trait impls for GraphMap back to the module?

Fixes #133