### PR TITLE
Implement multiple missing graph traits

### DIFF
--- a/src/csr.rs
+++ b/src/csr.rs
@@ -779,7 +779,7 @@ where
 
 impl<'a, N, Ix> ExactSizeIterator for NodeReferences<'a, N, Ix> where Ix: IndexType {}
 
-/// The adjacency matrix for **List** is a bitmap that's computed by
+/// The adjacency matrix for **Csr** is a bitmap that's computed by
 /// `.adjacency_matrix()`.
 impl<'a, N, E, Ty, Ix> GetAdjacencyMatrix for &'a Csr<N, E, Ty, Ix>
 where

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -6,9 +6,11 @@ use std::marker::PhantomData;
 use std::ops::{Index, IndexMut, Range};
 use std::slice::Windows;
 
-use crate::visit::{Data, GraphProp, IntoEdgeReferences, NodeCount};
-use crate::visit::{EdgeRef, GraphBase, IntoEdges, IntoNeighbors, NodeIndexable};
-use crate::visit::{IntoNodeIdentifiers, NodeCompactIndexable, Visitable};
+use crate::visit::{
+    Data, EdgeRef, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+    IntoNeighbors, IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeCount,
+    NodeIndexable, Visitable,
+};
 
 use crate::util::zip;
 
@@ -727,6 +729,85 @@ where
     type EdgeType = Ty;
 }
 
+impl<'a, N, E, Ty, Ix> IntoNodeReferences for &'a Csr<N, E, Ty, Ix>
+where
+    Ty: EdgeType,
+    Ix: IndexType,
+{
+    type NodeRef = (NodeIndex<Ix>, &'a N);
+    type NodeReferences = NodeReferences<'a, N, Ix>;
+    fn node_references(self) -> Self::NodeReferences {
+        NodeReferences {
+            iter: self.node_weights.iter().enumerate(),
+            ty: PhantomData,
+        }
+    }
+}
+
+/// Iterator over all nodes of a graph.
+#[derive(Debug, Clone)]
+pub struct NodeReferences<'a, N: 'a, Ix: IndexType = DefaultIx> {
+    iter: Enumerate<SliceIter<'a, N>>,
+    ty: PhantomData<Ix>,
+}
+
+impl<'a, N, Ix> Iterator for NodeReferences<'a, N, Ix>
+where
+    Ix: IndexType,
+{
+    type Item = (NodeIndex<Ix>, &'a N);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|(i, weight)| (Ix::new(i), weight))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'a, N, Ix> DoubleEndedIterator for NodeReferences<'a, N, Ix>
+where
+    Ix: IndexType,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next_back()
+            .map(|(i, weight)| (Ix::new(i), weight))
+    }
+}
+
+impl<'a, N, Ix> ExactSizeIterator for NodeReferences<'a, N, Ix> where Ix: IndexType {}
+
+/// The adjacency matrix for **List** is a bitmap that's computed by
+/// `.adjacency_matrix()`.
+impl<'a, N, E, Ty, Ix> GetAdjacencyMatrix for &'a Csr<N, E, Ty, Ix>
+where
+    Ix: IndexType,
+    Ty: EdgeType,
+{
+    type AdjMatrix = FixedBitSet;
+
+    fn adjacency_matrix(&self) -> FixedBitSet {
+        let n = self.node_count();
+        let mut matrix = FixedBitSet::with_capacity(n * n);
+        for edge in self.edge_references() {
+            let i = edge.source().index() * n + edge.target().index();
+            matrix.put(i);
+
+            let j = edge.source().index() + n * edge.target().index();
+            matrix.put(j);
+        }
+        matrix
+    }
+
+    fn is_adjacent(&self, matrix: &FixedBitSet, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
+        let n = self.edge_count();
+        let index = n * a.index() + b.index();
+        matrix.contains(index)
+    }
+}
+
 /*
  *
 Example
@@ -985,5 +1066,20 @@ mod tests {
         assert_eq!(g.neighbors_slice(c), &[]);
 
         assert_eq!(g.edge_count(), 1);
+    }
+
+    #[test]
+    fn test_node_references() {
+        use crate::visit::IntoNodeReferences;
+        let mut g: Csr<u32> = Csr::new();
+        g.add_node(42);
+        g.add_node(3);
+        g.add_node(44);
+
+        let mut refs = g.node_references();
+        assert_eq!(refs.next(), Some((0, &42)));
+        assert_eq!(refs.next(), Some((1, &3)));
+        assert_eq!(refs.next(), Some((2, &44)));
+        assert_eq!(refs.next(), None);
     }
 }

--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -5,10 +5,8 @@ use crate::data::{DataMap, DataMapMut};
 use crate::graph::Graph;
 use crate::graph::{GraphIndex, IndexType};
 use crate::visit::{
-    Data, EdgeIndexable, GraphProp, IntoNeighborsDirected, IntoNodeIdentifiers, NodeIndexable,
-};
-use crate::visit::{
-    GetAdjacencyMatrix, IntoEdges, IntoEdgesDirected, NodeCompactIndexable, NodeCount,
+    Data, EdgeCount, EdgeIndexable, GetAdjacencyMatrix, GraphProp, IntoEdges, IntoEdgesDirected,
+    IntoNeighborsDirected, IntoNodeIdentifiers, NodeCompactIndexable, NodeCount, NodeIndexable,
 };
 use crate::visit::{IntoEdgeReferences, IntoNeighbors, IntoNodeReferences, Visitable};
 use crate::{Direction, EdgeType};
@@ -94,6 +92,7 @@ IntoNodeReferences! {delegate_impl [['a, 'b, G], G, &'b Frozen<'a, G>, deref_twi
 NodeCompactIndexable! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 NodeCount! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 NodeIndexable! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
+EdgeCount! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 EdgeIndexable! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 GraphProp! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}
 Visitable! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -13,7 +13,7 @@ use crate::iter_format::{DebugMap, IterFormatExt, NoPretty};
 
 use crate::util::enumerate;
 use crate::visit::EdgeRef;
-use crate::visit::{IntoEdges, IntoEdgesDirected, IntoNodeReferences};
+use crate::visit::{EdgeIndexable, IntoEdges, IntoEdgesDirected, IntoNodeReferences};
 
 #[cfg(feature = "serde-1")]
 mod serialization;
@@ -2243,6 +2243,24 @@ where
 }
 
 impl<'a, E, Ix> ExactSizeIterator for EdgeReferences<'a, E, Ix> where Ix: IndexType {}
+
+impl<N, E, Ty, Ix> EdgeIndexable for Graph<N, E, Ty, Ix>
+where
+    Ty: EdgeType,
+    Ix: IndexType,
+{
+    fn edge_bound(&self) -> usize {
+        self.edge_count()
+    }
+
+    fn to_index(&self, ix: EdgeIndex<Ix>) -> usize {
+        ix.index()
+    }
+
+    fn from_index(&self, ix: usize) -> Self::EdgeId {
+        EdgeIndex::new(ix)
+    }
+}
 
 mod frozen;
 #[cfg(feature = "stable_graph")]

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -15,9 +15,9 @@ use crate::{Directed, Direction, EdgeType, IntoWeightedEdge, Outgoing, Undirecte
 use crate::graph::NodeIndex as GraphNodeIndex;
 
 use crate::visit::{
-    Data, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges, IntoNeighbors,
-    IntoNeighborsDirected, IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable,
-    NodeCount, NodeIndexable, Visitable,
+    Data, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+    IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
+    IntoNodeReferences, NodeCount, NodeIndexable, Visitable,
 };
 
 use crate::data::Build;
@@ -344,8 +344,6 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
 
     /// Add an edge from `a` to `b` to the graph, with its associated
     /// data `weight`.
-    ///
-    /// Return the index of the new edge.
     ///
     /// Computes in **O(1)** time, best case.
     /// Computes in **O(|V|^2)** time, worst case (matrix needs to be re-allocated).
@@ -1171,6 +1169,16 @@ impl<'a, N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> IntoEdg
     }
 }
 
+impl<'a, N, E, Null: Nullable<Wrapped = E>, Ix: IndexType> IntoEdgesDirected
+    for &'a MatrixGraph<N, E, Directed, Null, Ix>
+{
+    type EdgesDirected = Edges<'a, Directed, Null, Ix>;
+
+    fn edges_directed(self, a: Self::NodeId, dir: Direction) -> Self::EdgesDirected {
+        MatrixGraph::edges_directed(self, a, dir)
+    }
+}
+
 impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> NodeIndexable
     for MatrixGraph<N, E, Ty, Null, Ix>
 {
@@ -1185,11 +1193,6 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> NodeIndexab
     fn from_index(&self, ix: usize) -> Self::NodeId {
         NodeIndex::new(ix)
     }
-}
-
-impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> NodeCompactIndexable
-    for MatrixGraph<N, E, Ty, Null, Ix>
-{
 }
 
 impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> Build

--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -7,9 +7,9 @@ use std::marker::PhantomData;
 use crate::data::DataMap;
 use crate::visit::{Data, NodeCompactIndexable, NodeCount};
 use crate::visit::{
-    GraphBase, GraphProp, IntoEdgeReferences, IntoEdges, IntoEdgesDirected, IntoNeighbors,
-    IntoNeighborsDirected, IntoNodeIdentifiers, IntoNodeReferences, NodeIndexable, NodeRef,
-    VisitMap, Visitable,
+    EdgeIndexable, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges, IntoEdgesDirected,
+    IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, IntoNodeReferences, NodeIndexable,
+    NodeRef, VisitMap, Visitable,
 };
 
 /// A graph filter for nodes.
@@ -339,6 +339,7 @@ macro_rules! access0 {
 
 Data! {delegate_impl [[G, F], G, NodeFiltered<G, F>, access0]}
 NodeIndexable! {delegate_impl [[G, F], G, NodeFiltered<G, F>, access0]}
+EdgeIndexable! {delegate_impl [[G, F], G, NodeFiltered<G, F>, access0]}
 GraphProp! {delegate_impl [[G, F], G, NodeFiltered<G, F>, access0]}
 Visitable! {delegate_impl [[G, F], G, NodeFiltered<G, F>, access0]}
 
@@ -569,4 +570,5 @@ IntoNodeReferences! {delegate_impl [['a, G, F], G, &'a EdgeFiltered<G, F>, acces
 NodeCompactIndexable! {delegate_impl [[G, F], G, EdgeFiltered<G, F>, access0]}
 NodeCount! {delegate_impl [[G, F], G, EdgeFiltered<G, F>, access0]}
 NodeIndexable! {delegate_impl [[G, F], G, EdgeFiltered<G, F>, access0]}
+EdgeIndexable! {delegate_impl [[G, F], G, EdgeFiltered<G, F>, access0]}
 Visitable! {delegate_impl [[G, F], G, EdgeFiltered<G, F>, access0]}

--- a/src/visit/reversed.rs
+++ b/src/visit/reversed.rs
@@ -1,9 +1,10 @@
 use crate::{Direction, Incoming};
 
 use crate::visit::{
-    Data, EdgeRef, GraphBase, GraphProp, GraphRef, IntoEdgeReferences, IntoEdges,
-    IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
-    IntoNodeReferences, NodeCompactIndexable, NodeCount, NodeIndexable, Visitable,
+    Data, EdgeCount, EdgeIndexable, EdgeRef, GetAdjacencyMatrix, GraphBase, GraphProp, GraphRef,
+    IntoEdgeReferences, IntoEdges, IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected,
+    IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeCount, NodeIndexable,
+    Visitable,
 };
 
 /// An edge-reversing graph adaptor.
@@ -178,3 +179,6 @@ IntoNodeIdentifiers! {delegate_impl [[G], G, Reversed<G>, access0]}
 IntoNodeReferences! {delegate_impl [[G], G, Reversed<G>, access0]}
 GraphProp! {delegate_impl [[G], G, Reversed<G>, access0]}
 NodeCount! {delegate_impl [[G], G, Reversed<G>, access0]}
+EdgeCount! {delegate_impl [[G], G, Reversed<G>, access0]}
+EdgeIndexable! {delegate_impl [[G], G, Reversed<G>, access0]}
+GetAdjacencyMatrix! {delegate_impl [[G], G, Reversed<G>, access0]}

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -61,6 +61,35 @@ fn simple() {
 }
 
 #[test]
+fn edges_directed() {
+    let mut gr = DiGraphMap::new();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    let e = gr.add_node("E");
+    let f = gr.add_node("F");
+    gr.add_edge(a, b, 7);
+    gr.add_edge(a, c, 9);
+    gr.add_edge(a, d, 14);
+    gr.add_edge(b, c, 10);
+    gr.add_edge(c, d, 2);
+    gr.add_edge(d, e, 9);
+    gr.add_edge(b, f, 15);
+    gr.add_edge(c, f, 11);
+
+    let mut edges_out = gr.edges_directed(c, Direction::Outgoing);
+    assert_eq!(edges_out.next(), Some((c, d, &2)));
+    assert_eq!(edges_out.next(), Some((c, f, &11)));
+    assert_eq!(edges_out.next(), None);
+
+    let mut edges_in = gr.edges_directed(c, Direction::Incoming);
+    assert_eq!(edges_in.next(), Some((a, c, &9)));
+    assert_eq!(edges_in.next(), Some((b, c, &10)));
+    assert_eq!(edges_in.next(), None);
+}
+
+#[test]
 fn remov() {
     let mut g = UnGraphMap::new();
     g.add_node(1);

--- a/tests/iso.rs
+++ b/tests/iso.rs
@@ -4,8 +4,6 @@ use std::fs::File;
 use std::io::prelude::*;
 
 use petgraph::graph::{edge_index, node_index};
-#[cfg(feature = "matrix_graph")]
-use petgraph::matrix_graph::MatrixGraph;
 use petgraph::prelude::*;
 use petgraph::EdgeType;
 
@@ -485,14 +483,6 @@ fn iso_multigraph_failure() {
 
     let g1 = Graph::<(), ()>::from_edges(&[(0, 0), (0, 1), (0, 1), (1, 1), (1, 0), (1, 0)]);
     assert!(!is_isomorphic(&g0, &g1));
-}
-
-#[test]
-#[cfg(feature = "matrix_graph")]
-fn iso_graph_matrixgraph() {
-    let g0 = Graph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 0)]);
-    let g1 = MatrixGraph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 0)]);
-    assert!(is_isomorphic(&g0, &g1));
 }
 
 #[test]


### PR DESCRIPTION
This PR implements various missing traits in graphs and adaptors.
In the following table, previously implemented traits are marked with an `x`, and new ones as `added`:

|                       | Graph | StableGraph | GraphMap | MatrixGraph | Csr   | List  |
| ----------------- | ------- | ---------------- | --------------- | --------------- | ------ | ------ |
| GraphBase             | x     | x           |    x     | x           | x     |  x    |
| GraphProp             | x     | x           |    x     | x           | x     |  x    |
| NodeCount             | x     | x           |    x     | x           | x     |  x    |
| NodeIndexable         | x     | x           |    x     | x           | x     |  x    |
| NodeCompactIndexable  | x     |             |    x     | removed     | x     |  x    |
| EdgeCount             | x     |  x          |    x     | x           | x     | added |
| EdgeIndexable         | added |  x          |  added   |             |       |       |
| Data                  | x     |  x          |    x     | x           | x     |  x    |
| IntoNodeIdentifiers   | x     |  x          |    x     | x           | x     |  x    |
| IntoNodeReferences    | x     |  x          |    x     | x           | added |  x    |
| IntoEdgeReferences    | x     |  x          |    x     | x           | x     |  x    |
| IntoNeighbors         | x     |  x          |    x     | x           | x     |  x    |
| IntoNeighborsDirected | x     |  x          |    x     | x           |    |       |
| IntoEdges             | x     |  x          |    x     | x           | x     |  x    |
| IntoEdgesDirected     | x     |  x          |    added | added           |    |       |
| Visitable             | x     |  x          |    x     | x           | x     |  x    |
| GetAdjacencyMatrix    | x     |  x          |    x     | x           | added | added |

And for the adapters:

|                       | Frozen | EdgeFiltered | NodeFiltered | Reversed |
| ----------------- | ------- | ----------------- | ----------------- | ------------- |
| GraphBase             |   x    |       x      |      x       |    x     |
| GraphProp             |   x    |       x      |      x       |    x     |
| NodeCount             |   x    |       x      |              |    x     |
| NodeIndexable         |   x    |       x      |      x       |    x     |
| NodeCompactIndexable  |   x    |       x      |              |    x     |
| EdgeCount             | added  |              |              | added    |
| EdgeIndexable         |   x    | added        | added        | added    |
| Data                  |   x    |       x      |       x      |    x     |
| IntoNodeIdentifiers   |   x    |       x      |       x      |    x     |
| IntoNodeReferences    |   x    |       x      |       x      |    x     |
| IntoEdgeReferences    |   x    |       x      |       x      |    x     |
| IntoNeighbors         |   x    |       x      |       x      |    x     |
| IntoNeighborsDirected |   x    |       x      |       x      |    x     |
| IntoEdges             |   x    |       x      |       x      |    x     |
| IntoEdgesDirected     |   x    |       x      |       x      |    x     |
| Visitable             |   x    |       x      |       x      |    x     |
| GetAdjacencyMatrix    |   x    |           |              | added    |

Notice that I removed the implementation of `NodeCompactIndexable` for `MatrixGraph`. That's because the graph's node indices are not compact and therefore any code using it as such is silently broken. This is a breaking change that makes that into a hard compilation error.

The trait implementations are all over the place; some in the graph modules, some in `visit`, and a couple in `trait_graph`.
I'd like to move everything to where the graphs are defined to make it consistent, but I'll submit that as another PR to keep the diff noise out of this one.