### PR TITLE
Use `map()`, rather than match on `Option<T>`

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -565,16 +565,13 @@ where
 {
     type Item = (N, N, &'a E);
     fn next(&mut self) -> Option<Self::Item> {
-        match self.iter.next() {
-            None => None,
-            Some(b) => {
-                let a = self.from;
-                match self.edges.get(&GraphMap::<N, E, Ty>::edge_key(a, b)) {
-                    None => unreachable!(),
-                    Some(edge) => Some((a, b, edge)),
-                }
+        self.iter.next().map(|b| {
+            let a = self.from;
+            match self.edges.get(&GraphMap::<N, E, Ty>::edge_key(a, b)) {
+                None => unreachable!(),
+                Some(edge) => (a, b, edge),
             }
-        }
+        })
     }
 }
 
@@ -606,10 +603,7 @@ where
 {
     type Item = (N, N, &'a E);
     fn next(&mut self) -> Option<Self::Item> {
-        match self.inner.next() {
-            None => None,
-            Some((&(a, b), v)) => Some((a, b, v)),
-        }
+        self.inner.next().map(|(&(a, b), v)| (a, b, v))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
While looking for missing impls of `fn size_hint` I found these two methods, which match on a optional with the `None`-arm simply forwarding via `None => None`, which can be expressed more idiomatically using a simple `.map(|e| … )`.