### PR TITLE
Improve StableGraph de-serialization with holes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = "0.5.5"
 odds = { version = "0.2.19" }
 defmac = "0.1"
 itertools = { version = "0.8", default-features = false }
-bincode = "*"
+bincode = "1.3.3"
 
 [features]
 default = ["graphmap", "stable_graph", "matrix_graph"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rand = "0.5.5"
 odds = { version = "0.2.19" }
 defmac = "0.1"
 itertools = { version = "0.8", default-features = false }
+bincode = "*"
 
 [features]
 default = ["graphmap", "stable_graph", "matrix_graph"]

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -3,9 +3,9 @@
 extern crate petgraph;
 extern crate test;
 
-use test::Bencher;
 use petgraph::prelude::*;
-use rand::{Rng};
+use rand::Rng;
+use test::Bencher;
 
 const NUM_NODES: usize = 1_000_000;
 const NUM_EDGES: usize = 100_000;
@@ -33,13 +33,10 @@ fn make_stable_graph() -> StableGraph<u32, u32> {
     g
 }
 
-
 #[bench]
 fn serialize_bench(bench: &mut Bencher) {
     let graph = make_stable_graph();
-    bench.iter(|| {
-        bincode::serialize(&graph).unwrap()
-    });
+    bench.iter(|| bincode::serialize(&graph).unwrap());
 }
 
 #[bench]

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -13,10 +13,12 @@ const NUM_HOLES: usize = 1_000_000;
 
 fn make_stable_graph() -> StableGraph<u32, u32> {
     let mut g = StableGraph::with_capacity(NUM_NODES + NUM_HOLES, NUM_EDGES);
-    let indices: Vec<_> = (0 .. NUM_NODES + NUM_HOLES).map(|i| g.add_node(i as u32)).collect();
+    let indices: Vec<_> = (0..NUM_NODES + NUM_HOLES)
+        .map(|i| g.add_node(i as u32))
+        .collect();
 
     let mut rng = rand::thread_rng();
-    g.extend_with_edges((0 .. NUM_EDGES).map(|_| {
+    g.extend_with_edges((0..NUM_EDGES).map(|_| {
         let first = rng.gen_range(0, NUM_NODES + NUM_HOLES);
         let second = rng.gen_range(0, NUM_NODES + NUM_HOLES - 1);
         let second = second + (second >= first) as usize;

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -1,0 +1,40 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use test::Bencher;
+use petgraph::prelude::*;
+
+fn make_stable_graph() -> StableGraph<usize, usize> {
+    let mut g = StableGraph::default();
+    let indices: Vec<_> = (0 .. 10000).map(|i| g.add_node(i)).collect();
+    for i in 0 .. 1000 {
+        g.extend_with_edges((1 .. 1000).map(|j| (indices[j], indices[(j + i) % 10000], i)));
+    }
+
+    // Remove nodes to make the structure a bit more interesting
+    for i in (0 .. 10000).step_by(2) {
+        g.remove_node(indices[i]);
+    }
+    g
+}
+
+
+#[bench]
+fn serialize_bench(bench: &mut Bencher) {
+    let graph = make_stable_graph();
+    bench.iter(|| {
+        bincode::serialize(&graph).unwrap()
+    });
+}
+
+#[bench]
+fn deserialize_bench(bench: &mut Bencher) {
+    let graph = make_stable_graph();
+    let data = bincode::serialize(&graph).unwrap();
+    bench.iter(|| {
+        let graph2: StableGraph<usize, usize> = bincode::deserialize(&data).unwrap();
+        graph2
+    });
+}

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -34,13 +34,13 @@ fn make_stable_graph() -> StableGraph<u32, u32> {
 }
 
 #[bench]
-fn serialize_bench(bench: &mut Bencher) {
+fn serialize_stable_graph(bench: &mut Bencher) {
     let graph = make_stable_graph();
     bench.iter(|| bincode::serialize(&graph).unwrap());
 }
 
 #[bench]
-fn deserialize_bench(bench: &mut Bencher) {
+fn deserialize_stable_graph(bench: &mut Bencher) {
     let graph = make_stable_graph();
     let data = bincode::serialize(&graph).unwrap();
     bench.iter(|| {

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -5,18 +5,31 @@ extern crate test;
 
 use test::Bencher;
 use petgraph::prelude::*;
+use rand::{Rng};
 
-fn make_stable_graph() -> StableGraph<usize, usize> {
-    let mut g = StableGraph::default();
-    let indices: Vec<_> = (0 .. 10000).map(|i| g.add_node(i)).collect();
-    for i in 0 .. 1000 {
-        g.extend_with_edges((1 .. 1000).map(|j| (indices[j], indices[(j + i) % 10000], i)));
-    }
+const NUM_NODES: usize = 1_000_000;
+const NUM_EDGES: usize = 100_000;
+const NUM_HOLES: usize = 1_000_000;
+
+fn make_stable_graph() -> StableGraph<u32, u32> {
+    let mut g = StableGraph::with_capacity(NUM_NODES + NUM_HOLES, NUM_EDGES);
+    let indices: Vec<_> = (0 .. NUM_NODES + NUM_HOLES).map(|i| g.add_node(i as u32)).collect();
+
+    let mut rng = rand::thread_rng();
+    g.extend_with_edges((0 .. NUM_EDGES).map(|_| {
+        let first = rng.gen_range(0, NUM_NODES + NUM_HOLES);
+        let second = rng.gen_range(0, NUM_NODES + NUM_HOLES - 1);
+        let second = second + (second >= first) as usize;
+        let weight: u32 = rng.gen();
+        (indices[first], indices[second], weight)
+    }));
 
     // Remove nodes to make the structure a bit more interesting
-    for i in (0 .. 10000).step_by(2) {
-        g.remove_node(indices[i]);
+    while g.node_count() > NUM_NODES {
+        let idx = rng.gen_range(0, indices.len());
+        g.remove_node(indices[idx]);
     }
+
     g
 }
 
@@ -34,7 +47,7 @@ fn deserialize_bench(bench: &mut Bencher) {
     let graph = make_stable_graph();
     let data = bincode::serialize(&graph).unwrap();
     bench.iter(|| {
-        let graph2: StableGraph<usize, usize> = bincode::deserialize(&data).unwrap();
+        let graph2: StableGraph<u32, u32> = bincode::deserialize(&data).unwrap();
         graph2
     });
 }

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -148,12 +148,12 @@ where
     Ix: IndexType,
 {
     let mut g = StableGraph::default();
-    let indices: Vec<_> = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
-    for i in 1 .. 256 {
-        g.extend_with_edges((0 .. 1024).map(|j| (indices[j], indices[(j + i) % 1024], i as i32)));
+    let indices: Vec<_> = (0..1024).map(|i| g.add_node(format!("{}", i))).collect();
+    for i in 1..256 {
+        g.extend_with_edges((0..1024).map(|j| (indices[j], indices[(j + i) % 1024], i as i32)));
     }
     // Remove nodes to make the structure a bit more interesting
-    for i in (0 .. 1024).step_by(10) {
+    for i in (0..1024).step_by(10) {
         g.remove_node(indices[i]);
     }
     g

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -150,9 +150,7 @@ where
     let mut g = StableGraph::default();
     let indices = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
     for i in 1 .. 256 {
-        for j in 0 .. 1024 {
-            g.extend_with_edge(indices[j], indices[(j + i) % 1024], i);
-        }
+        g.extend_with_edge((0 .. 1024).map(|j| (indices[j], indices[(j + i) % 1024], i)));
     }
     // Remove nodes to make the structure a bit more interesting
     for i in (0 .. 1024).step_by(10) {

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -142,31 +142,22 @@ where
     g
 }
 
-fn make_stable_graph<Ty, Ix>() -> StableGraph<&'static str, i32, Ty, Ix>
+fn make_stable_graph<Ty, Ix>() -> StableGraph<String, i32, Ty, Ix>
 where
     Ty: EdgeType,
     Ix: IndexType,
 {
     let mut g = StableGraph::default();
-    let a = g.add_node("A");
-    let b = g.add_node("B");
-    let c = g.add_node("C");
-    let d = g.add_node("D");
-    let e = g.add_node("E");
-    let f = g.add_node("F");
-    g.extend_with_edges(&[
-        (a, b, 7),
-        (c, a, 9),
-        (a, d, 14),
-        (b, c, 10),
-        (d, c, 2),
-        (d, e, 9),
-        (b, f, 15),
-        (c, f, 11),
-        (e, f, 6),
-    ]);
-    // Remove a node to make the structure a bit more interesting
-    g.remove_node(d);
+    let indices = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
+    for i in 1 .. 256 {
+        for j in 0 .. 1024 {
+            g.extend_with_edge(indices[j], indices[(j + i) % 1024], i);
+        }
+    }
+    // Remove nodes to make the structure a bit more interesting
+    for i in (0 .. 1024).step_by(10) {
+        g.remove_node(indices[i]);
+    }
     g
 }
 

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -148,9 +148,9 @@ where
     Ix: IndexType,
 {
     let mut g = StableGraph::default();
-    let indices = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
+    let indices: Vec<_> = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
     for i in 1 .. 256 {
-        g.extend_with_edge((0 .. 1024).map(|j| (indices[j], indices[(j + i) % 1024], i)));
+        g.extend_with_edges((0 .. 1024).map(|j| (indices[j], indices[(j + i) % 1024], i as i32)));
     }
     // Remove nodes to make the structure a bit more interesting
     for i in (0 .. 1024).step_by(10) {

--- a/src/graph_impl/serialization.rs
+++ b/src/graph_impl/serialization.rs
@@ -282,6 +282,16 @@ where
     ))
 }
 
+pub fn invalid_hole_err<E>(node_index: usize) -> E
+where
+    E: Error,
+{
+    E::custom(format_args!(
+        "invalid value: node hole `{}` is not allowed.",
+        node_index
+    ))
+}
+
 pub fn invalid_length_err<Ix, E>(node_or_edge: &str, len: usize) -> E
 where
     E: Error,

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -222,27 +222,6 @@ where
         }
         nodes.extend(compact_nodes);
 
-        /*
-        // smart implementation using swap.
-        // is actually slower in the benchmark.
-        
-        let mut nodes = input.nodes;
-        nodes.extend(std::iter::repeat_with(|| Node {
-            weight: None,
-            next: [EdgeIndex::end(); 2],
-        }).take(node_holes.len()));
-
-        let mut node_pos = nodes.len();
-
-        for (hole_count, hole_pos) in node_holes.iter().enumerate().rev() {
-            node_pos -= 1;
-            while node_pos > hole_pos.index() {
-                nodes.swap(node_pos - hole_count - 1, node_pos);
-                node_pos -= 1;
-            }
-        }
-        */
-
         if nodes.len() >= <Ix as IndexType>::max().index() {
             Err(invalid_length_err::<Ix, _>("node", nodes.len()))?
         }

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -204,21 +204,26 @@ where
             Err(invalid_length_err::<Ix, _>("edge", edges.len()))?
         }
 
-        // insert Nones for each hole
+        // append Nones
+        nodes.extend(std::iter::from_fn(|| {
+            Node {
+                weight: None,
+                next: [EdgeIndex::end(); 2],
+            }
+        }).take(node_holes.len()));
+
+        // swap Nones for each hole
         let mut offset = node_holes.len();
         let node_bound = node_holes.len() + nodes.len();
-        for hole_pos in rev(node_holes) {
+        for (i, hole_pos) in rev(node_holes).enumerate() {
             offset -= 1;
             if hole_pos.index() >= node_bound {
                 Err(invalid_node_err(hole_pos.index(), node_bound))?;
             }
             let insert_pos = hole_pos.index() - offset;
-            nodes.insert(
+            nodes.swap(
                 insert_pos,
-                Node {
-                    weight: None,
-                    next: [EdgeIndex::end(); 2],
-                },
+                offset
             );
         }
 

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -217,6 +217,27 @@ where
         }
         nodes.extend(compact_nodes);
 
+        /*
+        // smart implementation using swap.
+        // is actually slower in the benchmark.
+        
+        let mut nodes = input.nodes;
+        nodes.extend(std::iter::repeat_with(|| Node {
+            weight: None,
+            next: [EdgeIndex::end(); 2],
+        }).take(node_holes.len()));
+
+        let mut node_pos = nodes.len();
+
+        for (hole_count, hole_pos) in node_holes.iter().enumerate().rev() {
+            node_pos -= 1;
+            while node_pos > hole_pos.index() {
+                nodes.swap(node_pos - hole_count - 1, node_pos);
+                node_pos -= 1;
+            }
+        }
+        */
+
         if nodes.len() >= <Ix as IndexType>::max().index() {
             Err(invalid_length_err::<Ix, _>("node", nodes.len()))?
         }

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -14,7 +14,9 @@ use crate::stable_graph::StableGraph;
 use crate::visit::{EdgeIndexable, NodeIndexable};
 use crate::EdgeType;
 
-use super::super::serialization::{invalid_length_err, invalid_node_err, invalid_hole_err, EdgeProperty};
+use super::super::serialization::{
+    invalid_hole_err, invalid_length_err, invalid_node_err, EdgeProperty,
+};
 
 // Serialization representation for StableGraph
 // Keep in sync with deserialization and Graph
@@ -201,7 +203,7 @@ where
         if edges.len() >= <Ix as IndexType>::max().index() {
             Err(invalid_length_err::<Ix, _>("edge", edges.len()))?
         }
-        
+
         let total_nodes = input.nodes.len() + node_holes.len();
         let mut nodes = Vec::with_capacity(total_nodes);
 
@@ -209,7 +211,7 @@ where
         let mut node_pos = 0;
         for hole_pos in node_holes.iter() {
             let hole_pos = hole_pos.index();
-            if !(node_pos .. total_nodes).contains(&hole_pos) {
+            if !(node_pos..total_nodes).contains(&hole_pos) {
                 return Err(invalid_hole_err(hole_pos));
             }
             nodes.extend(compact_nodes.by_ref().take(hole_pos - node_pos));

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -11,7 +11,6 @@ use crate::serde_utils::CollectSeqWithLength;
 use crate::serde_utils::MappedSequenceVisitor;
 use crate::serde_utils::{FromDeserialized, IntoSerializable};
 use crate::stable_graph::StableGraph;
-use crate::util::rev;
 use crate::visit::NodeIndexable;
 use crate::EdgeType;
 

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -14,7 +14,7 @@ use crate::stable_graph::StableGraph;
 use crate::visit::NodeIndexable;
 use crate::EdgeType;
 
-use super::super::serialization::{invalid_length_err, invalid_node_err, EdgeProperty};
+use super::super::serialization::{invalid_length_err, invalid_node_err, invalid_hole_err, EdgeProperty};
 
 // Serialization representation for StableGraph
 // Keep in sync with deserialization and Graph
@@ -202,17 +202,22 @@ where
             Err(invalid_length_err::<Ix, _>("edge", edges.len()))?
         }
         
-        let mut nodes = Vec::with_capacity(input.nodes.len() + node_holes.len());
+        let total_nodes = input.nodes.len() + node_holes.len();
+        let mut nodes = Vec::with_capacity(total_nodes);
 
         let mut compact_nodes = input.nodes.into_iter();
         let mut node_pos = 0;
         for hole_pos in node_holes.iter() {
-            nodes.extend(compact_nodes.by_ref().take(hole_pos.index() - node_pos));
+            let hole_pos = hole_pos.index();
+            if !(node_pos .. total_nodes).contains(&hole_pos) {
+                return Err(invalid_hole_err(hole_pos));
+            }
+            nodes.extend(compact_nodes.by_ref().take(hole_pos - node_pos));
             nodes.push(Node {
                 weight: None,
                 next: [EdgeIndex::end(); 2],
             });
-            node_pos = hole_pos.index() + 1;
+            node_pos = hole_pos + 1;
             debug_assert_eq!(nodes.len(), node_pos);
         }
         nodes.extend(compact_nodes);

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,15 +7,6 @@ where
     iterable.into_iter().enumerate()
 }
 
-#[cfg(feature = "serde-1")]
-pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
-where
-    I: IntoIterator,
-    I::IntoIter: DoubleEndedIterator,
-{
-    iterable.into_iter().rev()
-}
-
 pub fn zip<I, J>(i: I, j: J) -> iter::Zip<I::IntoIter, J::IntoIter>
 where
     I: IntoIterator,


### PR DESCRIPTION
The current function calls `insert` for every hole, which itself is `O(len - insert pos)`. Needless to say this is quite bad with lots of nodes and holes.
This replaces it with a `O(number of nodes + number of holes)` function that merges into a newly allocated `Vec`.
I wrote a swap based implementation as well, but it is slower.

This also adds a benchmark and makes the serialize-deserialize test more complex.