### PR TITLE
Fix various bugs in matrix graph

### DIFF
--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -853,8 +853,19 @@ fn extend_flat_square_matrix<T: Default>(
         let pos = c * old_node_capacity;
         let new_pos = c * new_node_capacity;
 
-        for i in 0..old_node_capacity {
-            node_adjacencies.as_mut_slice().swap(pos + i, new_pos + i);
+        // Move the slices directly if the directions are non overlapping
+        if pos + old_node_capacity <= new_pos {
+            let old = node_adjacencies[pos..pos + old_node_capacity].as_mut_ptr();
+            let new = node_adjacencies[new_pos..new_pos + old_node_capacity].as_mut_ptr();
+
+            // SAFE: new starts at least `old_node_capacity` after old.
+            unsafe {
+                std::ptr::swap_nonoverlapping(old, new, old_node_capacity);
+            }
+        } else {
+            for i in 0..old_node_capacity {
+                node_adjacencies.as_mut_slice().swap(pos + i, new_pos + i);
+            }
         }
     }
 

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -230,14 +230,23 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         };
 
         debug_assert!(node_capacity <= <Ix as IndexType>::max().index());
-        m.extend_capacity_for_node(NodeIndex::new(node_capacity));
+        if node_capacity > 0 {
+            m.extend_capacity_for_node(NodeIndex::new(node_capacity - 1));
+        }
 
         m
     }
 
     #[inline]
-    fn to_edge_position(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> usize {
-        to_linearized_matrix_position::<Ty>(a.index(), b.index(), self.node_capacity)
+    fn to_edge_position(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<usize> {
+        if a.index() >= self.node_capacity || b.index() >= self.node_capacity {
+            return None;
+        }
+        Some(to_linearized_matrix_position::<Ty>(
+            a.index(),
+            b.index(),
+            self.node_capacity,
+        ))
     }
 
     /// Remove all nodes and edges.
@@ -290,11 +299,15 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     pub fn remove_node(&mut self, a: NodeIndex<Ix>) -> N {
         for id in self.nodes.iter_ids() {
             let position = self.to_edge_position(a, NodeIndex::new(id));
-            self.node_adjacencies[position] = Default::default();
+            if let Some(pos) = position {
+                self.node_adjacencies[pos] = Default::default();
+            }
 
             if Ty::is_directed() {
                 let position = self.to_edge_position(NodeIndex::new(id), a);
-                self.node_adjacencies[position] = Default::default();
+                if let Some(pos) = position {
+                    self.node_adjacencies[pos] = Default::default();
+                }
             }
         }
 
@@ -306,7 +319,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         self.node_capacity = extend_linearized_matrix::<Ty, _>(
             &mut self.node_adjacencies,
             self.node_capacity,
-            min_node.index(),
+            min_node.index() + 1,
         );
     }
 
@@ -328,8 +341,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     /// **Panics** if any of the nodes don't exist.
     pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> Option<E> {
         self.extend_capacity_for_edge(a, b);
-
-        let p = self.to_edge_position(a, b);
+        let p = self.to_edge_position(a, b).unwrap();
         let old_weight = mem::replace(&mut self.node_adjacencies[p], Null::new(weight));
         if old_weight.is_null() {
             self.nb_edges += 1;
@@ -360,7 +372,9 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     /// **Panics** if any of the nodes don't exist.
     /// **Panics** if no edge exists between `a` and `b`.
     pub fn remove_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> E {
-        let p = self.to_edge_position(a, b);
+        let p = self
+            .to_edge_position(a, b)
+            .expect("No edge found between the nodes.");
         let old_weight = mem::replace(&mut self.node_adjacencies[p], Default::default())
             .into()
             .unwrap();
@@ -373,8 +387,10 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     ///
     /// **Panics** if any of the nodes don't exist.
     pub fn has_edge(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
-        let p = self.to_edge_position(a, b);
-        !self.node_adjacencies[p].is_null()
+        if let Some(p) = self.to_edge_position(a, b) {
+            return !self.node_adjacencies[p].is_null();
+        }
+        false
     }
 
     /// Access the weight for node `a`.
@@ -401,8 +417,12 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     ///
     /// **Panics** if no edge exists between `a` and `b`.
     pub fn edge_weight(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> &E {
-        let p = self.to_edge_position(a, b);
-        self.node_adjacencies[p].as_ref().unwrap()
+        let p = self
+            .to_edge_position(a, b)
+            .expect("No edge found between the nodes.");
+        self.node_adjacencies[p]
+            .as_ref()
+            .expect("No edge found between the nodes.")
     }
 
     /// Access the weight for edge `e`, mutably.
@@ -411,8 +431,12 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     ///
     /// **Panics** if no edge exists between `a` and `b`.
     pub fn edge_weight_mut(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> &mut E {
-        let p = self.to_edge_position(a, b);
-        self.node_adjacencies[p].as_mut().unwrap()
+        let p = self
+            .to_edge_position(a, b)
+            .expect("No edge found between the nodes.");
+        self.node_adjacencies[p]
+            .as_mut()
+            .expect("No edge found between the nodes.")
     }
 
     /// Return an iterator of all nodes with an edge starting from `a`.
@@ -784,12 +808,15 @@ fn to_linearized_matrix_position<Ty: EdgeType>(row: usize, column: usize, width:
 fn extend_linearized_matrix<Ty: EdgeType, T: Default>(
     node_adjacencies: &mut Vec<T>,
     old_node_capacity: usize,
-    min_node_capacity: usize,
+    new_capacity: usize,
 ) -> usize {
+    if old_node_capacity >= new_capacity {
+        return old_node_capacity;
+    }
     if Ty::is_directed() {
-        extend_flat_square_matrix(node_adjacencies, old_node_capacity, min_node_capacity)
+        extend_flat_square_matrix(node_adjacencies, old_node_capacity, new_capacity)
     } else {
-        extend_lower_triangular_matrix(node_adjacencies, min_node_capacity)
+        extend_lower_triangular_matrix(node_adjacencies, new_capacity)
     }
 }
 
@@ -802,29 +829,24 @@ fn to_flat_square_matrix_position(row: usize, column: usize, width: usize) -> us
 fn extend_flat_square_matrix<T: Default>(
     node_adjacencies: &mut Vec<T>,
     old_node_capacity: usize,
-    min_node_capacity: usize,
+    new_node_capacity: usize,
 ) -> usize {
-    let min_node_capacity = (min_node_capacity + 1).next_power_of_two();
+    let new_node_capacity = new_node_capacity.next_power_of_two();
 
     // Optimization: when resizing the matrix this way we skip the first few grows to make
     // small matrices a bit faster to work with.
     const MIN_CAPACITY: usize = 4;
-    let new_node_capacity = cmp::max(min_node_capacity, MIN_CAPACITY);
+    let new_node_capacity = cmp::max(new_node_capacity, MIN_CAPACITY);
 
-    let mut new_node_adjacencies = vec![];
-    ensure_len(&mut new_node_adjacencies, new_node_capacity.pow(2));
-
-    for c in 0..old_node_capacity {
+    ensure_len(node_adjacencies, new_node_capacity.pow(2));
+    for c in (0..old_node_capacity).rev() {
         let pos = c * old_node_capacity;
         let new_pos = c * new_node_capacity;
 
-        let mut old = &mut node_adjacencies[pos..pos + old_node_capacity];
-        let mut new = &mut new_node_adjacencies[new_pos..new_pos + old_node_capacity];
-
-        mem::swap(&mut old, &mut new);
+        for i in 0..old_node_capacity {
+            node_adjacencies.as_mut_slice().swap(pos + i, new_pos + i);
+        }
     }
-
-    mem::swap(node_adjacencies, &mut new_node_adjacencies);
 
     new_node_capacity
 }
@@ -842,11 +864,12 @@ fn to_lower_triangular_matrix_position(row: usize, column: usize) -> usize {
 #[inline]
 fn extend_lower_triangular_matrix<T: Default>(
     node_adjacencies: &mut Vec<T>,
-    new_node_capacity: usize,
+    new_capacity: usize,
 ) -> usize {
-    let max_pos = to_lower_triangular_matrix_position(new_node_capacity, new_node_capacity);
+    let max_node = new_capacity - 1;
+    let max_pos = to_lower_triangular_matrix_position(max_node, max_node);
     ensure_len(node_adjacencies, max_pos + 1);
-    new_node_capacity + 1
+    new_capacity
 }
 
 /// Grow a Vec by appending the type's default value until the `size` is reached.
@@ -1277,6 +1300,27 @@ mod tests {
         g.add_edge(b, c, ());
         assert_eq!(g.node_count(), 3);
         assert_eq!(g.edge_count(), 2);
+    }
+
+    #[test]
+    /// Adds an edge that triggers a second extension of the matrix.
+    /// From #425
+    fn test_add_edge_with_extension() {
+        let mut g = DiMatrix::<u8, ()>::new();
+        let _n0 = g.add_node(0);
+        let n1 = g.add_node(1);
+        let n2 = g.add_node(2);
+        let n3 = g.add_node(3);
+        let n4 = g.add_node(4);
+        let _n5 = g.add_node(5);
+        g.add_edge(n2, n1, ());
+        g.add_edge(n2, n3, ());
+        g.add_edge(n2, n4, ());
+        assert_eq!(g.node_count(), 6);
+        assert_eq!(g.edge_count(), 3);
+        assert!(g.has_edge(n2, n1));
+        assert!(g.has_edge(n2, n3));
+        assert!(g.has_edge(n2, n4));
     }
 
     #[test]


### PR DESCRIPTION
I made multiple changes and fixes to `MatrixGraph`:

1. The routine for extending the adjacency matrix for directed graphs created a new matrix and tried to copy the data doing a `mem::swap` of references to slices, which was effectively a no-op so the adjacencies were lost.
I changed it to inplace by-element `slice::swap`s which surprisingly seem to be faster than what was there before. This fixes #425.
I tried a version that uses an unsafe `ptr::swap_nonoverlapping` when possible in https://github.com/ABorgna/petgraph/commit/877edbdac2807ab336078b11cd9941564a347fba and it had around 15% better performance in resize-heavy tests.

4. Many functions didn't check the adjacency matrix capacity before looking for a node data.
  This was masked in the tests due to `new` always reserving a 4x4 matrix.

3. I renamed the new capacity parameter in the extension functions to avoid confusions (was `min_node`).

5. I made `with_capacity` reserve the exact value passed instead of rounding to the next power of two, to avoid quadratic wastage.

Benchmarks:

```
 name                               base ns/iter  fixed ns/iter  diff ns/iter   diff %  speedup
 add_100_edges_to_self              426           282                    -144  -33.80%   x 1.51
 add_100_nodes                      19,950        12,841               -7,109  -35.63%   x 1.55
 add_5_edges_for_each_of_100_nodes  1,060         904                    -156  -14.72%   x 1.17
 add_adjacent_edges                 27,491        24,965               -2,526   -9.19%   x 1.10
 add_edges_from_root                27,372        25,196               -2,176   -7.95%   x 1.09
 bigger_edges_in                    35            36                        1    2.86%   x 0.97
 bigger_edges_out                   31            35                        4   12.90%   x 0.89
 bigger_kosaraju_sccs               5,272         5,083                  -189   -3.58%   x 1.04
 bigger_neighbors_in                36            36                        0    0.00%   x 1.00
 bigger_neighbors_out               32            35                        3    9.38%   x 0.91
 bigger_tarjan_sccs                 2,779         2,731                   -48   -1.73%   x 1.02
 full_edges_in                      14            15                        1    7.14%   x 0.93
 full_edges_out                     13            13                        0    0.00%   x 1.00
 full_kosaraju_sccs                 953           991                      38    3.99%   x 0.96
 full_neighbors_in                  14            15                        1    7.14%   x 0.93
 full_neighbors_out                 13            13                        0    0.00%   x 1.00
 full_tarjan_sccs                   435           442                       7    1.61%   x 0.98
```