### PR TITLE
New layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rand = "0.5.5"
 odds = { version = "0.2.19" }
 defmac = "0.1"
 itertools = { version = "0.8", default-features = false }
+bincode = "*"
 
 [features]
 default = ["graphmap", "stable_graph", "matrix_graph"]

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -3,9 +3,9 @@
 extern crate petgraph;
 extern crate test;
 
-use test::Bencher;
 use petgraph::prelude::*;
-use rand::{Rng};
+use rand::Rng;
+use test::Bencher;
 
 const NUM_NODES: usize = 1_000_000;
 const NUM_EDGES: usize = 100_000;
@@ -33,13 +33,10 @@ fn make_stable_graph() -> StableGraph<u32, u32> {
     g
 }
 
-
 #[bench]
 fn serialize_bench(bench: &mut Bencher) {
     let graph = make_stable_graph();
-    bench.iter(|| {
-        bincode::serialize(&graph).unwrap()
-    });
+    bench.iter(|| bincode::serialize(&graph).unwrap());
 }
 
 #[bench]

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -1,0 +1,40 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use test::Bencher;
+use petgraph::prelude::*;
+
+fn make_stable_graph() -> StableGraph<usize, usize> {
+    let mut g = StableGraph::default();
+    let indices: Vec<_> = (0 .. 10000).map(|i| g.add_node(i)).collect();
+    for i in 0 .. 1000 {
+        g.extend_with_edges((1 .. 1000).map(|j| (indices[j], indices[(j + i) % 10000], i)));
+    }
+
+    // Remove nodes to make the structure a bit more interesting
+    for i in (0 .. 10000).step_by(2) {
+        g.remove_node(indices[i]);
+    }
+    g
+}
+
+
+#[bench]
+fn serialize_bench(bench: &mut Bencher) {
+    let graph = make_stable_graph();
+    bench.iter(|| {
+        bincode::serialize(&graph).unwrap()
+    });
+}
+
+#[bench]
+fn deserialize_bench(bench: &mut Bencher) {
+    let graph = make_stable_graph();
+    let data = bincode::serialize(&graph).unwrap();
+    bench.iter(|| {
+        let graph2: StableGraph<usize, usize> = bincode::deserialize(&data).unwrap();
+        graph2
+    });
+}

--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -5,18 +5,31 @@ extern crate test;
 
 use test::Bencher;
 use petgraph::prelude::*;
+use rand::{Rng};
 
-fn make_stable_graph() -> StableGraph<usize, usize> {
-    let mut g = StableGraph::default();
-    let indices: Vec<_> = (0 .. 10000).map(|i| g.add_node(i)).collect();
-    for i in 0 .. 1000 {
-        g.extend_with_edges((1 .. 1000).map(|j| (indices[j], indices[(j + i) % 10000], i)));
-    }
+const NUM_NODES: usize = 1_000_000;
+const NUM_EDGES: usize = 100_000;
+const NUM_HOLES: usize = 1_000_000;
+
+fn make_stable_graph() -> StableGraph<u32, u32> {
+    let mut g = StableGraph::with_capacity(NUM_NODES + NUM_HOLES, NUM_EDGES);
+    let indices: Vec<_> = (0 .. NUM_NODES + NUM_HOLES).map(|i| g.add_node(i as u32)).collect();
+
+    let mut rng = rand::thread_rng();
+    g.extend_with_edges((0 .. NUM_EDGES).map(|_| {
+        let first = rng.gen_range(0, NUM_NODES + NUM_HOLES);
+        let second = rng.gen_range(0, NUM_NODES + NUM_HOLES - 1);
+        let second = second + (second >= first) as usize;
+        let weight: u32 = rng.gen();
+        (indices[first], indices[second], weight)
+    }));
 
     // Remove nodes to make the structure a bit more interesting
-    for i in (0 .. 10000).step_by(2) {
-        g.remove_node(indices[i]);
+    while g.node_count() > NUM_NODES {
+        let idx = rng.gen_range(0, indices.len());
+        g.remove_node(indices[idx]);
     }
+
     g
 }
 
@@ -34,7 +47,7 @@ fn deserialize_bench(bench: &mut Bencher) {
     let graph = make_stable_graph();
     let data = bincode::serialize(&graph).unwrap();
     bench.iter(|| {
-        let graph2: StableGraph<usize, usize> = bincode::deserialize(&data).unwrap();
+        let graph2: StableGraph<u32, u32> = bincode::deserialize(&data).unwrap();
         graph2
     });
 }

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -148,12 +148,12 @@ where
     Ix: IndexType,
 {
     let mut g = StableGraph::default();
-    let indices: Vec<_> = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
-    for i in 1 .. 256 {
-        g.extend_with_edges((0 .. 1024).map(|j| (indices[j], indices[(j + i) % 1024], i as i32)));
+    let indices: Vec<_> = (0..1024).map(|i| g.add_node(format!("{}", i))).collect();
+    for i in 1..256 {
+        g.extend_with_edges((0..1024).map(|j| (indices[j], indices[(j + i) % 1024], i as i32)));
     }
     // Remove nodes to make the structure a bit more interesting
-    for i in (0 .. 1024).step_by(10) {
+    for i in (0..1024).step_by(10) {
         g.remove_node(indices[i]);
     }
     g

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -150,9 +150,7 @@ where
     let mut g = StableGraph::default();
     let indices = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
     for i in 1 .. 256 {
-        for j in 0 .. 1024 {
-            g.extend_with_edge(indices[j], indices[(j + i) % 1024], i);
-        }
+        g.extend_with_edge((0 .. 1024).map(|j| (indices[j], indices[(j + i) % 1024], i)));
     }
     // Remove nodes to make the structure a bit more interesting
     for i in (0 .. 1024).step_by(10) {

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -142,31 +142,22 @@ where
     g
 }
 
-fn make_stable_graph<Ty, Ix>() -> StableGraph<&'static str, i32, Ty, Ix>
+fn make_stable_graph<Ty, Ix>() -> StableGraph<String, i32, Ty, Ix>
 where
     Ty: EdgeType,
     Ix: IndexType,
 {
     let mut g = StableGraph::default();
-    let a = g.add_node("A");
-    let b = g.add_node("B");
-    let c = g.add_node("C");
-    let d = g.add_node("D");
-    let e = g.add_node("E");
-    let f = g.add_node("F");
-    g.extend_with_edges(&[
-        (a, b, 7),
-        (c, a, 9),
-        (a, d, 14),
-        (b, c, 10),
-        (d, c, 2),
-        (d, e, 9),
-        (b, f, 15),
-        (c, f, 11),
-        (e, f, 6),
-    ]);
-    // Remove a node to make the structure a bit more interesting
-    g.remove_node(d);
+    let indices = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
+    for i in 1 .. 256 {
+        for j in 0 .. 1024 {
+            g.extend_with_edge(indices[j], indices[(j + i) % 1024], i);
+        }
+    }
+    // Remove nodes to make the structure a bit more interesting
+    for i in (0 .. 1024).step_by(10) {
+        g.remove_node(indices[i]);
+    }
     g
 }
 

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -148,9 +148,9 @@ where
     Ix: IndexType,
 {
     let mut g = StableGraph::default();
-    let indices = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
+    let indices: Vec<_> = (0 .. 1024).map(|i| g.add_node(format!("{}", i))).collect();
     for i in 1 .. 256 {
-        g.extend_with_edge((0 .. 1024).map(|j| (indices[j], indices[(j + i) % 1024], i)));
+        g.extend_with_edges((0 .. 1024).map(|j| (indices[j], indices[(j + i) % 1024], i as i32)));
     }
     // Remove nodes to make the structure a bit more interesting
     for i in (0 .. 1024).step_by(10) {

--- a/src/graph_impl/serialization.rs
+++ b/src/graph_impl/serialization.rs
@@ -295,6 +295,16 @@ where
     ))
 }
 
+pub fn invalid_hole_err<E>(node_index: usize) -> E
+where
+    E: Error,
+{
+    E::custom(format_args!(
+        "invalid value: node hole `{}` is not allowed.",
+        node_index
+    ))
+}
+
 impl<'a, N, E, Ty, Ix> FromDeserialized for Graph<N, E, Ty, Ix>
 where
     Ix: IndexType,

--- a/src/graph_impl/serialization.rs
+++ b/src/graph_impl/serialization.rs
@@ -41,9 +41,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[serde(rename = "Graph")]
 #[serde(bound(serialize = "N: Serialize, E: Serialize, Ix: IndexType + Serialize"))]
 pub struct SerGraph<'a, N: 'a, E: 'a, Ix: 'a + IndexType> {
+    node_holes: &'a [NodeIndex<Ix>],
     #[serde(serialize_with = "ser_graph_nodes")]
     nodes: &'a [Node<N, Ix>],
-    node_holes: &'a [NodeIndex<Ix>],
     edge_property: EdgeProperty,
     #[serde(serialize_with = "ser_graph_edges")]
     edges: &'a [Edge<E, Ix>],
@@ -57,12 +57,12 @@ pub struct SerGraph<'a, N: 'a, E: 'a, Ix: 'a + IndexType> {
     deserialize = "N: Deserialize<'de>, E: Deserialize<'de>, Ix: IndexType + Deserialize<'de>"
 ))]
 pub struct DeserGraph<N, E, Ix> {
-    #[serde(deserialize_with = "deser_graph_nodes")]
-    nodes: Vec<Node<N, Ix>>,
     #[serde(deserialize_with = "deser_graph_node_holes")]
     #[allow(unused)]
     #[serde(default = "Vec::new")]
     node_holes: Vec<NodeIndex<Ix>>,
+    #[serde(deserialize_with = "deser_graph_nodes")]
+    nodes: Vec<Node<N, Ix>>,
     edge_property: EdgeProperty,
     #[serde(deserialize_with = "deser_graph_edges")]
     edges: Vec<Edge<E, Ix>>,

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -1,7 +1,8 @@
-use serde::de::Error;
+use serde::de::{Error, Visitor, SeqAccess, MapAccess, DeserializeSeed};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use std::marker::PhantomData;
+use std::fmt;
 
 use crate::prelude::*;
 
@@ -22,28 +23,283 @@ use super::super::serialization::{invalid_length_err, invalid_node_err, EdgeProp
 #[serde(rename = "Graph")]
 #[serde(bound(serialize = "N: Serialize, E: Serialize, Ix: IndexType + Serialize"))]
 pub struct SerStableGraph<'a, N: 'a, E: 'a, Ix: 'a + IndexType> {
-    nodes: Somes<&'a [Node<Option<N>, Ix>]>,
     node_holes: Holes<&'a [Node<Option<N>, Ix>]>,
+    nodes: Somes<&'a [Node<Option<N>, Ix>]>,
     edge_property: EdgeProperty,
     #[serde(serialize_with = "ser_stable_graph_edges")]
     edges: &'a [Edge<Option<E>, Ix>],
 }
 
+static STABLE_GRAPH_FIELDS: &[&str] = &["node_holes", "nodes", "edge_property", "edges"];
 // Deserialization representation for StableGraph
 // Keep in sync with serialization and Graph
+impl<'de, N, E, Ty, Ix> Deserialize<'de> for StableGraph<N, E, Ty, Ix>
+    where N: Deserialize<'de>, E: Deserialize<'de>, Ix: IndexType + Deserialize<'de>, Ty: EdgeType
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        deserializer.deserialize_struct("StableGraph", STABLE_GRAPH_FIELDS, StableGraphVisitor::new())
+    }
+}
+
 #[derive(Deserialize)]
-#[serde(rename = "Graph")]
-#[serde(bound(
-    deserialize = "N: Deserialize<'de>, E: Deserialize<'de>, Ix: IndexType + Deserialize<'de>"
-))]
-pub struct DeserStableGraph<N, E, Ix> {
-    #[serde(deserialize_with = "deser_stable_graph_nodes")]
-    nodes: Vec<Node<Option<N>, Ix>>,
-    #[serde(default = "Vec::new")]
+#[serde(field_identifier, rename_all = "snake_case")]
+enum SerializedFields {
+    NodeHoles,
+    Nodes,
+    EdgeProperty,
+    Edges,
+}
+
+enum NodeState<N, Ix> {
+    Compact(Vec<N>),
+    Expanded(Vec<Node<Option<N>, Ix>>)
+}
+
+struct StableGraphVisitor<N, E, Ty, Ix> {
+    marker: PhantomData<(N, E, Ty, Ix)>,
+}
+impl<'de, N, E, Ty, Ix> StableGraphVisitor<N, E, Ty, Ix>
+    where N: Deserialize<'de>, E: Deserialize<'de>, Ix: IndexType, Ty: EdgeType
+{
+    fn new() -> Self {
+        StableGraphVisitor { marker: PhantomData }
+    }
+    fn expand_nodes<Er, I>(node_holes: Vec<NodeIndex<Ix>>, mut compact_nodes: I, compact_nodes_len: Option<usize>)
+    -> Result<Vec<Node<Option<N>, Ix>>, Er>
+        where I: Iterator<Item=Result<N, Er>>, Er: Error
+    {
+        let mut nodes = Vec::with_capacity(compact_nodes_len.unwrap_or(0) + node_holes.len());
+
+        let make_node = |n| Node {
+            weight: Some(n),
+            next: [EdgeIndex::end(); 2],
+        };
+
+        let mut num_compact = 0;
+        let mut node_pos = 0;
+        for hole_pos in node_holes.iter() {
+            for _ in 0 .. hole_pos.index() - node_pos {
+                nodes.push(make_node(compact_nodes.next().ok_or_else(|| Error::invalid_length(num_compact, &"more nodes"))??));
+                num_compact += 1;
+            }
+            nodes.push(Node {
+                weight: None,
+                next: [EdgeIndex::end(); 2],
+            });
+            node_pos = hole_pos.index() + 1;
+            debug_assert_eq!(nodes.len(), node_pos);
+        }
+        for r in compact_nodes {
+            nodes.push(make_node(r?));
+            num_compact += 1;
+        }
+
+        Ok(nodes)
+    }
+
+    fn visit_nodes_with_holes<A>(node_holes: Vec<NodeIndex<Ix>>, mut seq: A) -> Result<Vec<Node<Option<N>, Ix>>, A::Error>
+        where A: SeqAccess<'de>
+    {
+        let size_hint = seq.size_hint();
+        Self::expand_nodes(node_holes, std::iter::from_fn(|| seq.next_element().transpose()), size_hint)
+    }
+
+    fn merge_nodes_with_holes<Er: Error>(node_holes: Vec<NodeIndex<Ix>>, compact_nodes: Vec<N>) -> Result<Vec<Node<Option<N>, Ix>>, Er> {
+        let size_hint = Some(compact_nodes.len());
+        Self::expand_nodes(node_holes, compact_nodes.into_iter().map(Ok), size_hint)
+    }
+
+    fn build<Er: Error>(nodes: Vec<Node<Option<N>, Ix>>, edges: Vec<Edge<Option<E>, Ix>>, edge_property: EdgeProperty) -> Result<StableGraph<N, E, Ty, Ix>, Er> {
+        let ty = PhantomData::<Ty>::from_deserialized(edge_property)?;
+        if edges.len() >= <Ix as IndexType>::max().index() {
+            Err(invalid_length_err::<Ix, _>("edge", edges.len()))?
+        }
+
+        if nodes.len() >= <Ix as IndexType>::max().index() {
+            Err(invalid_length_err::<Ix, _>("node", nodes.len()))?
+        }
+
+        let node_bound = nodes.len();
+        let mut sgr = StableGraph {
+            g: Graph {
+                nodes: nodes,
+                edges: edges,
+                ty: ty,
+            },
+            node_count: 0,
+            edge_count: 0,
+            free_edge: EdgeIndex::end(),
+            free_node: NodeIndex::end(),
+        };
+        sgr.link_edges()
+            .map_err(|i| invalid_node_err(i.index(), node_bound))?;
+        Ok(sgr)
+    }
+}
+
+impl<'de, N, E, Ty, Ix> Visitor<'de> for StableGraphVisitor<N, E, Ty, Ix>
+    where N: Deserialize<'de>, E: Deserialize<'de>, Ix: IndexType + Deserialize<'de>, Ty: EdgeType
+{
+    type Value = StableGraph<N, E, Ty, Ix>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "struct StableGraph")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let node_holes = NodeHoles::new(seq.next_element()?.ok_or(A::Error::missing_field("node_holes"))?);
+        let nodes = seq.next_element_seed(node_holes)?.ok_or(A::Error::missing_field("node_holes"))?;
+        let edge_property = seq.next_element()?.ok_or(A::Error::missing_field("edge_property"))?;
+        let edges = seq.next_element::<StableGraphEdges<E, Ix>>()?.ok_or(A::Error::missing_field("edge_property"))?.0;
+
+        StableGraphVisitor::build(nodes, edges, edge_property)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where A: MapAccess<'de>
+    {
+        let mut node_holes: Option<Vec<NodeIndex<Ix>>> = None;
+        let mut nodes: Option<NodeState<N, Ix>> = None;
+        let mut edges: Option<StableGraphEdges<E, Ix>> = None;
+        let mut edge_property = None;
+
+        while let Some(key) = map.next_key()? {
+            match key {
+                SerializedFields::NodeHoles => {
+                    if node_holes.is_some() {
+                        return Err(Error::duplicate_field("node_holes"));
+                    }
+                    node_holes = Some(map.next_value()?);
+                }
+                SerializedFields::Nodes => {
+                    if nodes.is_some() {
+                        return Err(Error::duplicate_field("nodes"));
+                    }
+                    nodes = Some(match node_holes.take() {
+                        None => NodeState::Compact(map.next_value()?),
+                        Some(node_holes) => NodeState::Expanded(map.next_value_seed(NodeHoles::new(node_holes))?),
+                    });
+                }
+                SerializedFields::Edges => {
+                    if edges.is_some() {
+                        return Err(Error::duplicate_field("edges"));
+                    }
+                    edges = Some(map.next_value()?);
+                }
+                SerializedFields::EdgeProperty => {
+                    if edge_property.is_some() {
+                        return Err(Error::duplicate_field("edge_property"));
+                    }
+                    edge_property = Some(map.next_value()?);
+                }
+            }
+        }
+
+        let nodes = match (node_holes, nodes) {
+            (None, Some(NodeState::Expanded(nodes))) => nodes,
+            (Some(node_holes), Some(NodeState::Compact(nodes))) => Self::merge_nodes_with_holes(node_holes, nodes)?,
+            (None, _) => return Err(Error::missing_field("node_holes")),
+            (Some(_), None) => return Err(Error::missing_field("nodes")),
+            (Some(_), Some(_)) => panic!("logic error. this should not happen.")
+        };
+        let edges = edges.ok_or_else(|| Error::missing_field("edges"))?.0;
+        let edge_property = edge_property.ok_or_else(|| Error::missing_field("edge_property"))?;
+
+        StableGraphVisitor::build(nodes, edges, edge_property)
+    }
+}
+
+struct NodeHoles<N, Ix>(Vec<NodeIndex<Ix>>, PhantomData<N>);
+impl<N, Ix> NodeHoles<N, Ix> {
+    fn new(node_holes: Vec<NodeIndex<Ix>>) -> Self {
+        NodeHoles(node_holes, PhantomData)
+    }
+}
+impl<'de, N, Ix> DeserializeSeed<'de> for NodeHoles<N, Ix>
+    where N: Deserialize<'de>, Ix: IndexType + Deserialize<'de>
+{
+    type Value = Vec<Node<Option<N>, Ix>>;
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where D: Deserializer<'de>
+    {
+        deserializer.deserialize_seq(CompactNodeVisitor::new(self.0))
+    }
+}
+
+/// Serde combinator. A sequence visitor that maps deserialized elements
+/// lazily; the visitor can also emit new errors if the elements have errors.
+pub struct CompactNodeVisitor<N, Ix> {
     node_holes: Vec<NodeIndex<Ix>>,
-    edge_property: EdgeProperty,
-    #[serde(deserialize_with = "deser_stable_graph_edges")]
-    edges: Vec<Edge<Option<E>, Ix>>,
+    marker: PhantomData<N>,
+}
+impl<'de, N, Ix> CompactNodeVisitor<N, Ix>
+    where N: Deserialize<'de>, Ix: IndexType
+{
+    pub fn new(node_holes: Vec<NodeIndex<Ix>>) -> Self {
+        CompactNodeVisitor {
+            node_holes,
+            marker: PhantomData,
+        }
+    }
+    fn expand_nodes<A>(self, mut nodes_seq: A) -> Result<Vec<Node<Option<N>, Ix>>, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut nodes = Vec::with_capacity(self.node_holes.len() + nodes_seq.size_hint().unwrap_or(0));
+        let mut node_pos = 0;
+        let mut full_nodes = 0;
+
+        for hole_pos in self.node_holes.iter() {
+            for _ in 0 .. hole_pos.index() - node_pos {
+                match nodes_seq.next_element()? {
+                    Some(n) => {
+                        nodes.push(Node {
+                            weight: Some(n),
+                            next: [EdgeIndex::end(); 2],
+                        });
+                        full_nodes += 1;
+                    }
+                    None => return Err(A::Error::invalid_length(full_nodes, &"more nodes"))
+                }
+            }
+            nodes.push(Node {
+                weight: None,
+                next: [EdgeIndex::end(); 2],
+            });
+            node_pos = hole_pos.index() + 1;
+            debug_assert_eq!(nodes.len(), node_pos);
+        }
+        while let Some(n) = nodes_seq.next_element()? {
+            nodes.push(Node {
+                weight: Some(n),
+                next: [EdgeIndex::end(); 2],
+            });
+        }
+
+        Ok(nodes)
+    }
+}
+
+impl<'de, N, Ix> Visitor<'de> for CompactNodeVisitor<N, Ix>
+    where N: Deserialize<'de>, Ix: IndexType + Deserialize<'de>
+{
+    type Value = Vec<Node<Option<N>, Ix>>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a sequence")
+    }
+
+    fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        self.expand_nodes(seq)
+    }
 }
 
 /// `Somes` are the present node weights N, with known length.
@@ -104,49 +360,34 @@ where
     }))
 }
 
-fn deser_stable_graph_nodes<'de, D, N, Ix>(
-    deserializer: D,
-) -> Result<Vec<Node<Option<N>, Ix>>, D::Error>
-where
-    D: Deserializer<'de>,
-    N: Deserialize<'de>,
-    Ix: IndexType + Deserialize<'de>,
+struct StableGraphEdges<E, Ix>(Vec<Edge<Option<E>, Ix>>);
+impl<'de, E, Ix> Deserialize<'de> for StableGraphEdges<E, Ix>
+    where E: Deserialize<'de>, Ix: IndexType + Deserialize<'de>,
 {
-    deserializer.deserialize_seq(MappedSequenceVisitor::new(|n| {
-        Ok(Node {
-            weight: Some(n),
-            next: [EdgeIndex::end(); 2],
-        })
-    }))
-}
-
-fn deser_stable_graph_edges<'de, D, N, Ix>(
-    deserializer: D,
-) -> Result<Vec<Edge<Option<N>, Ix>>, D::Error>
-where
-    D: Deserializer<'de>,
-    N: Deserialize<'de>,
-    Ix: IndexType + Deserialize<'de>,
-{
-    deserializer.deserialize_seq(MappedSequenceVisitor::<
-        Option<(NodeIndex<Ix>, NodeIndex<Ix>, N)>,
-        _,
-        _,
-    >::new(|x| {
-        if let Some((i, j, w)) = x {
-            Ok(Edge {
-                weight: Some(w),
-                node: [i, j],
-                next: [EdgeIndex::end(); 2],
-            })
-        } else {
-            Ok(Edge {
-                weight: None,
-                node: [NodeIndex::end(); 2],
-                next: [EdgeIndex::end(); 2],
-            })
-        }
-    }))
+    fn deserialize<D>(mut deserializer: D) -> Result<Self, D::Error> where
+        D: Deserializer<'de>,
+    {
+        let edges = deserializer.deserialize_seq(MappedSequenceVisitor::<
+            Option<(NodeIndex<Ix>, NodeIndex<Ix>, E)>,
+            _,
+            _,
+        >::new(|x| {
+            if let Some((i, j, w)) = x {
+                Ok(Edge {
+                    weight: Some(w),
+                    node: [i, j],
+                    next: [EdgeIndex::end(); 2],
+                })
+            } else {
+                Ok(Edge {
+                    weight: None,
+                    node: [NodeIndex::end(); 2],
+                    next: [EdgeIndex::end(); 2],
+                })
+            }
+        }))?;
+        Ok(StableGraphEdges(edges))
+    }
 }
 
 impl<'a, N, E, Ty, Ix> IntoSerializable for &'a StableGraph<N, E, Ty, Ix>
@@ -185,97 +426,7 @@ where
     }
 }
 
-impl<'a, N, E, Ty, Ix> FromDeserialized for StableGraph<N, E, Ty, Ix>
-where
-    Ix: IndexType,
-    Ty: EdgeType,
-{
-    type Input = DeserStableGraph<N, E, Ix>;
-    fn from_deserialized<E2>(input: Self::Input) -> Result<Self, E2>
-    where
-        E2: Error,
-    {
-        let ty = PhantomData::<Ty>::from_deserialized(input.edge_property)?;
-        let node_holes = input.node_holes;
-        let edges = input.edges;
-        if edges.len() >= <Ix as IndexType>::max().index() {
-            Err(invalid_length_err::<Ix, _>("edge", edges.len()))?
-        }
-        
-        let mut nodes = Vec::with_capacity(input.nodes.len() + node_holes.len());
-
-        let mut compact_nodes = input.nodes.into_iter();
-        let mut node_pos = 0;
-        for hole_pos in node_holes.iter() {
-            nodes.extend(compact_nodes.by_ref().take(hole_pos.index() - node_pos));
-            nodes.push(Node {
-                weight: None,
-                next: [EdgeIndex::end(); 2],
-            });
-            node_pos = hole_pos.index() + 1;
-            debug_assert_eq!(nodes.len(), node_pos);
-        }
-        nodes.extend(compact_nodes);
-
-        /*
-        // smart implementation using swap.
-        // is actually slower in the benchmark.
-        
-        let mut nodes = input.nodes;
-        nodes.extend(std::iter::repeat_with(|| Node {
-            weight: None,
-            next: [EdgeIndex::end(); 2],
-        }).take(node_holes.len()));
-
-        let mut node_pos = nodes.len();
-
-        for (hole_count, hole_pos) in node_holes.iter().enumerate().rev() {
-            node_pos -= 1;
-            while node_pos > hole_pos.index() {
-                nodes.swap(node_pos - hole_count - 1, node_pos);
-                node_pos -= 1;
-            }
-        }
-        */
-
-        if nodes.len() >= <Ix as IndexType>::max().index() {
-            Err(invalid_length_err::<Ix, _>("node", nodes.len()))?
-        }
-
-        let node_bound = nodes.len();
-        let mut sgr = StableGraph {
-            g: Graph {
-                nodes: nodes,
-                edges: edges,
-                ty: ty,
-            },
-            node_count: 0,
-            edge_count: 0,
-            free_edge: EdgeIndex::end(),
-            free_node: NodeIndex::end(),
-        };
-        sgr.link_edges()
-            .map_err(|i| invalid_node_err(i.index(), node_bound))?;
-        Ok(sgr)
-    }
-}
-
-/// Requires crate feature `"serde-1"`
-impl<'de, N, E, Ty, Ix> Deserialize<'de> for StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType + Deserialize<'de>,
-    N: Deserialize<'de>,
-    E: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Self::from_deserialized(DeserStableGraph::deserialize(deserializer)?)
-    }
-}
-
+/*
 #[test]
 fn test_from_deserialized_with_holes() {
     use crate::graph::node_index;
@@ -310,3 +461,4 @@ fn test_from_deserialized_with_holes() {
         vec![None, Some(1), None, None, Some(4), Some(5), None],
     );
 }
+*/

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -204,21 +204,26 @@ where
             Err(invalid_length_err::<Ix, _>("edge", edges.len()))?
         }
 
-        // insert Nones for each hole
+        // append Nones
+        nodes.extend(std::iter::from_fn(|| {
+            Node {
+                weight: None,
+                next: [EdgeIndex::end(); 2],
+            }
+        }).take(node_holes.len()));
+
+        // swap Nones for each hole
         let mut offset = node_holes.len();
         let node_bound = node_holes.len() + nodes.len();
-        for hole_pos in rev(node_holes) {
+        for (i, hole_pos) in rev(node_holes).enumerate() {
             offset -= 1;
             if hole_pos.index() >= node_bound {
                 Err(invalid_node_err(hole_pos.index(), node_bound))?;
             }
             let insert_pos = hole_pos.index() - offset;
-            nodes.insert(
+            nodes.swap(
                 insert_pos,
-                Node {
-                    weight: None,
-                    next: [EdgeIndex::end(); 2],
-                },
+                offset
             );
         }
 

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -217,6 +217,27 @@ where
         }
         nodes.extend(compact_nodes);
 
+        /*
+        // smart implementation using swap.
+        // is actually slower in the benchmark.
+        
+        let mut nodes = input.nodes;
+        nodes.extend(std::iter::repeat_with(|| Node {
+            weight: None,
+            next: [EdgeIndex::end(); 2],
+        }).take(node_holes.len()));
+
+        let mut node_pos = nodes.len();
+
+        for (hole_count, hole_pos) in node_holes.iter().enumerate().rev() {
+            node_pos -= 1;
+            while node_pos > hole_pos.index() {
+                nodes.swap(node_pos - hole_count - 1, node_pos);
+                node_pos -= 1;
+            }
+        }
+        */
+
         if nodes.len() >= <Ix as IndexType>::max().index() {
             Err(invalid_length_err::<Ix, _>("node", nodes.len()))?
         }

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -11,7 +11,6 @@ use crate::serde_utils::CollectSeqWithLength;
 use crate::serde_utils::MappedSequenceVisitor;
 use crate::serde_utils::{FromDeserialized, IntoSerializable};
 use crate::stable_graph::StableGraph;
-use crate::util::rev;
 use crate::visit::NodeIndexable;
 use crate::EdgeType;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,15 +7,6 @@ where
     iterable.into_iter().enumerate()
 }
 
-#[cfg(feature = "serde-1")]
-pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
-where
-    I: IntoIterator,
-    I::IntoIter: DoubleEndedIterator,
-{
-    iterable.into_iter().rev()
-}
-
 pub fn zip<I, J>(i: I, j: J) -> iter::Zip<I::IntoIter, J::IntoIter>
 where
     I: IntoIterator,

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1824,7 +1824,7 @@ fn dot() {
     struct Record {
         a: i32,
         b: &'static str,
-    };
+    }
     let mut gr = Graph::new();
     let a = gr.add_node(Record { a: 1, b: r"abc\" });
     gr.add_edge(a, a, (1, 2));


### PR DESCRIPTION
Associated issue: #394

This swaps the first two fields in the serialized order of Graph and StableGraph.
It also implements an optimal node expansion during deserialization of the nodes.
The code is a bit more complex as the field order is not guaranteed (JSON for example) and both orders need to be supported.
In the suboptimal case of `nodes` before `node_holes` it falls back to the same function as in https://github.com/petgraph/petgraph/pull/395 .