### PR TITLE
Change occurrences of `V` with `N` in the documentation.

### DIFF
--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -112,10 +112,10 @@ const UNDEFINED: usize = ::std::usize::MAX;
 /// This is an implementation of the engineered ["Simple, Fast Dominance
 /// Algorithm"][0] discovered by Cooper et al.
 ///
-/// This algorithm is **O(|V|²)**, and therefore has slower theoretical running time
-/// than the Lengauer-Tarjan algorithm (which is **O(|E| log |V|)**. However,
+/// This algorithm is **O(|N|²)**, and therefore has slower theoretical running time
+/// than the Lengauer-Tarjan algorithm (which is **O(|E| log |N|)**. However,
 /// Cooper et al found it to be faster in practice on control flow graphs of up
-/// to ~30,000 vertices.
+/// to ~30,000 nodes.
 ///
 /// [0]: http://www.cs.rice.edu/~keith/EMBED/dom.pdf
 pub fn simple_fast<G>(graph: G, root: G::NodeId) -> Dominators<G::NodeId>

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -564,8 +564,8 @@ where
 /// return a minimum spanning forest, i.e. a minimum spanning tree for each connected
 /// component of the graph.
 ///
-/// The resulting graph has all the vertices of the input graph (with identical node indices),
-/// and **|V| - c** edges, where **c** is the number of connected components in `g`.
+/// The resulting graph has all the nodes of the input graph (with identical node indices),
+/// and **|N| - c** edges, where **c** is the number of connected components in `g`.
 ///
 /// Use `from_elements` to create a graph from the resulting iterator.
 pub fn min_spanning_tree<G>(g: G) -> MinSpanningTree<G>
@@ -756,7 +756,7 @@ where
     let ix = |i| g.to_index(i);
 
     distance[ix(source)] = <_>::zero();
-    // scan up to |V| - 1 times.
+    // scan up to |N| - 1 times.
     for _ in 1..g.node_count() {
         let mut did_update = false;
         for i in g.node_identifiers() {

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -34,11 +34,11 @@ const BINARY_SEARCH_CUTOFF: usize = 32;
 /// - Index type `Ix`, which determines the maximum size of the graph.
 ///
 ///
-/// Using **O(|E| + |V|)** space.
+/// Using **O(|E| + |N|)** space.
 ///
 /// Self loops are allowed, no parallel edges.
 ///
-/// Fast iteration of the outgoing edges of a vertex.
+/// Fast iteration of the outgoing edges of a node.
 ///
 /// [`CSR`]: https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)
 #[derive(Debug)]
@@ -142,7 +142,7 @@ where
     /// Edges **must** be sorted and unique, where the sort order is the default
     /// order for the pair *(u, v)* in Rust (*u* has priority).
     ///
-    /// Computes in **O(|E| + |V|)** time.
+    /// Computes in **O(|E| + |N|)** time.
     /// # Example
     /// ```rust
     /// use petgraph::csr::Csr;
@@ -276,7 +276,7 @@ where
     /// Return `true` if the edge was added
     ///
     /// If you add all edges in row-major order, the time complexity
-    /// is **O(|V|·|E|)** for the whole operation.
+    /// is **O(|N|·|E|)** for the whole operation.
     ///
     /// **Panics** if `a` or `b` are out of bounds.
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> bool
@@ -332,7 +332,7 @@ where
         }
     }
 
-    /// Computes in **O(log |V|)** time.
+    /// Computes in **O(log |N|)** time.
     ///
     /// **Panics** if the node `a` does not exist.
     pub fn contains_edge(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -31,12 +31,12 @@ pub struct Generator<Ty> {
 }
 
 impl Generator<Directed> {
-    /// Generate all possible Directed acyclic graphs (DAGs) of a particular number of vertices.
+    /// Generate all possible Directed acyclic graphs (DAGs) of a particular number of nodes.
     ///
     /// These are only generated with one per isomorphism, so they use
     /// one canonical node labeling where node *i* can only have edges to node *j* if *i < j*.
     ///
-    /// For a graph of *k* vertices there are *e = (k - 1) k / 2* possible edges and
+    /// For a graph of *k* nodes there are *e = (k - 1) k / 2* possible edges and
     /// *2<sup>e</sup>* DAGs.
     pub fn directed_acyclic(nodes: usize) -> Self {
         assert!(nodes != 0);
@@ -54,11 +54,11 @@ impl Generator<Directed> {
 }
 
 impl<Ty: EdgeType> Generator<Ty> {
-    /// Generate all possible graphs of a particular number of vertices.
+    /// Generate all possible graphs of a particular number of nodes.
     ///
     /// All permutations are generated, so the graphs are not unique down to isomorphism.
     ///
-    /// For a graph of *k* vertices there are *e = k²* possible edges and
+    /// For a graph of *k* nodes there are *e = k²* possible edges and
     /// *2<sup>k<sup>2</sup></sup>* graphs.
     pub fn all(nodes: usize, allow_selfloops: bool) -> Self {
         let scale = if Ty::is_directed() { 1 } else { 2 };

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -271,7 +271,7 @@ impl<E, Ix: IndexType> Edge<E, Ix> {
 /// The `Graph` is a regular Rust collection and is `Send` and `Sync` (as long
 /// as associated data `N` and `E` are).
 ///
-/// The graph uses **O(|V| + |E|)** space, and allows fast node and edge insert,
+/// The graph uses **O(|N| + |E|)** space, and allows fast node and edge insert,
 /// efficient graph search and graph algorithms.
 /// It implements **O(e')** edge lookup and edge and node removals, where **e'**
 /// is some local measure of edge count.
@@ -711,7 +711,7 @@ where
     /// (that edge will adopt the removed edge index).
     ///
     /// Computes in **O(e')** time, where **e'** is the size of four particular edge lists, for
-    /// the vertices of `e` and the vertices of another affected edge.
+    /// the nodes of `e` and the nodes of another affected edge.
     pub fn remove_edge(&mut self, e: EdgeIndex<Ix>) -> Option<E> {
         // every edge is part of two lists,
         // outgoing and incoming edges.
@@ -951,7 +951,7 @@ where
     /// For a graph with undirected edges, both the sinks and the sources are
     /// just the nodes without edges.
     ///
-    /// The whole iteration computes in **O(|V|)** time.
+    /// The whole iteration computes in **O(|N|)** time.
     pub fn externals(&self, dir: Direction) -> Externals<N, Ty, Ix> {
         Externals {
             iter: self.nodes.iter().enumerate(),

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -47,7 +47,7 @@ mod serialization;
 /// - Edge type `Ty` that determines whether the graph edges are directed or undirected.
 /// - Index type `Ix`, which determines the maximum size of the graph.
 ///
-/// The graph uses **O(|V| + |E|)** space, and allows fast node and edge insert
+/// The graph uses **O(|N| + |E|)** space, and allows fast node and edge insert
 /// and efficient graph search.
 ///
 /// It implements **O(e')** edge lookup and edge and node removals, where **e'**
@@ -687,7 +687,7 @@ where
     /// For a graph with undirected edges, both the sinks and the sources are
     /// just the nodes without edges.
     ///
-    /// The whole iteration computes in **O(|V|)** time.
+    /// The whole iteration computes in **O(|N|)** time.
     pub fn externals(&self, dir: Direction) -> Externals<N, Ty, Ix> {
         Externals {
             iter: self.raw_nodes().iter().enumerate(),
@@ -1128,7 +1128,7 @@ where
 
 /// Convert a `Graph` into a `StableGraph`
 ///
-/// Computes in **O(|V| + |E|)** time.
+/// Computes in **O(|N| + |E|)** time.
 ///
 /// The resulting graph has the same node and edge indices as
 /// the original graph.
@@ -1163,7 +1163,7 @@ where
 
 /// Convert a `StableGraph` into a `Graph`
 ///
-/// Computes in **O(|V| + |E|)** time.
+/// Computes in **O(|N| + |E|)** time.
 ///
 /// This translates the stable graph into a graph with node and edge indices in
 /// a compact interval without holes (like `Graph`s always are).

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -36,7 +36,7 @@ pub type DiGraphMap<N, E> = GraphMap<N, E, Directed>;
 /// of its node weights `N`.
 ///
 /// It uses an combined adjacency list and sparse adjacency matrix
-/// representation, using **O(|V| + |E|)** space, and allows testing for edge
+/// representation, using **O(|N| + |E|)** space, and allows testing for edge
 /// existence in constant time.
 ///
 /// `GraphMap` is parameterized over:
@@ -185,7 +185,7 @@ where
 
     /// Return `true` if node `n` was removed.
     ///
-    /// Computes in **O(V)** time, due to the removal of edges with other nodes.
+    /// Computes in **O(N)** time, due to the removal of edges with other nodes.
     pub fn remove_node(&mut self, n: N) -> bool {
         let links = match self.nodes.swap_remove(&n) {
             None => return false,
@@ -413,7 +413,7 @@ where
     ///    node weights in the resulting `Graph`, too.
     /// 2. Note that the index type is user-chosen.
     ///
-    /// Computes in **O(|V| + |E|)** time (average).
+    /// Computes in **O(|N| + |E|)** time (average).
     ///
     /// **Panics** if the number of nodes or edges does not fit with
     /// the resulting graph's index type.

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -12,11 +12,11 @@ struct Vf2State<Ty, Ix> {
     /// NodeIndex::end() for no mapping.
     mapping: Vec<NodeIndex<Ix>>,
     /// out[i] is non-zero if i is in either M_0(s) or Tout_0(s)
-    /// These are all the next vertices that are not mapped yet, but
+    /// These are all the next node that are not mapped yet, but
     /// have an outgoing edge from the mapping.
     out: Vec<usize>,
     /// ins[i] is non-zero if i is in either M_0(s) or Tin_0(s)
-    /// These are all the incoming vertices, those not mapped yet, but
+    /// These are all the incoming node, those not mapped yet, but
     /// have an edge from them into the mapping.
     /// Unused if graph is undirected -- it's identical with out in that case.
     ins: Vec<usize>,

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -192,7 +192,7 @@ pub fn node_index(ax: usize) -> NodeIndex {
 ///   to mark the absence of an edge.
 /// - Index type `Ix` that sets the maximum size for the graph (defaults to `DefaultIx`).
 ///
-/// The graph uses **O(|V^2|)** space, with fast edge insertion & amortized node insertion, as well
+/// The graph uses **O(|N^2|)** space, with fast edge insertion & amortized node insertion, as well
 /// as efficient graph search and graph algorithms on dense graphs.
 ///
 /// This graph is backed by a flattened 2D array. For undirected graphs, only the lower triangular
@@ -284,7 +284,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
 
     /// Remove `a` from the graph.
     ///
-    /// Computes in **O(V)** time, due to the removal of edges with other nodes.
+    /// Computes in **O(N)** time, due to the removal of edges with other nodes.
     ///
     /// **Panics** if the node `a` does not exist.
     pub fn remove_node(&mut self, a: NodeIndex<Ix>) -> N {
@@ -323,7 +323,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     /// Return the previous data, if any.
     ///
     /// Computes in **O(1)** time, best case.
-    /// Computes in **O(|V|^2)** time, worst case (matrix needs to be re-allocated).
+    /// Computes in **O(|N|^2)** time, worst case (matrix needs to be re-allocated).
     ///
     /// **Panics** if any of the nodes don't exist.
     pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> Option<E> {
@@ -343,7 +343,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     /// Return the index of the new edge.
     ///
     /// Computes in **O(1)** time, best case.
-    /// Computes in **O(|V|^2)** time, worst case (matrix needs to be re-allocated).
+    /// Computes in **O(|N|^2)** time, worst case (matrix needs to be re-allocated).
     ///
     /// **Panics** if any of the nodes don't exist.
     /// **Panics** if an edge already exists from `a` to `b`.

--- a/src/visit/dfsvisit.rs
+++ b/src/visit/dfsvisit.rs
@@ -140,9 +140,9 @@ impl<B> Default for Control<B> {
 /// A recursive depth first search.
 ///
 /// Starting points are the nodes in the iterator `starts` (specify just one
-/// start vertex *x* by using `Some(x)`).
+/// start node *x* by using `Some(x)`).
 ///
-/// The traversal emits discovery and finish events for each reachable vertex,
+/// The traversal emits discovery and finish events for each reachable node,
 /// and edge classification of each reachable edge. `visitor` is called for each
 /// event, see [`DfsEvent`][de] for possible values.
 ///
@@ -164,8 +164,8 @@ impl<B> Default for Control<B> {
 ///
 /// # Example returning `Control`.
 ///
-/// Find a path from vertex 0 to 5, and exit the visit as soon as we reach
-/// the goal vertex.
+/// Find a path from node 0 to 5, and exit the visit as soon as we reach
+/// the goal node.
 ///
 /// ```
 /// use petgraph::prelude::*;


### PR DESCRIPTION
The petgraph structs are generic over `N` (node) rather than `V`, so the
use of `V` (which stands for vertices, but that's rarelt spelled out) in
the documentation is confusing.

Also change occurrences of vertex/vertices with node/nodes in rustdoc
comments, for more consistency.

Fixes: #356