### PR TITLE
 [visit] access original edge reference from a reversed edge 

### DIFF
--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -4,7 +4,7 @@ extern crate petgraph;
 extern crate test;
 
 use petgraph::prelude::*;
-use std::cmp::{ max, min };
+use std::cmp::{max, min};
 use test::Bencher;
 
 use petgraph::algo::dijkstra;
@@ -20,7 +20,7 @@ fn dijkstra_bench(bench: &mut Bencher) {
         let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
         let j_to = min(NODE_COUNT, j_from + neighbour_count);
         for j in j_from..j_to {
-            let n2  = nodes[j];
+            let n2 = nodes[j];
             let distance = (i + 3) % 10;
             g.add_edge(n1, n2, distance);
         }
@@ -30,4 +30,3 @@ fn dijkstra_bench(bench: &mut Bencher) {
         let _scores = dijkstra(&g, nodes[0], None, |e| *e.weight());
     });
 }
-

--- a/src/visit/reversed.rs
+++ b/src/visit/reversed.rs
@@ -95,6 +95,16 @@ where
 #[derive(Copy, Clone, Debug)]
 pub struct ReversedEdgeReference<R>(R);
 
+impl<R> ReversedEdgeReference<R> {
+    /// Return the original, unreversed edge reference.
+    pub fn as_unreversed(&self) -> &R { &self.0 }
+
+    /// Consume `self` and return the original, unreversed edge reference.
+    pub fn into_unreversed(self) -> R {
+        self.0
+    }
+}
+
 /// An edge reference
 impl<R> EdgeRef for ReversedEdgeReference<R>
 where


### PR DESCRIPTION
This can be useful when one is trying to write code that is always
interested in the original edge reference, whether the graph under
consideration is reversed or not.