### PR TITLE
Implement immediately_dominated_by

### DIFF
--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -13,7 +13,7 @@
 //! dominates **C** and **C** dominates **B**.
 
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map::Iter};
 use std::hash::Hash;
 
 use crate::visit::{DfsPostOrder, GraphBase, IntoNeighbors, Visitable, Walker};
@@ -79,6 +79,15 @@ where
             None
         }
     }
+
+    /// Iterate over all nodes immediately dominated by the given node (not
+    /// including the given node itself).
+    pub fn immediately_dominated_by(&self, node: N) -> DominatedByIter<N> {
+        DominatedByIter {
+            iter: self.dominators.iter(),
+            node: node
+        }
+    }
 }
 
 /// Iterator for a node's dominators.
@@ -102,6 +111,31 @@ where
             self.node = self.dominators.immediate_dominator(next);
         }
         next
+    }
+}
+
+/// Iterator for nodes dominated by a given node.
+pub struct DominatedByIter<'a, N>
+where
+    N: 'a + Copy + Eq + Hash,
+{
+    iter: Iter<'a, N, N>,
+    node: N,
+}
+
+impl<'a, N> Iterator for DominatedByIter<'a, N>
+where
+    N: 'a + Copy + Eq + Hash,
+{
+    type Item = N;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(next) = self.iter.next() {
+            if next.1 == &self.node {
+                return Some(*next.0);
+            }
+        }
+        None
     }
 }
 
@@ -280,5 +314,9 @@ mod tests {
             None::<()>,
             doms.strict_dominators(99).map(|_| unreachable!())
         );
+
+        let dom_by: Vec<_> = doms.immediately_dominated_by(1).collect();
+        assert_eq!(vec![2], dom_by);
+        assert_eq!(None, doms.immediately_dominated_by(99).next());
     }
 }


### PR DESCRIPTION
I figure this'll be useful while constructing dominance trees and if you just want to check what's immediately dominated by a node without having to get the whole tree.

I considered just exposing the underlying HashMap with an into_inner function, but I think this option (immediately_dominated_by)  is better.

I also considered returning impl Iterator<Item = N> and just calling filter in immediately_dominated_by, which would certainly be simpler. I was concerned about minimum supported Rust versions, though.

I am not attached to the name at all. In fact, I think dominated_by might even be better, at the risk of misleading people into thinking it returns the whole subtree of the dominance tree starting with the given node.

This should be compatible with the two outstanding dominance-algorithm PRs, since it just adds to the interface of Dominators.