### PR TITLE
Fix typo in describing ensure_len function

### DIFF
--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -834,7 +834,7 @@ fn extend_lower_triangular_matrix<T: Default>(
     new_node_capacity + 1
 }
 
-/// Grow a Vec by appending the type's default value the `size` is reached.
+/// Grow a Vec by appending the type's default value until the `size` is reached.
 fn ensure_len<T: Default>(v: &mut Vec<T>, size: usize) {
     if let Some(n) = size.checked_sub(v.len()) {
         v.reserve(n);


### PR DESCRIPTION
This is the new PR for the issue in pull request #344. 
Hopefully this works now.