### PR TITLE
A* instance implementation as requested in #338

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -25,6 +25,7 @@ use crate::visit::Walker;
 use crate::visit::{Data, IntoNodeReferences, NodeRef};
 
 pub use super::astar::astar;
+pub use super::astar::AstarInstance;
 pub use super::dijkstra::dijkstra;
 pub use super::isomorphism::{is_isomorphic, is_isomorphic_matching};
 pub use super::simple_paths::all_simple_paths;

--- a/src/astar.rs
+++ b/src/astar.rs
@@ -136,6 +136,7 @@ where
     None
 }
 
+#[derive(Debug)]
 pub struct AstarInstance<G, F, H, K, IsGoal>
 where
     G: IntoEdges + Visitable,

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -16,7 +16,7 @@ use petgraph::algo::{
 use petgraph::graph::node_index as n;
 use petgraph::graph::IndexType;
 
-use petgraph::algo::{astar, dijkstra, DfsSpace};
+use petgraph::algo::{astar, dijkstra, AstarInstance, DfsSpace};
 use petgraph::visit::{
     IntoEdges, IntoEdgesDirected, IntoNeighbors, IntoNodeIdentifiers, NodeFiltered, Reversed, Topo,
     VisitMap, Walker,
@@ -523,6 +523,32 @@ fn test_astar_null_heuristic() {
 }
 
 #[test]
+fn test_astar_instance_null_heuristic() {
+    let mut g = Graph::new();
+    let a = g.add_node("A");
+    let b = g.add_node("B");
+    let c = g.add_node("C");
+    let d = g.add_node("D");
+    let e = g.add_node("E");
+    let f = g.add_node("F");
+    g.add_edge(a, b, 7);
+    g.add_edge(c, a, 9);
+    g.add_edge(a, d, 14);
+    g.add_edge(b, c, 10);
+    g.add_edge(d, c, 2);
+    g.add_edge(d, e, 9);
+    g.add_edge(b, f, 15);
+    g.add_edge(c, f, 11);
+
+    let mut instance = AstarInstance::new(&g, |finish| finish == e, |e| *e.weight(), |_| 0);
+    for start in g.node_indices() {
+        let instance_path = instance.run(start);
+        let path = astar(&g, start, |finish| finish == e, |e| *e.weight(), |_| 0);
+        assert_eq!(instance_path, path);
+    }
+}
+
+#[test]
 fn test_astar_manhattan_heuristic() {
     let mut g = Graph::new();
     let a = g.add_node((0., 0.));
@@ -571,6 +597,49 @@ fn test_astar_manhattan_heuristic() {
             heuristic_for(end),
         );
         assert_eq!(dijkstra_run.get(&end).cloned(), astar_path.map(|t| t.0));
+    }
+}
+
+#[test]
+fn test_astar_instance_manhattan_heuristic() {
+    let mut g = Graph::new();
+    let a = g.add_node((0., 0.));
+    let b = g.add_node((2., 0.));
+    let c = g.add_node((1., 1.));
+    let d = g.add_node((0., 2.));
+    let e = g.add_node((3., 3.));
+    let f = g.add_node((4., 2.));
+    let _ = g.add_node((5., 5.)); // no path to node
+    g.add_edge(a, b, 2.);
+    g.add_edge(a, d, 4.);
+    g.add_edge(b, c, 1.);
+    g.add_edge(b, f, 7.);
+    g.add_edge(c, e, 5.);
+    g.add_edge(e, f, 1.);
+    g.add_edge(d, e, 1.);
+
+    let heuristic_for = |f: NodeIndex| {
+        let g = &g;
+        move |node: NodeIndex| -> f32 {
+            let (x1, y1): (f32, f32) = g[node];
+            let (x2, y2): (f32, f32) = g[f];
+
+            (x2 - x1).abs() + (y2 - y1).abs()
+        }
+    };
+
+    let mut instance = AstarInstance::new(&g, |n| n == f, |e| *e.weight(), heuristic_for(f));
+
+    for start in g.node_indices() {
+        let instance_path = instance.run(start);
+        let path = astar(
+            &g,
+            start,
+            |finish| finish == f,
+            |e| *e.weight(),
+            heuristic_for(f),
+        );
+        assert_eq!(instance_path, path);
     }
 }
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -22,8 +22,9 @@ use itertools::cloned;
 use rand::Rng;
 
 use petgraph::algo::{
-    bellman_ford, condensation, dijkstra, is_cyclic_directed, is_cyclic_undirected, is_isomorphic,
-    is_isomorphic_matching, kosaraju_scc, min_spanning_tree, tarjan_scc, toposort,
+    astar, bellman_ford, condensation, dijkstra, is_cyclic_directed, is_cyclic_undirected,
+    is_isomorphic, is_isomorphic_matching, kosaraju_scc, min_spanning_tree, tarjan_scc, toposort,
+    AstarInstance,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -962,6 +963,17 @@ quickcheck! {
         }
         for i in edges {
             assert!(gr2.edge_weight(edge_index(i)).is_none());
+        }
+    }
+}
+
+quickcheck! {
+    fn astar_instance_equivalence(graph: Graph<u32, u32>, node: u32) -> () {
+        let mut instance = AstarInstance::new(&graph, |f| f == node.into(), |e| *e.weight(), |_| 0);
+        for start in graph.node_indices() {
+            let path = astar(&graph, start, |f| f == node.into(), |e| *e.weight(), |_| 0);
+            let instance_path = instance.run(start);
+            assert_eq!(path, instance_path);
         }
     }
 }


### PR DESCRIPTION
This is a simple extension of the already existing A*-implementation.

I've tried to keep it simple, more optimisation and caching could be done for certain scenarios but that would come with tradeoffs (e.g. caching results for calls to `run`, using actual shortest path lengths from previous calls as "estimates", ...); I'd be happy to implement them though, just let me know.

The time complexity does not change, at all (unless `estimate_cost` has a bigger complexity than `astar`). Optimisation is achieved by reducing calls to `estimate_cost`. If `estimate_cost` is very inexpensive (e.g. `|_| 0`) this might even result in a significant performance penalty.

The space complexity has technically not changed either. 