### PR TITLE
Add a few more`fn size_hint` method overrides

### DIFF
--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -139,6 +139,10 @@ where
         }
         None
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 /// The undefined dominator sentinel, for when we have not yet discovered a

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -474,6 +474,9 @@ where
             }
         })
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<N, E, Ty, Ix> Data for Csr<N, E, Ty, Ix>

--- a/src/data.rs
+++ b/src/data.rs
@@ -472,4 +472,8 @@ where
             return Some(elt);
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1464,6 +1464,10 @@ where
             }
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 /// Iterator over the neighbors of a node.
@@ -1709,6 +1713,10 @@ where
         }
 
         None
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.edges.size_hint();
+        (0, upper)
     }
 }
 

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -1558,6 +1558,10 @@ where
             }
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 /// Iterator over the neighbors of a node.
@@ -1712,10 +1716,9 @@ impl<'a, N, Ix: IndexType> Iterator for NodeIndices<'a, N, Ix> {
             }
         })
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (_, hi) = self.iter.size_hint();
-        (0, hi)
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
     }
 }
 
@@ -1786,10 +1789,9 @@ impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
             }
         })
     }
-
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (_, hi) = self.iter.size_hint();
-        (0, hi)
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
     }
 }
 

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -511,6 +511,14 @@ where
             self.iter.next().map(|&(n, _)| n)
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.iter.size_hint();
+        if Ty::is_directed() {
+            (0, upper)
+        } else {
+            (lower, upper)
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -548,6 +556,14 @@ where
             self.iter.next().map(|&(n, _)| n)
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.iter.size_hint();
+        if Ty::is_directed() {
+            (0, upper)
+        } else {
+            (lower, upper)
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -576,6 +592,9 @@ where
                 Some(edge) => (a, b, edge),
             }
         })
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 
@@ -858,6 +877,9 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(&n, _)| n)
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, N, E, Ty> IntoNodeReferences for &'a GraphMap<N, E, Ty>
@@ -895,6 +917,9 @@ where
     type Item = (N, &'a N);
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(n, _)| (*n, n))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -565,6 +565,9 @@ impl<'a, Ix: IndexType> Iterator for NodeIdentifiers<'a, Ix> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(NodeIndex::new)
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 /// Iterator over all nodes of a graph.
@@ -597,6 +600,9 @@ impl<'a, N: 'a, Ix: IndexType> Iterator for NodeReferences<'a, N, Ix> {
         self.iter
             .next()
             .map(|i| (NodeIndex::new(i), &self.nodes[i]))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 
@@ -680,6 +686,9 @@ impl<'a, Ty: EdgeType, Null: Nullable, Ix: IndexType> Iterator for Neighbors<'a,
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(_, b, _)| b)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 

--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -128,6 +128,10 @@ where
             self.iter.find(move |&target| f.include_node(target))
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 impl<'a, G, F> IntoNeighborsDirected for &'a NodeFiltered<G, F>
@@ -199,6 +203,10 @@ where
             self.iter.find(move |&target| f.include_node(target.id()))
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 impl<'a, G, F> IntoEdgeReferences for &'a NodeFiltered<G, F>
@@ -236,6 +244,10 @@ where
         let f = self.f;
         self.iter
             .find(move |&edge| f.include_node(edge.source()) && f.include_node(edge.target()))
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
     }
 }
 
@@ -294,6 +306,10 @@ where
             let f = self.f;
             self.iter.find(move |&edge| f.include_node(edge.target()))
         }
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
     }
 }
 
@@ -428,6 +444,10 @@ where
             })
             .next()
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 impl<'a, G, F> IntoEdgeReferences for &'a EdgeFiltered<G, F>
@@ -496,6 +516,10 @@ where
         let f = self.f;
         self.iter.find(move |&edge| f.include_edge(edge))
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
+    }
 }
 
 /// A filtered neighbors-directed iterator.
@@ -531,6 +555,10 @@ where
                 }
             })
             .next()
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper)
     }
 }
 

--- a/src/visit/reversed.rs
+++ b/src/visit/reversed.rs
@@ -90,6 +90,9 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(ReversedEdgeReference)
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 /// A reversed edge reference
@@ -157,6 +160,9 @@ where
     type Item = ReversedEdgeReference<I::Item>;
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(ReversedEdgeReference)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 


### PR DESCRIPTION
The default implementation of `fn size_hint` returns `(0, None)` which is correct for any iterator, but might prohibit certain optimizations (such as for pre-allocating a collecting buffer).

While some of the Iterator implementations already provided an implementation of `fn size_hint`, others don't yet, but could.

There are basically two possible straight-forward implementations for wrapping iterators to pick from:

Non-filtering iterators:
```rust
fn size_hint(&self) -> (usize, Option<usize>) {
    self.iter.size_hint()
}
```

Filtering iterators:
```rust
fn size_hint(&self) -> (usize, Option<usize>) {
    let (_, upper) = self.iter.size_hint();
    (0, upper)
}
```