### PR TITLE
Fix some clippy warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 matrix:
   include:
-    - rust: 1.37.0
+    - rust: 1.40.0
       env:
       - ALL=' '
     - rust: stable

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 petgraph
 ========
 
-Graph data structure library. Known to support Rust 1.37 and later.
+Graph data structure library. Known to support Rust 1.40 and later.
 
 Please read the `API documentation here`__
 

--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -4,7 +4,7 @@ extern crate petgraph;
 extern crate test;
 
 use petgraph::prelude::*;
-use std::cmp::{ max, min };
+use std::cmp::{max, min};
 use test::Bencher;
 
 use petgraph::algo::dijkstra;
@@ -20,7 +20,7 @@ fn dijkstra_bench(bench: &mut Bencher) {
         let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
         let j_to = min(NODE_COUNT, j_from + neighbour_count);
         for j in j_from..j_to {
-            let n2  = nodes[j];
+            let n2 = nodes[j];
             let distance = (i + 3) % 10;
             g.add_edge(n1, n2, distance);
         }
@@ -30,4 +30,3 @@ fn dijkstra_bench(bench: &mut Bencher) {
         let _scores = dijkstra(&g, nodes[0], None, |e| *e.weight());
     });
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,8 +199,8 @@ copyclone!(Direction);
 impl Direction {
     /// Return the opposite `Direction`.
     #[inline]
-    pub fn opposite(&self) -> Direction {
-        match *self {
+    pub fn opposite(self) -> Direction {
+        match self {
             Outgoing => Incoming,
             Incoming => Outgoing,
         }
@@ -208,8 +208,8 @@ impl Direction {
 
     /// Return `0` for `Outgoing` and `1` for `Incoming`.
     #[inline]
-    pub fn index(&self) -> usize {
-        (*self as usize) & 0x1
+    pub fn index(self) -> usize {
+        (self as usize) & 0x1
     }
 }
 

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -361,9 +361,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     /// **Panics** if no edge exists between `a` and `b`.
     pub fn remove_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> E {
         let p = self.to_edge_position(a, b);
-        let old_weight = mem::replace(&mut self.node_adjacencies[p], Default::default())
-            .into()
-            .unwrap();
+        let old_weight = mem::take(&mut self.node_adjacencies[p]).into().unwrap();
         let old_weight: Option<_> = old_weight.into();
         self.nb_edges -= 1;
         old_weight.unwrap()

--- a/src/scored.rs
+++ b/src/scored.rs
@@ -39,10 +39,10 @@ impl<K: PartialOrd, T> Ord for MinScored<K, T> {
             Ordering::Greater
         } else if a > b {
             Ordering::Less
-        } else if a != a && b != b {
+        } else if a.ne(a) && b.ne(b) {
             // these are the NaN cases
             Ordering::Equal
-        } else if a != a {
+        } else if a.ne(a) {
             // Order NaN less, so that it is last in the MinScore order
             Ordering::Less
         } else {

--- a/src/visit/macros.rs
+++ b/src/visit/macros.rs
@@ -105,7 +105,7 @@ macro_rules! delegate_impl {
         @section self
         $(
             $(#[$_method_attr:meta])*
-            fn $method_name:ident(self $(: $self_selftype:ty)* $(,$marg:ident : $marg_ty:ty)*) -> $mret:ty;
+            fn $method_name:ident(self $(: $self_selftype:ty)* $(,$marg:ident : $marg_ty:ty)*) $(-> $mret:ty)?;
         )+
         )*
         // Arbitrary tail that is ignored when forwarding.
@@ -125,7 +125,7 @@ macro_rules! delegate_impl {
             )*
             $(
             $(
-                fn $method_name(self $(: $self_selftype)* $(,$marg: $marg_ty)*) -> $mret {
+                fn $method_name(self $(: $self_selftype)* $(,$marg: $marg_ty)*) $(-> $mret)? {
                     $self_map!(self).$method_name($($marg),*)
                 }
             )*

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -626,7 +626,7 @@ pub trait Visitable : GraphBase {
     /// Create a new visitor map
     fn visit_map(self: &Self) -> Self::Map;
     /// Reset the visitor map (and resize to new size of graph if needed)
-    fn reset_map(self: &Self, map: &mut Self::Map) -> ();
+    fn reset_map(self: &Self, map: &mut Self::Map);
 }
 }
 Visitable! {delegate_impl []}


### PR DESCRIPTION
Fix a number of clippy warnings. See #306.

I have not fixed `clippy::type_complexity` or `clippy::float_cmp`.

Note: the last commit applies `cargo fmt`.