### PR TITLE
Modified Tarjan SCC to reduce memory usage.

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -387,7 +387,10 @@ impl<N> TarjanScc<N> {
             .resize(g.node_bound(), NodeData { rootindex: None });
 
         for n in g.node_identifiers() {
-            self.visit(n, g, &mut f);
+            let visited = self.nodes[g.to_index(n)].rootindex.is_some();
+            if !visited {
+                self.visit(n, g, &mut f);
+            }
         }
 
         debug_assert!(self.stack.is_empty());
@@ -406,10 +409,7 @@ impl<N> TarjanScc<N> {
         }
 
         let node_v = &mut node![v];
-        if node_v.rootindex.is_some() {
-            // already visited
-            return;
-        }
+        debug_assert!(node_v.rootindex.is_none());
 
         let mut v_is_local_root = true;
         let v_index = self.index;
@@ -417,7 +417,9 @@ impl<N> TarjanScc<N> {
         self.index += 1;
 
         for w in g.neighbors(v) {
-            self.visit(w, g, f);
+            if node![w].rootindex.is_none() {
+                self.visit(w, g, f);
+            }
             if node![w].rootindex < node![v].rootindex {
                 node![v].rootindex = node![w].rootindex;
                 v_is_local_root = false

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -329,7 +329,7 @@ where
 
 #[derive(Copy, Clone, Debug)]
 struct NodeData {
-    rootindex: Option<usize>
+    rootindex: Option<usize>,
 }
 
 /// A reusable state for computing the *strongly connected components* using [Tarjan's algorithm][1].
@@ -349,12 +349,11 @@ impl<N> Default for TarjanScc<N> {
     }
 }
 
-
 impl<N> TarjanScc<N> {
     /// Creates a new `TarjanScc`
     pub fn new() -> Self {
         TarjanScc {
-            index: usize::MAX, // Invariant: index > componentcount at all times.
+            index: std::usize::MAX, // Invariant: index > componentcount at all times.
             componentcount: 0, // Will hold if index is initialized to number of nodes - 1 or higher.
             nodes: Vec::new(),
             stack: Vec::new(),
@@ -379,12 +378,8 @@ impl<N> TarjanScc<N> {
         N: Copy + PartialEq,
     {
         self.nodes.clear();
-        self.nodes.resize(
-            g.node_bound(),
-            NodeData {
-                rootindex: None,
-            },
-        );
+        self.nodes
+            .resize(g.node_bound(), NodeData { rootindex: None });
 
         for n in g.node_identifiers() {
             self.visit(n, g, &mut f);
@@ -417,31 +412,32 @@ impl<N> TarjanScc<N> {
         self.index -= 1;
 
         for w in g.neighbors(v) {
-            self.visit(w,g,f);
+            self.visit(w, g, f);
             if node![w].rootindex > node![v].rootindex {
-                node![v].rootindex =  node![w].rootindex;
+                node![v].rootindex = node![w].rootindex;
                 v_is_local_root = false
             }
         }
 
-        if v_is_local_root { // Pop the stack and generate an SCC.
+        if v_is_local_root {
+            // Pop the stack and generate an SCC.
             let mut indexadjustment = 1;
             let c = Some(self.componentcount);
             let nodes = &mut self.nodes;
             let start = self
                 .stack
                 .iter()
-                .rposition(
-                    |&w| {
-                        if nodes[g.to_index(v)].rootindex < nodes[g.to_index(w)].rootindex {
-                            true
-                        } else {
-                            nodes[g.to_index(w)].rootindex = c;
-                            indexadjustment += 1;
-                            false
-                        }
+                .rposition(|&w| {
+                    if nodes[g.to_index(v)].rootindex < nodes[g.to_index(w)].rootindex {
+                        true
+                    } else {
+                        nodes[g.to_index(w)].rootindex = c;
+                        indexadjustment += 1;
+                        false
                     }
-                ).map(|x| x + 1).unwrap_or_default();
+                })
+                .map(|x| x + 1)
+                .unwrap_or_default();
             nodes[g.to_index(v)].rootindex = c;
             self.stack.push(v); // Pushing the component root to the back right before getting rid of it is somewhat ugly, but it lets it be included in f.
             f(&self.stack[start..]);
@@ -449,12 +445,10 @@ impl<N> TarjanScc<N> {
             self.index += indexadjustment; // Backtrack index back to where it was before we ever encountered the component.
             self.componentcount += 1;
         } else {
-            self.stack.push(v);  // Stack is filled up when backtracking, unlike in Tarjans original algorithm.
+            self.stack.push(v); // Stack is filled up when backtracking, unlike in Tarjans original algorithm.
         }
     }
 }
-
-
 
 /// \[Generic\] Compute the *strongly connected components* using [Tarjan's algorithm][1].
 ///

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -458,8 +458,12 @@ impl<N> TarjanScc<N> {
     {
         let rindex: usize = self.nodes[g.to_index(v)]
             .rootindex
-            .expect("Tried to get the component index of an unvisited node.")
-            .into();
+            .map(NonZeroUsize::get)
+            .unwrap_or(0); // Compiles to no-op.
+        debug_assert!(
+            rindex != 0,
+            "Tried to get the component index of an unvisited node."
+        );
         debug_assert!(
             rindex > self.componentcount,
             "Given node has been visited but not yet assigned to a component."

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -361,9 +361,13 @@ impl<N> TarjanScc<N> {
         }
     }
 
-    /// \[Generic\] Compute the *strongly connected components* using [Tarjan's algorithm][1].
+    /// \[Generic\] Compute the *strongly connected components* using Algorithm 3 in
+    /// [A Space-Efficient Algorithm for Finding Strongly Connected Components][1] by David J. Pierce,
+    /// which is a memory-efficient variation of [Tarjan's algorithm][2].
     ///
-    /// [1]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+    ///
+    /// [1]: https://homepages.ecs.vuw.ac.nz/~djp/files/P05.pdf
+    /// [2]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
     ///
     /// Calls `f` for each strongly strongly connected component (scc).
     /// The order of node ids within each scc is arbitrary, but the order of
@@ -475,6 +479,7 @@ impl<N> TarjanScc<N> {
 /// \[Generic\] Compute the *strongly connected components* using [Tarjan's algorithm][1].
 ///
 /// [1]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+/// [2]: https://homepages.ecs.vuw.ac.nz/~djp/files/P05.pdf
 ///
 /// Return a vector where each element is a strongly connected component (scc).
 /// The order of node ids within each scc is arbitrary, but the order of
@@ -482,7 +487,9 @@ impl<N> TarjanScc<N> {
 ///
 /// For an undirected graph, the sccs are simply the connected components.
 ///
-/// This implementation is recursive and does one pass over the nodes.
+/// This implementation is recursive and does one pass over the nodes. It is based on
+/// [A Space-Efficient Algorithm for Finding Strongly Connected Components][2] by David J. Pierce,
+/// to provide a memory-efficient implementation of [Tarjan's algorithm][1].
 pub fn tarjan_scc<G>(g: G) -> Vec<Vec<G::NodeId>>
 where
     G: IntoNodeIdentifiers + IntoNeighbors + NodeIndexable,


### PR DESCRIPTION
Reduced heap memory usage, improved cache locality, and made the code somewhat cleaner for a possible future rewrite to an imperative implementation. The changes to a more modern version of Tarjan's algorithm were directly based on algorithm 3 in "A Space-Efficient Algorithm for Finding Strongly Connected Components" by David J. Pearce, while also aiming to avoid changing the structure of the code too much.

In addition to saving memory, this version has the property that it builds a lookup
table for the components at the same time as it outputs them. If v belongs to the kth output component, then
` self.nodes[g.to_index(v)] == Some(k) ` . This could be used to save work in
functions that may want to call it such as condensation (where the work needed to make the node map can be completely avoided, while also creating a condensation that is topologically sorted).