### PR TITLE
Implement floyd warshall

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -27,6 +27,7 @@ use crate::visit::{Data, IntoNodeReferences, NodeRef};
 
 pub use super::astar::astar;
 pub use super::dijkstra::dijkstra;
+pub use super::floyd_warshall::floyd_warshall;
 pub use super::k_shortest_path::k_shortest_path;
 
 pub use super::isomorphism::{
@@ -903,20 +904,56 @@ pub trait FloatMeasure: Measure + Copy {
     fn infinite() -> Self;
 }
 
-impl FloatMeasure for f32 {
-    fn zero() -> Self {
-        0.
-    }
-    fn infinite() -> Self {
-        1. / 0.
-    }
+/// A measure with bounds, i.e. a zero and an infinity.
+///
+/// This is effectivly a rename for `FloatMeasure` for types that are not
+/// floats, but require the same traits.
+pub trait BoundedMeasure: FloatMeasure {}
+
+impl<T: FloatMeasure> BoundedMeasure for T {}
+
+/// Implements `BoundMeasure(FloatMeasure)` for `$type` using the builtin `MIN` and `MAX`
+/// associated values.
+macro_rules! impl_bounded_measure {
+    ($type:ident) => {
+        impl FloatMeasure for $type {
+            fn zero() -> $type {
+                0
+            }
+            fn infinite() -> $type {
+                std::$type::MAX
+            }
+        }
+    };
 }
 
-impl FloatMeasure for f64 {
-    fn zero() -> Self {
-        0.
-    }
-    fn infinite() -> Self {
-        1. / 0.
-    }
+/// Implements `FloatMeasure` for `$type` using zero and `1./0.`.
+macro_rules! impl_float_measure {
+    ($type:ident) => {
+        impl FloatMeasure for $type {
+            fn zero() -> $type {
+                0.
+            }
+            fn infinite() -> $type {
+                1. / 0.
+            }
+        }
+    };
 }
+
+impl_float_measure!(f32);
+impl_float_measure!(f64);
+
+impl_bounded_measure!(u8);
+impl_bounded_measure!(u16);
+impl_bounded_measure!(u32);
+impl_bounded_measure!(u64);
+impl_bounded_measure!(u128);
+impl_bounded_measure!(usize);
+
+impl_bounded_measure!(i8);
+impl_bounded_measure!(i16);
+impl_bounded_measure!(i32);
+impl_bounded_measure!(i64);
+impl_bounded_measure!(i128);
+impl_bounded_measure!(isize);

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -719,7 +719,7 @@ impl<N> Cycle<N> {
 }
 /// An algorithm error: a cycle of negative weights was found in the graph.
 #[derive(Clone, Debug, PartialEq)]
-pub struct NegativeCycle(());
+pub struct NegativeCycle(pub(crate) ());
 
 /// \[Generic\] Compute shortest paths from node `source` to all other.
 ///

--- a/src/floyd_warshall.rs
+++ b/src/floyd_warshall.rs
@@ -1,0 +1,178 @@
+use super::algo::{BoundedMeasure, FloatMeasure};
+use super::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable};
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// Calculates the distance between any two nodes in the graph using the
+/// \[Generic\] The Floyd-Warshall shortest paths algorithm. Calculates the
+/// shortest path between each node in the graph.
+///
+/// Returns a PathCostMatrix that maps `(NodeId, NodeId)` to the cost of
+/// traveling from the first node to the second.
+///
+/// # Example
+/// ```rust
+/// use petgraph::{Graph, algo::floyd_warshall};
+///
+/// let mut graph = Graph::new();
+/// let a = graph.add_node(()); // node with no weight
+/// let b = graph.add_node(());
+/// let c = graph.add_node(());
+/// let d = graph.add_node(());
+/// let e = graph.add_node(());
+/// let f = graph.add_node(());
+/// let g = graph.add_node(());
+/// let h = graph.add_node(());
+/// // z will be in another connected component
+/// let z = graph.add_node(());
+///
+/// graph.extend_with_edges(&[
+///     (a, b, 3),
+///     (b, c, 5),
+///     (c, d, 2),
+///     (d, a, 9),
+///     (e, f, 1),
+///     (b, e, -2),
+///     (f, g, 8),
+///     (g, h, -1),
+///     (h, e, 0),
+/// ]);
+/// // a -----> b ----> e ------> f
+/// // ^       |       ^       |
+/// // |       v       |       v
+/// // d <----- c       h <---- g
+///
+/// let costs = floyd_warshall(&graph);
+/// assert_eq!(costs[(c,h)], 20);
+/// assert_eq!(costs[(b,b)], 0);
+/// assert_eq!(costs[(e,h)], 8);
+///
+/// // There is no valid path from e to b.
+/// assert_eq!(costs[(e,b)], i32::MAX);
+/// ```
+pub fn floyd_warshall<G>(graph: G) -> PathCostMatrix<G>
+where
+    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
+    G::EdgeWeight: BoundedMeasure + std::fmt::Debug,
+{
+    let mut dist: PathCostMatrix<G> = PathCostMatrix::new(graph);
+    for edge in graph.node_identifiers().flat_map(|i| graph.edges(i)) {
+        dist[(edge.source(), edge.target())] = *edge.weight();
+    }
+    for vertex in graph.node_identifiers() {
+        dist[(vertex, vertex)] = G::EdgeWeight::zero();
+    }
+    for k in graph.node_identifiers() {
+        for i in graph.node_identifiers() {
+            for j in graph.node_identifiers() {
+                // Overflow guard.
+                if dist[(i, k)] != G::EdgeWeight::infinite()
+                    && dist[(k, j)] != G::EdgeWeight::infinite()
+                {
+                    if dist[(i, j)] > dist[(i, k)] + dist[(k, j)] {
+                        dist[(i, j)] = dist[(i, k)] + dist[(k, j)]
+                    }
+                }
+            }
+        }
+    }
+    dist
+}
+
+/// Made to be used with with `floyd_warshall` algorithm. the cost of going from
+/// each node to each other node.
+///
+/// ```rust
+/// # use petgraph::{algo::floyd_warshall, Graph};
+/// # use std::collections::HashMap;
+/// # let mut get_graph = Graph::new();
+/// # let node1 = get_graph.add_node(1);
+/// # let node2 = get_graph.add_node(2);
+/// # get_graph.extend_with_edges(&[(node1, node2, 1)]);
+/// let g = get_graph;
+/// let cost_matrix = floyd_warshall(&g);
+///
+/// assert_eq!(cost_matrix[(node1, node2)], 1);
+///
+/// // Or equivalently
+///
+/// let map: HashMap<_,_> = cost_matrix.into_hashmap();
+/// assert_eq!(map.get(&(node1, node2)), Some(&1));
+/// ```
+pub struct PathCostMatrix<G>
+where
+    G: NodeIndexable + NodeCount + IntoNodeIdentifiers + IntoEdges,
+    G::EdgeWeight: Clone,
+{
+    graph: G,
+    weights: Vec<G::EdgeWeight>, // Single vector improves cache locality and prevents unnecessary allocations.
+}
+
+impl<G> PathCostMatrix<G>
+where
+    G: NodeIndexable + NodeCount + IntoNodeIdentifiers + IntoEdges,
+    G::EdgeWeight: Clone + BoundedMeasure,
+{
+    /// Generates `PathWeightMatrix` from a graph. The matrix is initialized,
+    /// setting all weights to infinity.
+    pub(crate) fn new(graph: G) -> Self {
+        let weights = vec![G::EdgeWeight::infinite(); graph.node_bound().pow(2)];
+        PathCostMatrix { graph, weights }
+    }
+}
+impl<G> PathCostMatrix<G>
+where
+    G: NodeIndexable + NodeCount + IntoNodeIdentifiers + IntoEdges,
+    G::EdgeWeight: Clone + BoundedMeasure,
+    G::NodeId: Eq + Hash,
+{
+    /// Converts a `PathWeightMatrix` into a hashmap where the keys are index
+    /// pairs and values are thier associated trevel costs.
+    pub fn into_hashmap(self) -> HashMap<(G::NodeId, G::NodeId), G::EdgeWeight> {
+        self.graph
+            .node_identifiers()
+            .flat_map(|i1| self.graph.node_identifiers().map(move |i2| (i1, i2)))
+            .map(|pair| (pair, self[pair]))
+            .collect()
+    }
+}
+
+impl<G> std::ops::Index<(G::NodeId, G::NodeId)> for PathCostMatrix<G>
+where
+    G: NodeIndexable + NodeCount + IntoNodeIdentifiers + IntoEdges,
+    G::EdgeWeight: Clone,
+{
+    type Output = G::EdgeWeight;
+    fn index(&self, index: (G::NodeId, G::NodeId)) -> &Self::Output {
+        let index_0 = self.graph.to_index(index.0);
+        let index_1 = self.graph.to_index(index.1);
+        self.weights
+            .index(index_0 * self.graph.node_bound() + index_1)
+    }
+}
+
+impl<G> std::ops::IndexMut<(G::NodeId, G::NodeId)> for PathCostMatrix<G>
+where
+    G: NodeIndexable + NodeCount + IntoNodeIdentifiers + IntoEdges,
+    G::EdgeWeight: Clone,
+{
+    fn index_mut(&mut self, index: (G::NodeId, G::NodeId)) -> &mut Self::Output {
+        let index_0 = self.graph.to_index(index.0);
+        let index_1 = self.graph.to_index(index.1);
+        self.weights
+            .index_mut(index_0 * self.graph.node_bound() + index_1)
+    }
+}
+
+impl<G> Clone for PathCostMatrix<G>
+where
+    G::EdgeWeight: Clone,
+    G: Clone + IntoNodeIdentifiers + NodeIndexable + NodeCount + IntoEdges,
+{
+    fn clone(&self) -> Self {
+        Self {
+            graph: self.graph.clone(),
+            weights: self.weights.clone(),
+        }
+    }
+}

--- a/src/floyd_warshall.rs
+++ b/src/floyd_warshall.rs
@@ -5,7 +5,11 @@ use std::hash::Hash;
 
 /// Calculates the distance between any two nodes in the graph using the
 /// \[Generic\] The Floyd-Warshall shortest paths algorithm. Calculates the
-/// shortest path between each node in the graph.
+/// shortest path between each node in the graph in `O(V^3)` time, where `V` is
+/// the number of nodes in the graph. Floyd-Warshall takes up `O(V^2)` space.
+///
+/// Details can be found on
+/// [Wikipedia](https://en.wikipedia.org/wiki/Floyd–Warshall_algorithm).
 ///
 /// Returns a PathCostMatrix that maps `(NodeId, NodeId)` to the cost of
 /// traveling from the first node to the second.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ mod astar;
 pub mod csr;
 mod dijkstra;
 pub mod dot;
+mod floyd_warshall;
 #[cfg(feature = "generate")]
 pub mod generate;
 mod graph_impl;

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -9,7 +9,7 @@ use petgraph::EdgeType;
 use petgraph as pg;
 
 use petgraph::algo::{
-    dominators, has_path_connecting, is_bipartite_undirected, is_cyclic_undirected,
+    dominators, floyd_warshall, has_path_connecting, is_bipartite_undirected, is_cyclic_undirected,
     is_isomorphic_matching, min_spanning_tree,
 };
 
@@ -490,6 +490,55 @@ fn dijk() {
 
     let scores = dijkstra(&g, a, Some(c), |e| *e.weight());
     assert_eq!(scores[&c], 9);
+}
+
+#[test]
+fn flyd_wrshll() {
+    let mut g: Graph<(), f32, Directed> = Graph::new();
+    let a = g.add_node(());
+    let b = g.add_node(());
+    let c = g.add_node(());
+    let d = g.add_node(());
+    g.extend_with_edges(&[
+        (a, b, 3.0),
+        (b, a, 2.0),
+        (a, d, 5.0),
+        (d, c, 2.0),
+        (c, b, 1.0),
+        (b, d, 4.0),
+    ]);
+    let res = floyd_warshall(&g);
+    assert_eq!(res[(a, a)], 0.0);
+    assert_eq!(res[(a, b)], 3.0);
+    assert_eq!(res[(a, c)], 7.0);
+    assert_eq!(res[(a, d)], 5.0);
+
+    assert_eq!(res[(b, a)], 2.0);
+    assert_eq!(res[(b, b)], 0.0);
+    assert_eq!(res[(b, c)], 6.0);
+    assert_eq!(res[(b, d)], 4.0);
+
+    assert_eq!(res[(c, a)], 3.0);
+    assert_eq!(res[(c, b)], 1.0);
+    assert_eq!(res[(c, c)], 0.0);
+    assert_eq!(res[(c, d)], 5.0);
+
+    assert_eq!(res[(d, a)], 5.0);
+    assert_eq!(res[(d, b)], 3.0);
+    assert_eq!(res[(d, c)], 2.0);
+    assert_eq!(res[(d, d)], 0.0);
+}
+
+#[test]
+fn flyd_small_directed() {
+    let mut get_graph = Graph::new();
+    let node1 = get_graph.add_node(1);
+    let node2 = get_graph.add_node(2);
+    get_graph.extend_with_edges(&[(node1, node2, 1)]);
+    let g = get_graph;
+    let cost_matrix = floyd_warshall(&g);
+
+    assert_eq!(cost_matrix[(node1, node2)], 1);
 }
 
 #[test]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -507,7 +507,7 @@ fn flyd_wrshll() {
         (c, b, 1.0),
         (b, d, 4.0),
     ]);
-    let res = floyd_warshall(&g);
+    let res = floyd_warshall(&g).unwrap(); // for negative cycles
     assert_eq!(res[(a, a)], 0.0);
     assert_eq!(res[(a, b)], 3.0);
     assert_eq!(res[(a, c)], 7.0);
@@ -536,7 +536,8 @@ fn flyd_small_directed() {
     let node2 = get_graph.add_node(2);
     get_graph.extend_with_edges(&[(node1, node2, 1)]);
     let g = get_graph;
-    let cost_matrix = floyd_warshall(&g);
+    // For negative cycles
+    let cost_matrix = floyd_warshall(&g).unwrap();
 
     assert_eq!(cost_matrix[(node1, node2)], 1);
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -22,8 +22,9 @@ use itertools::cloned;
 use rand::Rng;
 
 use petgraph::algo::{
-    bellman_ford, condensation, dijkstra, is_cyclic_directed, is_cyclic_undirected, is_isomorphic,
-    is_isomorphic_matching, k_shortest_path, kosaraju_scc, min_spanning_tree, tarjan_scc, toposort,
+    bellman_ford, condensation, dijkstra, floyd_warshall, is_cyclic_directed, is_cyclic_undirected,
+    is_isomorphic, is_isomorphic_matching, k_shortest_path, kosaraju_scc, min_spanning_tree,
+    tarjan_scc, toposort,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -748,6 +749,24 @@ quickcheck! {
                 if distances.contains_key(&u) && distances[&u] > dv2 + w {
                     return false;
                 }
+            }
+        }
+        true
+    }
+}
+
+quickcheck! {
+    // checks that Floyd-Warshall
+    fn floyd_warshall_agree_dijkstra(g: Graph<u32, u32>, node: usize) -> bool {
+        if g.node_count() == 0 {
+            return true;
+        }
+        let v = node_index(node % g.node_count());
+        let distances = dijkstra(&g, v, None, |e| *e.weight());
+        let cost_matrix = floyd_warshall(&g);
+        for (v2, cost) in distances.into_iter() {
+            if cost != cost_matrix[(v, v2)] {
+                return false;
             }
         }
         true

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -763,7 +763,7 @@ quickcheck! {
         }
         let v = node_index(node % g.node_count());
         let distances = dijkstra(&g, v, None, |e| *e.weight());
-        let cost_matrix = floyd_warshall(&g);
+        let cost_matrix = floyd_warshall(&g).unwrap();
         for (v2, cost) in distances.into_iter() {
             if cost != cost_matrix[(v, v2)] {
                 return false;


### PR DESCRIPTION
This PR implements the Floyd-Warshall algorithm for a generic graph. It imposes less restrictions than https://github.com/petgraph/petgraph/pull/377, which requires `NodeId`s  to implement `Eq + Hash`. This is accomplished by keeping the results in a matrix (`Vec`). This result can then be converted into a `HashMap` as needed. 


PS: I saw https://github.com/petgraph/petgraph/pull/377 after I wrote most of this. It also looks like a good implementation. Merging either would make me happy. 