### PR TITLE
Specify that IntoEdges must have `a` as source

### DIFF
--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -219,7 +219,7 @@ trait_template! {
 /// The edges are, depending on the graph’s edge type:
 ///
 /// - `Directed`: All edges from `a`.
-/// - `Undirected`: All edges connected to `a`.
+/// - `Undirected`: All edges connected to `a`, with `a` being the source of each edge.
 ///
 /// This is an extended version of the trait `IntoNeighbors`; the former
 /// only iterates over the target node identifiers, while this trait


### PR DESCRIPTION
`IntoEdges::edges` did not require the passed node to be the source of the returned edges when the graph is Undirected, in contrast to `IntoEdgesDirected`.

A (correct) graph implementation returning the node as target would break some algorithms such as `bellman_ford`, which assume the contrary.

I think is reasonable to ask for this, even if it's _technically_ a breaking change. All our graph definitions already work this way.