### PR TITLE
Run rustfmt with latest rust version (1.50.0)

### DIFF
--- a/src/adj.rs
+++ b/src/adj.rs
@@ -1,10 +1,10 @@
 //! Simple adjacency list.
-use fixedbitset::FixedBitSet;
+use crate::data::{Build, DataMap, DataMapMut};
 use crate::iter_format::NoPretty;
+use crate::visit::{self, EdgeRef, IntoEdgeReferences, IntoNeighbors, NodeCount};
+use fixedbitset::FixedBitSet;
 use std::fmt;
 use std::ops::Range;
-use crate::visit::{self, EdgeRef, IntoEdgeReferences, IntoNeighbors, NodeCount};
-use crate::data::{Build, DataMap, DataMapMut};
 
 #[doc(no_inline)]
 pub use crate::graph::{DefaultIx, IndexType};
@@ -222,7 +222,11 @@ impl<E, Ix: IndexType> List<E, Ix> {
     /// to avoid this, use [`.update_edge(a, b, weight)`](#method.update_edge) instead.
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
         if b.index() >= self.suc.len() {
-            panic!("{} is not a valid node index for a {} nodes adjacency list", b.index(), self.suc.len());
+            panic!(
+                "{} is not a valid node index for a {} nodes adjacency list",
+                b.index(),
+                self.suc.len()
+            );
         }
         let row = &mut self.suc[a.index()];
         let rank = row.len();
@@ -311,10 +315,8 @@ impl<E, Ix: IndexType> List<E, Ix> {
     }
 }
 
-
 /// A very simple adjacency list with no node or label weights.
 pub type UnweightedList<Ix> = List<(), Ix>;
-
 
 impl<E, Ix: IndexType> Build for List<E, Ix> {
     /// Adds a new node to the list. This allocates a new `Vec` and then should
@@ -365,8 +367,6 @@ impl<E, Ix: IndexType> Build for List<E, Ix> {
         }
     }
 }
-
-
 
 impl<'a, E, Ix> fmt::Debug for EdgeReferences<'a, E, Ix>
 where
@@ -550,10 +550,12 @@ impl<'a, Ix: IndexType, E> visit::IntoEdges for &'a List<E, Ix> {
 
 impl<E, Ix: IndexType> visit::GraphProp for List<E, Ix> {
     type EdgeType = crate::Directed;
-    fn is_directed(&self) -> bool { true }
+    fn is_directed(&self) -> bool {
+        true
+    }
 }
 
-impl <E, Ix: IndexType> NodeCount for List<E, Ix> {
+impl<E, Ix: IndexType> NodeCount for List<E, Ix> {
     /// Returns the number of nodes in the list
     ///
     /// Computes in **O(1)** time.
@@ -613,4 +615,3 @@ impl<E, Ix: IndexType> DataMapMut for List<E, Ix> {
         self.get_edge_mut(e).map(|x| &mut x.weight)
     }
 }
-

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -13,7 +13,7 @@
 //! dominates **C** and **C** dominates **B**.
 
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet, hash_map::Iter};
+use std::collections::{hash_map::Iter, HashMap, HashSet};
 use std::hash::Hash;
 
 use crate::visit::{DfsPostOrder, GraphBase, IntoNeighbors, Visitable, Walker};
@@ -85,7 +85,7 @@ where
     pub fn immediately_dominated_by(&self, node: N) -> DominatedByIter<N> {
         DominatedByIter {
             iter: self.dominators.iter(),
-            node: node
+            node: node,
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,13 +11,13 @@ macro_rules! clone_fields {
 }
 
 macro_rules! iterator_wrap {
-    (impl () for 
+    (impl () for
     struct $name: ident <$($typarm:tt),*> where { $($bounds: tt)* }
      item: $item: ty,
      iter: $iter: ty,
      ) => ();
     (
-    impl (Iterator $($rest:tt)*)  for 
+    impl (Iterator $($rest:tt)*)  for
     $(#[$derive:meta])*
      struct $name: ident <$($typarm:tt),*> where { $($bounds: tt)* }
      item: $item: ty,
@@ -50,7 +50,7 @@ macro_rules! iterator_wrap {
             iter: $iter,
             );
         );
-    
+
     (
 impl (ExactSizeIterator $($rest:tt)*)  for
     $(#[$derive:meta])*
@@ -74,7 +74,7 @@ impl (ExactSizeIterator $($rest:tt)*)  for
             iter: $iter,
             );
     );
-    
+
     (
 impl (DoubleEndedIterator $($rest:tt)*)  for
     $(#[$derive:meta])*

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -65,12 +65,12 @@ use crate::prelude::{Direction, Graph};
 use crate::csr::Csr;
 use crate::graph::Frozen;
 use crate::graph::IndexType;
-#[cfg(feature = "stable_graph")]
-use crate::stable_graph;
-#[cfg(feature = "matrix_graph")]
-use crate::matrix_graph::MatrixGraph;
 #[cfg(feature = "graphmap")]
 use crate::graphmap::{self, NodeTrait};
+#[cfg(feature = "matrix_graph")]
+use crate::matrix_graph::MatrixGraph;
+#[cfg(feature = "stable_graph")]
+use crate::stable_graph;
 
 trait_template! {
 /// Base graph trait: defines the associated node identifier and

--- a/src/visit/reversed.rs
+++ b/src/visit/reversed.rs
@@ -97,7 +97,9 @@ pub struct ReversedEdgeReference<R>(R);
 
 impl<R> ReversedEdgeReference<R> {
     /// Return the original, unreversed edge reference.
-    pub fn as_unreversed(&self) -> &R { &self.0 }
+    pub fn as_unreversed(&self) -> &R {
+        &self.0
+    }
 
     /// Consume `self` and return the original, unreversed edge reference.
     pub fn into_unreversed(self) -> R {

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -590,10 +590,16 @@ fn test_astar_runtime_optimal() {
 
     let mut times_called = 0;
 
-    let _ = astar(&g, a, |n| n == e, |edge| {
-        times_called += 1;
-        *edge.weight()
-    }, |_| 0);
+    let _ = astar(
+        &g,
+        a,
+        |n| n == e,
+        |edge| {
+            times_called += 1;
+            *edge.weight()
+        },
+        |_| 0,
+    );
 
     // A* is runtime optimal in the sense it won't expand more nodes than needed, for the given
     // heuristic. Here, A* should expand, in order: A, B, C, D, E. This should should ask for the
@@ -1824,7 +1830,7 @@ fn dot() {
     struct Record {
         a: i32,
         b: &'static str,
-    };
+    }
     let mut gr = Graph::new();
     let a = gr.add_node(Record { a: 1, b: r"abc\" });
     gr.add_edge(a, a, (1, 2));

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -3,13 +3,13 @@ extern crate petgraph;
 #[macro_use]
 extern crate defmac;
 
-use petgraph::adj::{List, UnweightedList};
-use petgraph::prelude::*;
 use petgraph::adj::DefaultIx;
 use petgraph::adj::IndexType;
+use petgraph::adj::{List, UnweightedList};
 use petgraph::algo::tarjan_scc;
 use petgraph::data::{DataMap, DataMapMut};
 use petgraph::dot::Dot;
+use petgraph::prelude::*;
 use petgraph::visit::{
     IntoEdgeReferences, IntoEdges, IntoNeighbors, IntoNodeReferences, NodeCount, NodeIndexable,
 };


### PR DESCRIPTION
The CI jobs to check rustfmt are all failing. To fix this, this commit
just runs 'cargo fmt' on the repo using the latest stable release of
rust, 1.50.0 to fix this ci job.