### PR TITLE
add dependency list for feature 'quickcheck'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ jobs:
       - ALL=' '
     - rust: stable
       env:
-        - FEATURES='unstable quickcheck'
+        - FEATURES='unstable apply_quickcheck'
         - CHECKFMT=1
     - rust: beta
     - rust: nightly
     - rust: nightly
       env:
-       - FEATURES='unstable quickcheck'
+       - FEATURES='unstable apply_quickcheck'
        - BENCH=1
 branches:
   only:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,13 +46,14 @@ graphmap = []
 serde-1 = ["serde", "serde_derive"]
 stable_graph = []
 matrix_graph = []
+apply_quickcheck = ["quickcheck", "stable_graph", "graphmap"]
 
 # For unstable features
 generate = []
 unstable = ["generate"]
 
 # feature flags for testing use only
-all = ["unstable", "quickcheck", "matrix_graph", "stable_graph", "graphmap"]
+all = ["unstable", "apply_quickcheck", "matrix_graph", "stable_graph", "graphmap"]
 
 [workspace]
 members = ["serialization-tests"]

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/bluss/petgraph"
 
 
 [dependencies]
-petgraph = { path = "..", features = ["serde-1", "quickcheck"] }
+petgraph = { path = "..", features = ["serde-1", "apply_quickcheck"] }
 itertools = { version = "0.6.2" }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ mod iter_utils;
 mod k_shortest_path;
 #[cfg(feature = "matrix_graph")]
 pub mod matrix_graph;
-#[cfg(feature = "quickcheck")]
+#[cfg(feature = "apply_quickcheck")]
 mod quickcheck;
 #[cfg(feature = "serde-1")]
 mod serde_utils;

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "quickcheck")]
+#![cfg(feature = "apply_quickcheck")]
 #[macro_use]
 extern crate quickcheck;
 extern crate petgraph;


### PR DESCRIPTION
Hello :crab: , this PR attempts to fix issue #331 (resolves #331).

Currently running `cargo test --no-default-features --features 'quickcheck` fails with errors.
This PR makes the following changes to solve the issue.
* add a dependency list for feature `quickcheck`
* rename feature `quickcheck` to `apply_quickcheck`
  The reason for this changes is that the project currently has a name conflict between the feature `quickcheck` and the dependency library name `quickcheck`. Feature `quickcheck` isn't defined in `Cargo.toml`, but is used for a feature gate in `src/lib.rs`. I had to resolve the name conflict to enable adding a dependency list for feature `quickcheck`.

Thank you for reviewing this PR :+1: 