### PR TITLE
Fixed broken documentation links for Directed and Undirected enums.

### DIFF
--- a/src/adj.rs
+++ b/src/adj.rs
@@ -141,15 +141,15 @@ iterator_wrap! {
 /// Can be interpreted as a directed graph
 /// with unweighted nodes.
 ///
-/// This is the most simple adjacency list you can imagine. `Graph`, in contrast,
+/// This is the most simple adjacency list you can imagine. [`Graph`](../graph/struct.Graph.html), in contrast,
 /// maintains both the list of successors and predecessors for each node,
 /// which is a different trade-off.
 ///
 /// Allows parallel edges and self-loops.
 ///
-/// This data structure is append-only (except for [`clear`]), so indices
+/// This data structure is append-only (except for [`clear`](#method.clear)), so indices
 /// returned at some point for a given graph will stay valid with this same
-/// graph until it is dropped or [`clear`] is called.
+/// graph until it is dropped or [`clear`](#method.clear) is called.
 ///
 /// Space consumption: **O(|E|)**.
 #[derive(Clone, Default)]

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -95,10 +95,9 @@ where
         }
     }
 
-    /// Create a new [`Csr`] with `n` nodes. `N` must implement [`Default`] for the weight of each node.
+    /// Create a new `Csr` with `n` nodes. `N` must implement [`Default`] for the weight of each node.
     ///
     /// [`Default`]: https://doc.rust-lang.org/nightly/core/default/trait.Default.html
-    /// [`Csr`]: #struct.Csr.html
     ///
     /// # Example
     /// ```rust

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1905,7 +1905,7 @@ where
     }
 }
 
-/// A  `GraphIndex` is a node or edge index.
+/// A `GraphIndex` is a node or edge index.
 pub trait GraphIndex: Copy {
     #[doc(hidden)]
     fn index(&self) -> usize;
@@ -1915,10 +1915,12 @@ pub trait GraphIndex: Copy {
 
 impl<Ix: IndexType> GraphIndex for NodeIndex<Ix> {
     #[inline]
+    #[doc(hidden)]
     fn index(&self) -> usize {
         NodeIndex::index(*self)
     }
     #[inline]
+    #[doc(hidden)]
     fn is_node_index() -> bool {
         true
     }
@@ -1926,10 +1928,12 @@ impl<Ix: IndexType> GraphIndex for NodeIndex<Ix> {
 
 impl<Ix: IndexType> GraphIndex for EdgeIndex<Ix> {
     #[inline]
+    #[doc(hidden)]
     fn index(&self) -> usize {
         EdgeIndex::index(*self)
     }
     #[inline]
+    #[doc(hidden)]
     fn is_node_index() -> bool {
         false
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,8 @@
 //! [`GraphMap`](./graphmap/struct.GraphMap.html) requires node weights that can serve as hash
 //! map keys, since that graph type does not create standalone node indices.
 //!
-//! `Ty` controls whether edges are [`Directed`](./petgraph/enum.Directed.html) or
-//! [`Undirected`](./petgraph/enum.Unirected.html).
+//! `Ty` controls whether edges are [`Directed`](./enum.Directed.html) or
+//! [`Undirected`](./enum.Undirected.html).
 //!
 //! `Ix` appears on graph types that use indices. It is exposed so you can control
 //! the size of node and edge indices, and therefore the memory footprint of your graphs.

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -94,18 +94,22 @@ impl<T: Zero> Default for NotZero<T> {
 }
 
 impl<T: Zero> Nullable for NotZero<T> {
+    #[doc(hidden)]
     type Wrapped = T;
 
+    #[doc(hidden)]
     fn new(value: T) -> Self {
         assert!(!value.is_zero());
         NotZero(value)
     }
 
     // implemented here for optimization purposes
+    #[doc(hidden)]
     fn is_null(&self) -> bool {
         self.0.is_zero()
     }
 
+    #[doc(hidden)]
     fn as_ref(&self) -> Option<&Self::Wrapped> {
         if !self.is_null() {
             Some(&self.0)
@@ -114,6 +118,7 @@ impl<T: Zero> Nullable for NotZero<T> {
         }
     }
 
+    #[doc(hidden)]
     fn as_mut(&mut self) -> Option<&mut Self::Wrapped> {
         if !self.is_null() {
             Some(&mut self.0)


### PR DESCRIPTION
I'm not sure if there's an automated way to test for broken documentation links, as I'm new to Rust, so I've verified locally using `cargo doc --open`. 

Thanks for the crate all the same. I was tearing my hair out trying to figure out how to work with graphs.