### PR TITLE
Clarification of references to nodes and V as described in #356

### DIFF
--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -115,7 +115,7 @@ const UNDEFINED: usize = ::std::usize::MAX;
 /// This algorithm is **O(|V|²)**, and therefore has slower theoretical running time
 /// than the Lengauer-Tarjan algorithm (which is **O(|E| log |V|)**. However,
 /// Cooper et al found it to be faster in practice on control flow graphs of up
-/// to ~30,000 vertices.
+/// to ~30,000 nodes.
 ///
 /// [0]: http://www.cs.rice.edu/~keith/EMBED/dom.pdf
 pub fn simple_fast<G>(graph: G, root: G::NodeId) -> Dominators<G::NodeId>

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -112,8 +112,8 @@ const UNDEFINED: usize = ::std::usize::MAX;
 /// This is an implementation of the engineered ["Simple, Fast Dominance
 /// Algorithm"][0] discovered by Cooper et al.
 ///
-/// This algorithm is **O(|V|²)**, and therefore has slower theoretical running time
-/// than the Lengauer-Tarjan algorithm (which is **O(|E| log |V|)**. However,
+/// This algorithm is **O(|V|²)** where V is the set of nodes, and therefore has slower theoretical running time
+/// than the Lengauer-Tarjan algorithm (which is **O(|E| log |V|)** where E is the set of edges). However,
 /// Cooper et al found it to be faster in practice on control flow graphs of up
 /// to ~30,000 nodes.
 ///

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -71,14 +71,14 @@ pub fn connected_components<G>(g: G) -> usize
 where
     G: NodeCompactIndexable + IntoEdgeReferences,
 {
-    let mut vertex_sets = UnionFind::new(g.node_bound());
+    let mut node_sets = UnionFind::new(g.node_bound());
     for edge in g.edge_references() {
         let (a, b) = (edge.source(), edge.target());
 
-        // union the two vertices of the edge
-        vertex_sets.union(g.to_index(a), g.to_index(b));
+        // union the two nodes of the edge
+        node_sets.union(g.to_index(a), g.to_index(b));
     }
-    let mut labels = vertex_sets.into_labeling();
+    let mut labels = node_sets.into_labeling();
     labels.sort();
     labels.dedup();
     labels.len()
@@ -95,7 +95,7 @@ where
     for edge in g.edge_references() {
         let (a, b) = (edge.source(), edge.target());
 
-        // union the two vertices of the edge
+        // union the two nodes of the edge
         //  -- if they were already the same, then we have a cycle
         if !edge_sets.union(g.to_index(a), g.to_index(b)) {
             return true;
@@ -564,7 +564,7 @@ where
 /// return a minimum spanning forest, i.e. a minimum spanning tree for each connected
 /// component of the graph.
 ///
-/// The resulting graph has all the vertices of the input graph (with identical node indices),
+/// The resulting graph has all the nodes of the input graph (with identical node indices),
 /// and **|V| - c** edges, where **c** is the number of connected components in `g`.
 ///
 /// Use `from_elements` to create a graph from the resulting iterator.
@@ -574,7 +574,7 @@ where
     G::EdgeWeight: Clone + PartialOrd,
     G: IntoNodeReferences + IntoEdgeReferences + NodeIndexable,
 {
-    // Initially each vertex is its own disjoint subgraph, track the connectedness
+    // Initially each node is its own disjoint subgraph, track the connectedness
     // of the pre-MST with a union & find datastructure.
     let subgraphs = UnionFind::new(g.node_bound());
 
@@ -634,7 +634,7 @@ where
         // Kruskal's algorithm.
         // Algorithm is this:
         //
-        // 1. Create a pre-MST with all the vertices and no edges.
+        // 1. Create a pre-MST with all the nodes and no edges.
         // 2. Repeat:
         //
         //  a. Remove the shortest edge from the original graph.

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -565,7 +565,7 @@ where
 /// component of the graph.
 ///
 /// The resulting graph has all the nodes of the input graph (with identical node indices),
-/// and **|V| - c** edges, where **c** is the number of connected components in `g`.
+/// and **|V| - c** edges, where V is the set of nodes and **c** is the number of connected components in `g`.
 ///
 /// Use `from_elements` to create a graph from the resulting iterator.
 pub fn min_spanning_tree<G>(g: G) -> MinSpanningTree<G>

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -34,7 +34,7 @@ const BINARY_SEARCH_CUTOFF: usize = 32;
 /// - Index type `Ix`, which determines the maximum size of the graph.
 ///
 ///
-/// Using **O(|E| + |V|)** space.
+/// Using **O(|V| + |E|)** space where V is the set of nodes and E is the set of edges.
 ///
 /// Self loops are allowed, no parallel edges.
 ///
@@ -142,7 +142,7 @@ where
     /// Edges **must** be sorted and unique, where the sort order is the default
     /// order for the pair *(u, v)* in Rust (*u* has priority).
     ///
-    /// Computes in **O(|E| + |V|)** time.
+    /// Computes in **O(|V| + |E|)** time where V is the set of nodes and E is the set of edges.
     /// # Example
     /// ```rust
     /// use petgraph::csr::Csr;
@@ -331,7 +331,7 @@ where
         }
     }
 
-    /// Computes in **O(log |V|)** time.
+    /// Computes in **O(log |V|)** time where V is the set of nodes.
     ///
     /// **Panics** if the node `a` does not exist.
     pub fn contains_edge(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -38,7 +38,7 @@ const BINARY_SEARCH_CUTOFF: usize = 32;
 ///
 /// Self loops are allowed, no parallel edges.
 ///
-/// Fast iteration of the outgoing edges of a vertex.
+/// Fast iteration of the outgoing edges of a node.
 ///
 /// [`CSR`]: https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)
 #[derive(Debug)]

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -31,12 +31,12 @@ pub struct Generator<Ty> {
 }
 
 impl Generator<Directed> {
-    /// Generate all possible Directed acyclic graphs (DAGs) of a particular number of vertices.
+    /// Generate all possible Directed acyclic graphs (DAGs) of a particular number of nodes.
     ///
     /// These are only generated with one per isomorphism, so they use
     /// one canonical node labeling where node *i* can only have edges to node *j* if *i < j*.
     ///
-    /// For a graph of *k* vertices there are *e = (k - 1) k / 2* possible edges and
+    /// For a graph of *k* nodes there are *e = (k - 1) k / 2* possible edges and
     /// *2<sup>e</sup>* DAGs.
     pub fn directed_acyclic(nodes: usize) -> Self {
         assert!(nodes != 0);
@@ -54,11 +54,11 @@ impl Generator<Directed> {
 }
 
 impl<Ty: EdgeType> Generator<Ty> {
-    /// Generate all possible graphs of a particular number of vertices.
+    /// Generate all possible graphs of a particular number of nodes.
     ///
     /// All permutations are generated, so the graphs are not unique down to isomorphism.
     ///
-    /// For a graph of *k* vertices there are *e = k²* possible edges and
+    /// For a graph of *k* nodes there are *e = k²* possible edges and
     /// *2<sup>k<sup>2</sup></sup>* graphs.
     pub fn all(nodes: usize, allow_selfloops: bool) -> Self {
         let scale = if Ty::is_directed() { 1 } else { 2 };

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -478,7 +478,7 @@ where
         }
     }
 
-    /// Return the number of nodes (vertices) in the graph.
+    /// Return the number of nodes (also called vertices) in the graph.
     ///
     /// Computes in **O(1)** time.
     pub fn node_count(&self) -> usize {
@@ -711,7 +711,7 @@ where
     /// (that edge will adopt the removed edge index).
     ///
     /// Computes in **O(e')** time, where **e'** is the size of four particular edge lists, for
-    /// the vertices of `e` and the vertices of another affected edge.
+    /// the nodes of `e` and the nodes of another affected edge.
     pub fn remove_edge(&mut self, e: EdgeIndex<Ix>) -> Option<E> {
         // every edge is part of two lists,
         // outgoing and incoming edges.

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -271,7 +271,8 @@ impl<E, Ix: IndexType> Edge<E, Ix> {
 /// The `Graph` is a regular Rust collection and is `Send` and `Sync` (as long
 /// as associated data `N` and `E` are).
 ///
-/// The graph uses **O(|V| + |E|)** space, and allows fast node and edge insert,
+/// The graph uses **O(|V| + |E|)** space where V is the set of nodes and E is the number 
+/// of edges, and allows fast node and edge insert,
 /// efficient graph search and graph algorithms.
 /// It implements **O(e')** edge lookup and edge and node removals, where **e'**
 /// is some local measure of edge count.
@@ -951,7 +952,7 @@ where
     /// For a graph with undirected edges, both the sinks and the sources are
     /// just the nodes without edges.
     ///
-    /// The whole iteration computes in **O(|V|)** time.
+    /// The whole iteration computes in **O(|V|)** time where V is the set of nodes.
     pub fn externals(&self, dir: Direction) -> Externals<N, Ty, Ix> {
         Externals {
             iter: self.nodes.iter().enumerate(),

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -214,7 +214,7 @@ where
         }
     }
 
-    /// Return the number of nodes (vertices) in the graph.
+    /// Return the number of nodes (also called vertices) in the graph.
     ///
     /// Computes in **O(1)** time.
     pub fn node_count(&self) -> usize {

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -47,8 +47,8 @@ mod serialization;
 /// - Edge type `Ty` that determines whether the graph edges are directed or undirected.
 /// - Index type `Ix`, which determines the maximum size of the graph.
 ///
-/// The graph uses **O(|V| + |E|)** space, and allows fast node and edge insert
-/// and efficient graph search.
+/// The graph uses **O(|V| + |E|)** space where V is the set of nodes and E is the 
+/// set of edges, and allows fast node and edge insert and efficient graph search.
 ///
 /// It implements **O(e')** edge lookup and edge and node removals, where **e'**
 /// is some local measure of edge count.
@@ -687,7 +687,7 @@ where
     /// For a graph with undirected edges, both the sinks and the sources are
     /// just the nodes without edges.
     ///
-    /// The whole iteration computes in **O(|V|)** time.
+    /// The whole iteration computes in **O(|V|)** time where V is the set of nodes.
     pub fn externals(&self, dir: Direction) -> Externals<N, Ty, Ix> {
         Externals {
             iter: self.raw_nodes().iter().enumerate(),
@@ -1128,7 +1128,7 @@ where
 
 /// Convert a `Graph` into a `StableGraph`
 ///
-/// Computes in **O(|V| + |E|)** time.
+/// Computes in **O(|V| + |E|)** time where V is the set of nodes and E is the set of edges.
 ///
 /// The resulting graph has the same node and edge indices as
 /// the original graph.
@@ -1163,7 +1163,7 @@ where
 
 /// Convert a `StableGraph` into a `Graph`
 ///
-/// Computes in **O(|V| + |E|)** time.
+/// Computes in **O(|V| + |E|)** time where V is the set of nodes and E is the set of edges.
 ///
 /// This translates the stable graph into a graph with node and edge indices in
 /// a compact interval without holes (like `Graph`s always are).

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -36,7 +36,8 @@ pub type DiGraphMap<N, E> = GraphMap<N, E, Directed>;
 /// of its node weights `N`.
 ///
 /// It uses an combined adjacency list and sparse adjacency matrix
-/// representation, using **O(|V| + |E|)** space, and allows testing for edge
+/// representation, using **O(|V| + |E|)** space where V is the set of nodes
+/// and E is the set of edges, and allows testing for edge
 /// existence in constant time.
 ///
 /// `GraphMap` is parameterized over:
@@ -413,7 +414,7 @@ where
     ///    node weights in the resulting `Graph`, too.
     /// 2. Note that the index type is user-chosen.
     ///
-    /// Computes in **O(|V| + |E|)** time (average).
+    /// Computes in **O(|V| + |E|)** time (average) where V is the set of nodes and E is the set of edges.
     ///
     /// **Panics** if the number of nodes or edges does not fit with
     /// the resulting graph's index type.

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -12,11 +12,11 @@ struct Vf2State<Ty, Ix> {
     /// NodeIndex::end() for no mapping.
     mapping: Vec<NodeIndex<Ix>>,
     /// out[i] is non-zero if i is in either M_0(s) or Tout_0(s)
-    /// These are all the next vertices that are not mapped yet, but
+    /// These are all the next nodes that are not mapped yet, but
     /// have an outgoing edge from the mapping.
     out: Vec<usize>,
     /// ins[i] is non-zero if i is in either M_0(s) or Tin_0(s)
-    /// These are all the incoming vertices, those not mapped yet, but
+    /// These are all the incoming nodes, those not mapped yet, but
     /// have an edge from them into the mapping.
     /// Unused if graph is undirected -- it's identical with out in that case.
     ins: Vec<usize>,

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -249,7 +249,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         self.nb_edges = 0;
     }
 
-    /// Return the number of nodes (vertices) in the graph.
+    /// Return the number of nodes (also called vertices) in the graph.
     ///
     /// Computes in **O(1)** time.
     #[inline]

--- a/src/visit/dfsvisit.rs
+++ b/src/visit/dfsvisit.rs
@@ -135,9 +135,9 @@ impl<B> Default for Control<B> {
 /// A recursive depth first search.
 ///
 /// Starting points are the nodes in the iterator `starts` (specify just one
-/// start vertex *x* by using `Some(x)`).
+/// start node *x* by using `Some(x)`).
 ///
-/// The traversal emits discovery and finish events for each reachable vertex,
+/// The traversal emits discovery and finish events for each reachable node,
 /// and edge classification of each reachable edge. `visitor` is called for each
 /// event, see [`DfsEvent`][de] for possible values.
 ///
@@ -159,8 +159,8 @@ impl<B> Default for Control<B> {
 ///
 /// # Example returning `Control`.
 ///
-/// Find a path from vertex 0 to 5, and exit the visit as soon as we reach
-/// the goal vertex.
+/// Find a path from node 0 to 5, and exit the visit as soon as we reach
+/// the goal node.
 ///
 /// ```
 /// use petgraph::prelude::*;


### PR DESCRIPTION
This is an alternative suggestion to #357 and trying to fix the issue #356.

# What changes have been made?

1. All occurrences, except for those that are explicitly alternatives, of "vertex"/"vertices", have been replaced with "node"/"nodes".
2. Most occurrences of `|V|` and `|E|` now include "where V is the set of nodes and E is the set of edges".

# Why do I think this is better than #357?

The letter V is very widely used to refer to the set of nodes/vertices, regardless of which word you prefer. I believe it is more important to stick to this convention to make the documentation more understandable to experienced readers as N is more commonly used to refer to a natural number.

This mismatch between symbols and words happens all the time and is nothing to worry about. (see electric current (I) in physics, for example)

I understand however that readers might be confused as to the meaning of V in particular. For this reason, I have included sufficient explanations within the documentation.

Fixes: #356 