### PR TITLE
Add EdgeIndexable public trait

### DIFF
--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -4,7 +4,9 @@ use super::Frozen;
 use crate::data::{DataMap, DataMapMut};
 use crate::graph::Graph;
 use crate::graph::{GraphIndex, IndexType};
-use crate::visit::{Data, GraphProp, IntoNeighborsDirected, IntoNodeIdentifiers, NodeIndexable};
+use crate::visit::{
+    Data, EdgeIndexable, GraphProp, IntoNeighborsDirected, IntoNodeIdentifiers, NodeIndexable,
+};
 use crate::visit::{
     GetAdjacencyMatrix, IntoEdges, IntoEdgesDirected, NodeCompactIndexable, NodeCount,
 };
@@ -92,5 +94,6 @@ IntoNodeReferences! {delegate_impl [['a, 'b, G], G, &'b Frozen<'a, G>, deref_twi
 NodeCompactIndexable! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 NodeCount! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 NodeIndexable! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
+EdgeIndexable! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 GraphProp! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 Visitable! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -19,7 +19,8 @@ use crate::iter_utils::IterUtilsExt;
 
 use super::{index_twice, Edge, Frozen, Node, Pair, DIRECTIONS};
 use crate::visit::{
-    EdgeRef, IntoEdgeReferences, IntoEdges, IntoEdgesDirected, IntoNodeReferences, NodeIndexable,
+    EdgeIndexable, EdgeRef, IntoEdgeReferences, IntoEdges, IntoEdgesDirected, IntoNodeReferences,
+    NodeIndexable,
 };
 use crate::IntoWeightedEdge;
 
@@ -936,12 +937,6 @@ where
         self.g.raw_edges()
     }
 
-    fn edge_bound(&self) -> usize {
-        self.edge_references()
-            .next_back()
-            .map_or(0, |edge| edge.id().index() + 1)
-    }
-
     #[cfg(feature = "serde-1")]
     /// Fix up node and edge links after deserialization
     fn link_edges(&mut self) -> Result<(), NodeIndex<Ix>> {
@@ -1695,6 +1690,26 @@ where
     }
     fn from_index(&self, ix: usize) -> Self::NodeId {
         NodeIndex::new(ix)
+    }
+}
+
+impl<N, E, Ty, Ix> EdgeIndexable for StableGraph<N, E, Ty, Ix>
+where
+    Ty: EdgeType,
+    Ix: IndexType,
+{
+    fn edge_bound(&self) -> usize {
+        self.edge_references()
+            .next_back()
+            .map_or(0, |edge| edge.id().index() + 1)
+    }
+
+    fn to_index(&self, ix: EdgeIndex<Ix>) -> usize {
+        ix.index()
+    }
+
+    fn from_index(&self, ix: usize) -> Self::EdgeId {
+        EdgeIndex::new(ix)
     }
 }
 

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -12,7 +12,7 @@ use crate::serde_utils::MappedSequenceVisitor;
 use crate::serde_utils::{FromDeserialized, IntoSerializable};
 use crate::stable_graph::StableGraph;
 use crate::util::rev;
-use crate::visit::NodeIndexable;
+use crate::visit::{EdgeIndexable, NodeIndexable};
 use crate::EdgeType;
 
 use super::super::serialization::{invalid_length_err, invalid_node_err, EdgeProperty};

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -516,6 +516,22 @@ trait_template! {
 NodeIndexable! {delegate_impl []}
 
 trait_template! {
+    /// The graph’s `NodeId`s map to indices
+    pub trait EdgeIndexable : GraphBase {
+        @section self
+        /// Return an upper bound of the edge indices in the graph
+        /// (suitable for the size of a bitmap).
+        fn edge_bound(self: &Self) -> usize;
+        /// Convert `a` to an integer index.
+        fn to_index(self: &Self, a: Self::EdgeId) -> usize;
+        /// Convert `i` to a node index
+        fn from_index(self: &Self, i: usize) -> Self::EdgeId;
+    }
+}
+
+EdgeIndexable! {delegate_impl []}
+
+trait_template! {
 /// A graph with a known node count.
 pub trait NodeCount : GraphBase {
     @section self

--- a/tests/stable_graph.rs
+++ b/tests/stable_graph.rs
@@ -9,8 +9,9 @@ use itertools::assert_equal;
 use petgraph::algo::{kosaraju_scc, min_spanning_tree, tarjan_scc};
 use petgraph::dot::Dot;
 use petgraph::prelude::*;
+use petgraph::stable_graph::edge_index as e;
 use petgraph::stable_graph::node_index as n;
-use petgraph::visit::{IntoEdgeReferences, IntoNodeReferences, NodeIndexable};
+use petgraph::visit::{EdgeIndexable, IntoEdgeReferences, IntoNodeReferences, NodeIndexable};
 use petgraph::EdgeType;
 
 #[test]
@@ -40,6 +41,25 @@ fn node_bound() {
     assert_eq!(g.node_bound(), full_count);
     g.clear();
     assert_eq!(g.node_bound(), 0);
+}
+
+#[test]
+fn edge_bound() {
+    let mut g = StableGraph::<_, _>::new();
+    assert_eq!(g.edge_bound(), g.edge_count());
+    for i in 0..10 {
+        g.add_node(i);
+    }
+    for i in 0..9 {
+        g.add_edge(n(i), n(i + 1), i);
+        assert_eq!(g.edge_bound(), g.edge_count());
+    }
+    let full_count = g.edge_count();
+    g.remove_edge(e(0));
+    g.remove_edge(e(2));
+    assert_eq!(g.edge_bound(), full_count);
+    g.clear();
+    assert_eq!(g.edge_bound(), 0);
 }
 
 #[test]


### PR DESCRIPTION
Just as there is a NodeIndexable public trait that lets users handle the
interaction with node indices there was no corresponding trait for
edges. This commit adds a new public trait EdgeIndexable which mirrors
NodeIndexable but works with edge indices instead. It is then
implemented for StableGraph and frozen (the graphs where there were
NodeIndexable impls and EdgeIndexable made sense).