### PR TITLE
Fix double assigment in bellman_ford algo

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -832,7 +832,6 @@ where
         let mut did_update = false;
         for i in g.node_identifiers() {
             for edge in g.edges(i) {
-                let i = edge.source();
                 let j = edge.target();
                 let w = *edge.weight();
                 if distance[ix(i)] + w < distance[ix(j)] {


### PR DESCRIPTION
No big deal but i think the `i` removed here is not needed as it is populated before in `for i in g.node_identifiers()`