### PR TITLE
Fixed miri stacked borrow violation

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -441,8 +441,9 @@ fn index_twice<T>(slc: &mut [T], a: usize, b: usize) -> Pair<&mut T> {
     } else {
         // safe because a, b are in bounds and distinct
         unsafe {
-            let ar = &mut *(slc.get_unchecked_mut(a) as *mut _);
-            let br = &mut *(slc.get_unchecked_mut(b) as *mut _);
+            let ptr = slc.as_mut_ptr();
+            let ar = &mut *ptr.offset(a as isize);
+            let br = &mut *ptr.offset(b as isize);
             Pair::Both(ar, br)
         }
     }


### PR DESCRIPTION
In my project, I found this bug with miri.
Can be reproduced in petgraph repo with `cargo +nightly miri test -- dot::test::test_edgeindexlable_option`
To be sure, I asked this at the miri repo: https://github.com/rust-lang/miri/issues/1747