### PR TITLE
Add "serde-1" support to GraphMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ itertools = { version = "0.8", default-features = false }
 [features]
 default = ["graphmap", "stable_graph", "matrix_graph"]
 graphmap = []
-serde-1 = ["serde", "serde_derive"]
+serde-1 = ["serde", "serde_derive", "indexmap/serde-1"]
 stable_graph = []
 matrix_graph = []
 

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -436,7 +436,7 @@ IntoEdgeReferences! {delegate_impl [] }
 #[cfg(feature = "graphmap")]
 impl<N, E, Ty> Data for GraphMap<N, E, Ty>
 where
-    N: Copy + PartialEq,
+    N: Eq + Hash + Copy + PartialEq,
     Ty: EdgeType,
 {
     type NodeWeight = N;
@@ -693,7 +693,7 @@ where
 #[cfg(feature = "graphmap")]
 impl<N, E, Ty> GraphBase for GraphMap<N, E, Ty>
 where
-    N: Copy + PartialEq,
+    N: Eq + Hash + Copy + PartialEq,
 {
     type NodeId = N;
     type EdgeId = (N, N);


### PR DESCRIPTION
This PR propagates `serde-1` to `indexmap` and implements a custom serializer for `(N, N)` tuples, i.e., edges (`[Source, Target, Weight]` array format). The custom serializer is required for `serde_json` to work (tuples are not allowed as object keys). Also tested using `bincode`.