### PR TITLE
Re-visit nodes in A* (fix for #378)

### DIFF
--- a/src/astar.rs
+++ b/src/astar.rs
@@ -3,7 +3,7 @@ use std::collections::{BinaryHeap, HashMap};
 
 use std::hash::Hash;
 
-use super::visit::{EdgeRef, GraphBase, IntoEdges};
+use super::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 use crate::scored::MinScored;
 
 use crate::algo::Measure;
@@ -71,7 +71,7 @@ pub fn astar<G, F, H, K, IsGoal>(
     mut estimate_cost: H,
 ) -> Option<(K, Vec<G::NodeId>)>
 where
-    G: IntoEdges,
+    G: IntoEdges + Visitable,
     IsGoal: FnMut(G::NodeId) -> bool,
     G::NodeId: Eq + Hash,
     F: FnMut(G::EdgeRef) -> K,

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -574,6 +574,30 @@ fn test_astar_manhattan_heuristic() {
     }
 }
 
+#[test]
+fn test_astar_admissible_inconsistent() {
+    let mut g = Graph::new();
+    let a = g.add_node("A");
+    let b = g.add_node("B");
+    let c = g.add_node("C");
+    let d = g.add_node("D");
+    g.add_edge(a, b, 3);
+    g.add_edge(b, c, 3);
+    g.add_edge(c, d, 3);
+    g.add_edge(a, c, 8);
+    g.add_edge(a, d, 10);
+
+    let admissible_inconsistent = |n: NodeIndex| match g[n] {
+        "A" => 9,
+        "B" => 6,
+        "C" => 0,
+        &_ => 0,
+    };
+
+    let optimal = astar(&g, a, |n| n == d, |e| *e.weight(), admissible_inconsistent);
+    assert_eq!(optimal, Some((9, vec![a, b, c, d])));
+}
+
 #[cfg(feature = "generate")]
 #[test]
 fn test_generate_undirected() {

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -575,6 +575,35 @@ fn test_astar_manhattan_heuristic() {
 }
 
 #[test]
+fn test_astar_runtime_optimal() {
+    let mut g = Graph::new();
+    let a = g.add_node("A");
+    let b = g.add_node("B");
+    let c = g.add_node("C");
+    let d = g.add_node("D");
+    let e = g.add_node("E");
+    g.add_edge(a, b, 2);
+    g.add_edge(a, c, 3);
+    g.add_edge(b, d, 3);
+    g.add_edge(c, d, 1);
+    g.add_edge(d, e, 1);
+
+    let mut times_called = 0;
+
+    let _ = astar(&g, a, |n| n == e, |edge| {
+        times_called += 1;
+        *edge.weight()
+    }, |_| 0);
+
+    // A* is runtime optimal in the sense it won't expand more nodes than needed, for the given
+    // heuristic. Here, A* should expand, in order: A, B, C, D, E. This should should ask for the
+    // costs of edges (A, B), (A, C), (B, D), (C, D), (D, E). Node D will be added to `visit_next`
+    // twice, but should only be expanded once. If it is erroneously expanded twice, it will call
+    // for (D, E) again and `times_called` will be 6.
+    assert_eq!(times_called, 5);
+}
+
+#[test]
 fn test_astar_admissible_inconsistent() {
     let mut g = Graph::new();
     let a = g.add_node("A");


### PR DESCRIPTION
You can see more details in #378 

This PR forces A* to re-visit nodes if they are reached through a shorter path than before. This ensures that the algorithm can find optimal paths when using an inconsistent (but admissible) heuristic.