### PR TITLE
Add benchmarks for Tarjan's SCC algorithm

### DIFF
--- a/benches/matrix_graph.rs
+++ b/benches/matrix_graph.rs
@@ -198,9 +198,15 @@ fn full_neighbors_in(bench: &mut Bencher) {
 }
 
 #[bench]
-fn full_sccs(bench: &mut Bencher) {
+fn full_kosaraju_sccs(bench: &mut Bencher) {
     let a = parse_matrix::<Directed>(FULL);
     bench.iter(|| algo::kosaraju_scc(&a));
+}
+
+#[bench]
+fn full_tarjan_sccs(bench: &mut Bencher) {
+    let a = parse_matrix::<Directed>(FULL);
+    bench.iter(|| algo::tarjan_scc(&a));
 }
 
 #[bench]
@@ -229,7 +235,13 @@ fn bigger_neighbors_in(bench: &mut Bencher) {
 }
 
 #[bench]
-fn bigger_sccs(bench: &mut Bencher) {
+fn bigger_kosaraju_sccs(bench: &mut Bencher) {
     let a = parse_matrix::<Directed>(BIGGER);
     bench.iter(|| algo::kosaraju_scc(&a));
+}
+
+#[bench]
+fn bigger_tarjan_sccs(bench: &mut Bencher) {
+    let a = parse_matrix::<Directed>(BIGGER);
+    bench.iter(|| algo::tarjan_scc(&a));
 }

--- a/benches/stable_graph.rs
+++ b/benches/stable_graph.rs
@@ -49,15 +49,27 @@ fn neighbors_in(bench: &mut Bencher) {
 }
 
 #[bench]
-fn sccs_stable_graph(bench: &mut Bencher) {
+fn sccs_kosaraju_stable_graph(bench: &mut Bencher) {
     let a = stable_digraph().bigger();
     bench.iter(|| petgraph::algo::kosaraju_scc(&a));
 }
 
 #[bench]
-fn sccs_graph(bench: &mut Bencher) {
+fn sccs_kosaraju_graph(bench: &mut Bencher) {
     let a = digraph().bigger();
     bench.iter(|| petgraph::algo::kosaraju_scc(&a));
+}
+
+#[bench]
+fn sccs_tarjan_stable_graph(bench: &mut Bencher) {
+    let a = stable_digraph().bigger();
+    bench.iter(|| petgraph::algo::tarjan_scc(&a));
+}
+
+#[bench]
+fn sccs_tarjan_graph(bench: &mut Bencher) {
+    let a = digraph().bigger();
+    bench.iter(|| petgraph::algo::tarjan_scc(&a));
 }
 
 #[bench]


### PR DESCRIPTION
Rename the current SCC benchmarks to indicate they are using Kosaraju's algorithm, and add similar benchs for the Tarjan implementation.

The goal is to have a baseline for #413.