### PR TITLE
Add a `find_negative_cycle` algo based on Bellman-Ford

### DIFF
--- a/benches/bellman_ford.rs
+++ b/benches/bellman_ford.rs
@@ -1,0 +1,54 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use petgraph::prelude::*;
+use std::cmp::{max, min};
+use test::Bencher;
+
+use petgraph::algo::{bellman_ford, find_negative_cycle};
+
+#[bench]
+fn bellman_ford_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 1_000;
+    let mut g = Graph::new();
+    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).into_iter().map(|i| g.add_node(i)).collect();
+    for i in 0..NODE_COUNT {
+        let n1 = nodes[i];
+        let neighbour_count = i % 8 + 3;
+        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
+        let j_to = min(NODE_COUNT, j_from + neighbour_count);
+        for j in j_from..j_to {
+            let n2 = nodes[j];
+            let distance = (i + 3) % 10;
+            g.add_edge(n1, n2, distance as f64);
+        }
+    }
+
+    bench.iter(|| {
+        let _scores = bellman_ford(&g, nodes[0]);
+    });
+}
+
+#[bench]
+fn find_negative_cycle_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 1_000;
+    let mut g = Graph::new();
+    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).into_iter().map(|i| g.add_node(i)).collect();
+    for i in 0..NODE_COUNT {
+        let n1 = nodes[i];
+        let neighbour_count = i % 8 + 3;
+        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
+        let j_to = min(NODE_COUNT, j_from + neighbour_count);
+        for j in j_from..j_to {
+            let n2 = nodes[j];
+            let distance = (i + 3) % 10;
+            g.add_edge(n1, n2, distance as f64);
+        }
+    }
+
+    bench.iter(|| {
+        let _scores = find_negative_cycle(&g, nodes[0]);
+    });
+}

--- a/benches/bellman_ford.rs
+++ b/benches/bellman_ford.rs
@@ -11,7 +11,7 @@ use petgraph::algo::{bellman_ford, find_negative_cycle};
 
 #[bench]
 fn bellman_ford_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 1_000;
+    static NODE_COUNT: usize = 100;
     let mut g = Graph::new();
     let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).into_iter().map(|i| g.add_node(i)).collect();
     for i in 0..NODE_COUNT {
@@ -21,7 +21,10 @@ fn bellman_ford_bench(bench: &mut Bencher) {
         let j_to = min(NODE_COUNT, j_from + neighbour_count);
         for j in j_from..j_to {
             let n2 = nodes[j];
-            let distance = (i + 3) % 10;
+            let mut distance: f64 = ((i + 3) % 10) as f64;
+            if n1 != n2 {
+                distance -= 1.0
+            }
             g.add_edge(n1, n2, distance as f64);
         }
     }
@@ -33,7 +36,7 @@ fn bellman_ford_bench(bench: &mut Bencher) {
 
 #[bench]
 fn find_negative_cycle_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 1_000;
+    static NODE_COUNT: usize = 100;
     let mut g = Graph::new();
     let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).into_iter().map(|i| g.add_node(i)).collect();
     for i in 0..NODE_COUNT {
@@ -43,8 +46,11 @@ fn find_negative_cycle_bench(bench: &mut Bencher) {
         let j_to = min(NODE_COUNT, j_from + neighbour_count);
         for j in j_from..j_to {
             let n2 = nodes[j];
-            let distance = (i + 3) % 10;
-            g.add_edge(n1, n2, distance as f64);
+            let mut distance: f64 = ((i + 3) % 10) as f64;
+            if n1 != n2 {
+                distance -= 1.0
+            }
+            g.add_edge(n1, n2, distance);
         }
     }
 

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -173,7 +173,6 @@ where
                             .expect("we should always have a position");
                         path = path[pos..path.len()].to_vec();
 
-                        path.push(ancestor);
                         break;
                     }
 

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -1,0 +1,233 @@
+//! Bellman-Ford algorithms.
+
+use crate::prelude::*;
+
+use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable};
+
+use super::{FloatMeasure, NegativeCycle};
+
+/// \[Generic\] Compute shortest paths from node `source` to all other.
+///
+/// Using the [Bellman–Ford algorithm][bf]; negative edge costs are
+/// permitted, but the graph must not have a cycle of negative weights
+/// (in that case it will return an error).
+///
+/// On success, return one vec with path costs, and another one which points
+/// out the predecessor of a node along a shortest path. The vectors
+/// are indexed by the graph's node indices.
+///
+/// [bf]: https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
+///
+/// # Example
+/// ```rust
+/// use petgraph::Graph;
+/// use petgraph::algo::bellman_ford;
+/// use petgraph::prelude::*;
+///
+/// let mut g = Graph::new();
+/// let a = g.add_node(()); // node with no weight
+/// let b = g.add_node(());
+/// let c = g.add_node(());
+/// let d = g.add_node(());
+/// let e = g.add_node(());
+/// let f = g.add_node(());
+/// g.extend_with_edges(&[
+///     (0, 1, 2.0),
+///     (0, 3, 4.0),
+///     (1, 2, 1.0),
+///     (1, 5, 7.0),
+///     (2, 4, 5.0),
+///     (4, 5, 1.0),
+///     (3, 4, 1.0),
+/// ]);
+///
+/// // Graph represented with the weight of each edge
+/// //
+/// //     2       1
+/// // a ----- b ----- c
+/// // | 4     | 7     |
+/// // d       f       | 5
+/// // | 1     | 1     |
+/// // \------ e ------/
+///
+/// let path = bellman_ford(&g, a);
+/// assert_eq!(path, Ok((vec![0.0 ,     2.0,    3.0,    4.0,     5.0,     6.0],
+///                      vec![None, Some(a),Some(b),Some(a), Some(d), Some(e)]
+///                    ))
+///           );
+/// // Node f (indice 5) can be reach from a with a path costing 6.
+/// // Predecessor of f is Some(e) which predecessor is Some(d) which predecessor is Some(a).
+/// // Thus the path from a to f is a <-> d <-> e <-> f
+///
+/// let graph_with_neg_cycle = Graph::<(), f32, Undirected>::from_edges(&[
+///         (0, 1, -2.0),
+///         (0, 3, -4.0),
+///         (1, 2, -1.0),
+///         (1, 5, -25.0),
+///         (2, 4, -5.0),
+///         (4, 5, -25.0),
+///         (3, 4, -1.0),
+/// ]);
+///
+/// assert!(bellman_ford(&graph_with_neg_cycle, NodeIndex::new(0)).is_err());
+/// ```
+pub fn bellman_ford<G>(
+    g: G,
+    source: G::NodeId,
+) -> Result<(Vec<G::EdgeWeight>, Vec<Option<G::NodeId>>), NegativeCycle>
+where
+    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
+    G::EdgeWeight: FloatMeasure,
+{
+    let ix = |i| g.to_index(i);
+
+    // Step 1 and Step 2: initialize and relax
+    let (distance, predecessor) = bellman_ford_initialize_relax(g, source);
+
+    // Step 3: check for negative weight cycle
+    for i in g.node_identifiers() {
+        for edge in g.edges(i) {
+            let j = edge.target();
+            let w = *edge.weight();
+            if distance[ix(i)] + w < distance[ix(j)] {
+                //println!("neg cycle, detected from {} to {}, weight={}", i, j, w);
+                return Err(NegativeCycle(()));
+            }
+        }
+    }
+
+    Ok((distance, predecessor))
+}
+
+/// \[Generic\] find the path of a negative cycle from node `source` to all other.
+///
+/// Using the [find_negative_cycle][nc]; will search the Graph for negative cycles using
+/// [Bellman–Ford algorithm][bf]. If no negative cycle is found the function will return `None`.
+///
+/// If a negative cycle is found from source, return one vec with a path of `NodeId`s.
+///
+/// The time complexity of this algorithm should be the same as the Bellman-Ford (O(|V|·|E|)).
+///
+/// [nc]: https://blogs.asarkar.com/assets/docs/algorithms-curated/Negative-Weight%20Cycle%20Algorithms%20-%20Huang.pdf
+/// [bf]: https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
+///
+/// # Example
+/// ```rust
+/// use petgraph::Graph;
+/// use petgraph::algo::find_negative_cycle;
+/// use petgraph::prelude::*;
+///
+/// let graph_with_neg_cycle = Graph::<(), f32, Directed>::from_edges(&[
+///         (0, 1, 1.),
+///         (0, 2, 1.),
+///         (0, 3, 1.),
+///         (1, 3, 1.),
+///         (2, 1, 1.),
+///         (3, 2, -3.),
+/// ]);
+///
+/// let path = find_negative_cycle(&graph_with_neg_cycle, NodeIndex::new(0));
+/// assert_eq!(
+///     path,
+///     Some([NodeIndex::new(1), NodeIndex::new(3), NodeIndex::new(2)].to_vec())
+/// );
+/// ```
+pub fn find_negative_cycle<G>(g: G, source: G::NodeId) -> Option<Vec<G::NodeId>>
+where
+    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
+    G::EdgeWeight: FloatMeasure,
+{
+    let ix = |i| g.to_index(i);
+    let mut path = Vec::<G::NodeId>::new();
+
+    // Step 1: initialize and relax
+    let (distance, predecessor) = bellman_ford_initialize_relax(g, source);
+
+    // Step 2: Check for negative weight cycle
+    'outer: for i in g.node_identifiers() {
+        for edge in g.edges(i) {
+            let j = edge.target();
+            let w = *edge.weight();
+            if distance[ix(i)] + w < distance[ix(j)] {
+                // Step 3: negative cycle found
+                let start = j;
+                let mut node = start;
+                // Go backward in the predecessor chain
+                loop {
+                    let ancestor = match predecessor[ix(node)] {
+                        Some(predecessor_node) => predecessor_node,
+                        None => node, // no predecessor, self cycle
+                    };
+                    // We have only 2 ways to find the cycle and break the loop:
+                    // 1. start is reached
+                    if ancestor == start {
+                        path.push(ancestor);
+                        break;
+                    }
+                    // 2. some node was reached twice
+                    else if path.iter().any(|&p| p == ancestor) {
+                        // Drop any node in path that is before the first ancestor
+                        let pos = path
+                            .iter()
+                            .position(|&p| p == ancestor)
+                            .expect("we should always have a position");
+                        path = path[pos..path.len()].to_vec();
+
+                        path.push(ancestor);
+                        break;
+                    }
+
+                    // None of the above, some middle path node
+                    path.push(ancestor);
+                    node = ancestor;
+                }
+                // We are done here
+                break 'outer;
+            }
+        }
+    }
+    if path.len() > 0 {
+        // Users will probably need to follow the path of the negative cycle
+        // so it should be in the reverse order than it was found by the algorithm.
+        path.reverse();
+        Some(path)
+    } else {
+        None
+    }
+}
+
+// Perform Step 1 and Step 2 of the Bellman-Ford algorithm.
+fn bellman_ford_initialize_relax<G>(
+    g: G,
+    source: G::NodeId,
+) -> (Vec<G::EdgeWeight>, Vec<Option<G::NodeId>>)
+where
+    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
+    G::EdgeWeight: FloatMeasure,
+{
+    // Step 1: initialize graph
+    let mut predecessor = vec![None; g.node_bound()];
+    let mut distance = vec![<_>::infinite(); g.node_bound()];
+    let ix = |i| g.to_index(i);
+    distance[ix(source)] = <_>::zero();
+
+    // Step 2: relax edges repeatedly
+    for _ in 1..g.node_count() {
+        let mut did_update = false;
+        for i in g.node_identifiers() {
+            for edge in g.edges(i) {
+                let j = edge.target();
+                let w = *edge.weight();
+                if distance[ix(i)] + w < distance[ix(j)] {
+                    distance[ix(j)] = distance[ix(i)] + w;
+                    predecessor[ix(j)] = Some(i);
+                    did_update = true;
+                }
+            }
+        }
+        if !did_update {
+            break;
+        }
+    }
+    (distance, predecessor)
+}

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -2,7 +2,7 @@
 
 use crate::prelude::*;
 
-use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable, Visitable, VisitMap};
+use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable, VisitMap, Visitable};
 
 use super::{FloatMeasure, NegativeCycle};
 

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -90,7 +90,6 @@ where
             let j = edge.target();
             let w = *edge.weight();
             if distance[ix(i)] + w < distance[ix(j)] {
-                //println!("neg cycle, detected from {} to {}, weight={}", i, j, w);
                 return Err(NegativeCycle(()));
             }
         }

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -196,6 +196,7 @@ where
 }
 
 // Perform Step 1 and Step 2 of the Bellman-Ford algorithm.
+#[inline(always)]
 fn bellman_ford_initialize_relax<G>(
     g: G,
     source: G::NodeId,

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -98,7 +98,7 @@ where
     Ok((distance, predecessor))
 }
 
-/// \[Generic\] find the path of a negative cycle from node `source` to all other.
+/// \[Generic\] Find the path of a negative cycle reachable from node `source`.
 ///
 /// Using the [find_negative_cycle][nc]; will search the Graph for negative cycles using
 /// [Bellman–Ford algorithm][bf]. If no negative cycle is found the function will return `None`.

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -744,6 +744,7 @@ impl<N> Cycle<N> {
         self.0
     }
 }
+
 /// An algorithm error: a cycle of negative weights was found in the graph.
 #[derive(Clone, Debug, PartialEq)]
 pub struct NegativeCycle(pub ());
@@ -821,13 +822,141 @@ where
     G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
     G::EdgeWeight: FloatMeasure,
 {
-    let mut predecessor = vec![None; g.node_bound()];
-    let mut distance = vec![<_>::infinite(); g.node_bound()];
-
     let ix = |i| g.to_index(i);
 
+    // Step 1 and Step 2: initialize and relax
+    let (distance, predecessor) = bellman_ford_initialize_relax(g, source);
+
+    // Step 3: check for negative weight cycle
+    for i in g.node_identifiers() {
+        for edge in g.edges(i) {
+            let j = edge.target();
+            let w = *edge.weight();
+            if distance[ix(i)] + w < distance[ix(j)] {
+                //println!("neg cycle, detected from {} to {}, weight={}", i, j, w);
+                return Err(NegativeCycle(()));
+            }
+        }
+    }
+
+    Ok((distance, predecessor))
+}
+
+/// \[Generic\] find the path of a negative cycle from node `source` to all other.
+///
+/// Using the [find_negative_cycle][nc]; will search the Graph for negative cycles using
+/// [Bellman–Ford algorithm][bf]. If no negative cycle is found the function will return `None`.
+///
+/// If a negative cycle is found from source, return one vec with a path of `NodeId`s.
+///
+/// The time complexity of this algorithm should be the same as the Bellman-Ford (O(|V|·|E|)).
+///
+/// [nc]: https://blogs.asarkar.com/assets/docs/algorithms-curated/Negative-Weight%20Cycle%20Algorithms%20-%20Huang.pdf
+/// [bf]: https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
+///
+/// # Example
+/// ```rust
+/// use petgraph::Graph;
+/// use petgraph::algo::find_negative_cycle;
+/// use petgraph::prelude::*;
+///
+/// let graph_with_neg_cycle = Graph::<(), f32, Directed>::from_edges(&[
+///         (0, 1, 1.),
+///         (0, 2, 1.),
+///         (0, 3, 1.),
+///         (1, 3, 1.),
+///         (2, 1, 1.),
+///         (3, 2, -3.),
+/// ]);
+///
+/// let path = find_negative_cycle(&graph_with_neg_cycle, NodeIndex::new(0));
+/// assert_eq!(
+///     path,
+///     Some([NodeIndex::new(1), NodeIndex::new(3), NodeIndex::new(2), NodeIndex::new(1)].to_vec())
+/// );
+/// ```
+pub fn find_negative_cycle<G>(g: G, source: G::NodeId) -> Option<Vec<G::NodeId>>
+where
+    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
+    G::EdgeWeight: FloatMeasure,
+{
+    let ix = |i| g.to_index(i);
+    let mut path = Vec::<G::NodeId>::new();
+
+    // Step 1: initialize and relax
+    let (distance, predecessor) = bellman_ford_initialize_relax(g, source);
+
+    // Step 2: Check for negative weight cycle
+    'outer: for i in g.node_identifiers() {
+        for edge in g.edges(i) {
+            let j = edge.target();
+            let w = *edge.weight();
+            if distance[ix(i)] + w < distance[ix(j)] {
+                // Step 3: negative cycle found
+                let start = j;
+                let mut node = start;
+                // Go backward in the predecessor chain
+                loop {
+                    let ansestor = match predecessor[ix(node)] {
+                        Some(predecessor_node) => predecessor_node,
+                        None => node, // no predecessor, self cycle
+                    };
+                    // We have only 2 ways to find the cycle and break the loop
+                    // 1. start is reached
+                    if ansestor == start {
+                        // Insert the ancestor at the beginning and at the end of the path
+                        path.insert(0, ansestor);
+                        path.push(ansestor);
+                        break;
+                    }
+                    // 2. some node was reached twice
+                    else if path.iter().any(|&p| p == ansestor) {
+                        // Drop any node in path that is before the first ansestor
+                        let pos = path
+                            .iter()
+                            .position(|&p| p == ansestor)
+                            .expect("we should always have a position");
+                        path = path[pos..path.len()].to_vec();
+
+                        path.push(ansestor);
+                        break;
+                    }
+
+                    // None of the above, some middle path node
+                    path.push(ansestor);
+                    node = ansestor;
+                }
+                // We are done here
+                break 'outer;
+            }
+        }
+    }
+    if path.len() > 0 {
+        // Users will probably need to follow the path of the negative cycle
+        // so it should be in the reverse other than it was found by the algorithm.
+        path.reverse();
+        Some(path)
+    } else {
+        None
+    }
+}
+
+// Perform Step 1 and Step 2 of the Bellman–Ford_algorithm.
+fn bellman_ford_initialize_relax<G>(
+    g: G,
+    source: G::NodeId,
+) -> (Vec<G::EdgeWeight>, Vec<Option<G::NodeId>>)
+where
+    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
+    G::EdgeWeight: FloatMeasure,
+{
+    // Step 1: initialize graph
+    let mut predecessor = vec![None; g.node_bound()];
+    let mut distance = vec![<_>::infinite(); g.node_bound()];
+    let ix = |i| g.to_index(i);
     distance[ix(source)] = <_>::zero();
-    // scan up to |V| - 1 times.
+
+    // Step 2: relax edges repeatedly
     for _ in 1..g.node_count() {
         let mut did_update = false;
         for i in g.node_identifiers() {
@@ -845,20 +974,7 @@ where
             break;
         }
     }
-
-    // check for negative weight cycle
-    for i in g.node_identifiers() {
-        for edge in g.edges(i) {
-            let j = edge.target();
-            let w = *edge.weight();
-            if distance[ix(i)] + w < distance[ix(j)] {
-                //println!("neg cycle, detected from {} to {}, weight={}", i, j, w);
-                return Err(NegativeCycle(()));
-            }
-        }
-    }
-
-    Ok((distance, predecessor))
+    (distance, predecessor)
 }
 
 /// Return `true` if the graph is bipartite. A graph is bipartite if it's nodes can be divided into

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -901,7 +901,7 @@ where
                         Some(predecessor_node) => predecessor_node,
                         None => node, // no predecessor, self cycle
                     };
-                    // We have only 2 ways to find the cycle and break the loop
+                    // We have only 2 ways to find the cycle and break the loop:
                     // 1. start is reached
                     if ansestor == start {
                         // Insert the ancestor at the beginning and at the end of the path
@@ -933,7 +933,7 @@ where
     }
     if path.len() > 0 {
         // Users will probably need to follow the path of the negative cycle
-        // so it should be in the reverse other than it was found by the algorithm.
+        // so it should be in the reverse order than it was found by the algorithm.
         path.reverse();
         Some(path)
     } else {
@@ -941,7 +941,7 @@ where
     }
 }
 
-// Perform Step 1 and Step 2 of the Bellman–Ford_algorithm.
+// Perform Step 1 and Step 2 of the Bellman-Ford algorithm.
 fn bellman_ford_initialize_relax<G>(
     g: G,
     source: G::NodeId,

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -897,34 +897,34 @@ where
                 let mut node = start;
                 // Go backward in the predecessor chain
                 loop {
-                    let ansestor = match predecessor[ix(node)] {
+                    let ancestor = match predecessor[ix(node)] {
                         Some(predecessor_node) => predecessor_node,
                         None => node, // no predecessor, self cycle
                     };
                     // We have only 2 ways to find the cycle and break the loop:
                     // 1. start is reached
-                    if ansestor == start {
+                    if ancestor == start {
                         // Insert the ancestor at the beginning and at the end of the path
-                        path.insert(0, ansestor);
-                        path.push(ansestor);
+                        path.insert(0, ancestor);
+                        path.push(ancestor);
                         break;
                     }
                     // 2. some node was reached twice
-                    else if path.iter().any(|&p| p == ansestor) {
-                        // Drop any node in path that is before the first ansestor
+                    else if path.iter().any(|&p| p == ancestor) {
+                        // Drop any node in path that is before the first ancestor
                         let pos = path
                             .iter()
-                            .position(|&p| p == ansestor)
+                            .position(|&p| p == ancestor)
                             .expect("we should always have a position");
                         path = path[pos..path.len()].to_vec();
 
-                        path.push(ansestor);
+                        path.push(ancestor);
                         break;
                     }
 
                     // None of the above, some middle path node
-                    path.push(ansestor);
-                    node = ansestor;
+                    path.push(ancestor);
+                    node = ancestor;
                 }
                 // We are done here
                 break 'outer;

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -4,6 +4,7 @@
 //! so that they are generally applicable. For now, some of these still require
 //! the `Graph` type.
 
+pub mod bellman_ford;
 pub mod dominators;
 pub mod tred;
 
@@ -15,9 +16,8 @@ use crate::prelude::*;
 use super::graph::IndexType;
 use super::unionfind::UnionFind;
 use super::visit::{
-    GraphBase, GraphRef, IntoEdgeReferences, IntoEdges, IntoNeighbors, IntoNeighborsDirected,
-    IntoNodeIdentifiers, NodeCompactIndexable, NodeCount, NodeIndexable, Reversed, VisitMap,
-    Visitable,
+    GraphBase, GraphRef, IntoEdgeReferences, IntoNeighbors, IntoNeighborsDirected,
+    IntoNodeIdentifiers, NodeCompactIndexable, NodeIndexable, Reversed, VisitMap, Visitable,
 };
 use super::EdgeType;
 use crate::data::Element;
@@ -36,6 +36,8 @@ pub use super::isomorphism::{
 };
 pub use super::matching::{greedy_matching, maximum_matching, Matching};
 pub use super::simple_paths::all_simple_paths;
+
+pub use bellman_ford::{bellman_ford, find_negative_cycle};
 
 /// \[Generic\] Return the number of connected components of the graph.
 ///
@@ -748,232 +750,6 @@ impl<N> Cycle<N> {
 /// An algorithm error: a cycle of negative weights was found in the graph.
 #[derive(Clone, Debug, PartialEq)]
 pub struct NegativeCycle(pub ());
-
-/// \[Generic\] Compute shortest paths from node `source` to all other.
-///
-/// Using the [Bellman–Ford algorithm][bf]; negative edge costs are
-/// permitted, but the graph must not have a cycle of negative weights
-/// (in that case it will return an error).
-///
-/// On success, return one vec with path costs, and another one which points
-/// out the predecessor of a node along a shortest path. The vectors
-/// are indexed by the graph's node indices.
-///
-/// [bf]: https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
-///
-/// # Example
-/// ```rust
-/// use petgraph::Graph;
-/// use petgraph::algo::bellman_ford;
-/// use petgraph::prelude::*;
-///
-/// let mut g = Graph::new();
-/// let a = g.add_node(()); // node with no weight
-/// let b = g.add_node(());
-/// let c = g.add_node(());
-/// let d = g.add_node(());
-/// let e = g.add_node(());
-/// let f = g.add_node(());
-/// g.extend_with_edges(&[
-///     (0, 1, 2.0),
-///     (0, 3, 4.0),
-///     (1, 2, 1.0),
-///     (1, 5, 7.0),
-///     (2, 4, 5.0),
-///     (4, 5, 1.0),
-///     (3, 4, 1.0),
-/// ]);
-///
-/// // Graph represented with the weight of each edge
-/// //
-/// //     2       1
-/// // a ----- b ----- c
-/// // | 4     | 7     |
-/// // d       f       | 5
-/// // | 1     | 1     |
-/// // \------ e ------/
-///
-/// let path = bellman_ford(&g, a);
-/// assert_eq!(path, Ok((vec![0.0 ,     2.0,    3.0,    4.0,     5.0,     6.0],
-///                      vec![None, Some(a),Some(b),Some(a), Some(d), Some(e)]
-///                    ))
-///           );
-/// // Node f (indice 5) can be reach from a with a path costing 6.
-/// // Predecessor of f is Some(e) which predecessor is Some(d) which predecessor is Some(a).
-/// // Thus the path from a to f is a <-> d <-> e <-> f
-///
-/// let graph_with_neg_cycle = Graph::<(), f32, Undirected>::from_edges(&[
-///         (0, 1, -2.0),
-///         (0, 3, -4.0),
-///         (1, 2, -1.0),
-///         (1, 5, -25.0),
-///         (2, 4, -5.0),
-///         (4, 5, -25.0),
-///         (3, 4, -1.0),
-/// ]);
-///
-/// assert!(bellman_ford(&graph_with_neg_cycle, NodeIndex::new(0)).is_err());
-/// ```
-pub fn bellman_ford<G>(
-    g: G,
-    source: G::NodeId,
-) -> Result<(Vec<G::EdgeWeight>, Vec<Option<G::NodeId>>), NegativeCycle>
-where
-    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
-    G::EdgeWeight: FloatMeasure,
-{
-    let ix = |i| g.to_index(i);
-
-    // Step 1 and Step 2: initialize and relax
-    let (distance, predecessor) = bellman_ford_initialize_relax(g, source);
-
-    // Step 3: check for negative weight cycle
-    for i in g.node_identifiers() {
-        for edge in g.edges(i) {
-            let j = edge.target();
-            let w = *edge.weight();
-            if distance[ix(i)] + w < distance[ix(j)] {
-                //println!("neg cycle, detected from {} to {}, weight={}", i, j, w);
-                return Err(NegativeCycle(()));
-            }
-        }
-    }
-
-    Ok((distance, predecessor))
-}
-
-/// \[Generic\] find the path of a negative cycle from node `source` to all other.
-///
-/// Using the [find_negative_cycle][nc]; will search the Graph for negative cycles using
-/// [Bellman–Ford algorithm][bf]. If no negative cycle is found the function will return `None`.
-///
-/// If a negative cycle is found from source, return one vec with a path of `NodeId`s.
-///
-/// The time complexity of this algorithm should be the same as the Bellman-Ford (O(|V|·|E|)).
-///
-/// [nc]: https://blogs.asarkar.com/assets/docs/algorithms-curated/Negative-Weight%20Cycle%20Algorithms%20-%20Huang.pdf
-/// [bf]: https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
-///
-/// # Example
-/// ```rust
-/// use petgraph::Graph;
-/// use petgraph::algo::find_negative_cycle;
-/// use petgraph::prelude::*;
-///
-/// let graph_with_neg_cycle = Graph::<(), f32, Directed>::from_edges(&[
-///         (0, 1, 1.),
-///         (0, 2, 1.),
-///         (0, 3, 1.),
-///         (1, 3, 1.),
-///         (2, 1, 1.),
-///         (3, 2, -3.),
-/// ]);
-///
-/// let path = find_negative_cycle(&graph_with_neg_cycle, NodeIndex::new(0));
-/// assert_eq!(
-///     path,
-///     Some([NodeIndex::new(1), NodeIndex::new(3), NodeIndex::new(2)].to_vec())
-/// );
-/// ```
-pub fn find_negative_cycle<G>(g: G, source: G::NodeId) -> Option<Vec<G::NodeId>>
-where
-    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
-    G::EdgeWeight: FloatMeasure,
-{
-    let ix = |i| g.to_index(i);
-    let mut path = Vec::<G::NodeId>::new();
-
-    // Step 1: initialize and relax
-    let (distance, predecessor) = bellman_ford_initialize_relax(g, source);
-
-    // Step 2: Check for negative weight cycle
-    'outer: for i in g.node_identifiers() {
-        for edge in g.edges(i) {
-            let j = edge.target();
-            let w = *edge.weight();
-            if distance[ix(i)] + w < distance[ix(j)] {
-                // Step 3: negative cycle found
-                let start = j;
-                let mut node = start;
-                // Go backward in the predecessor chain
-                loop {
-                    let ancestor = match predecessor[ix(node)] {
-                        Some(predecessor_node) => predecessor_node,
-                        None => node, // no predecessor, self cycle
-                    };
-                    // We have only 2 ways to find the cycle and break the loop:
-                    // 1. start is reached
-                    if ancestor == start {
-                        path.push(ancestor);
-                        break;
-                    }
-                    // 2. some node was reached twice
-                    else if path.iter().any(|&p| p == ancestor) {
-                        // Drop any node in path that is before the first ancestor
-                        let pos = path
-                            .iter()
-                            .position(|&p| p == ancestor)
-                            .expect("we should always have a position");
-                        path = path[pos..path.len()].to_vec();
-
-                        path.push(ancestor);
-                        break;
-                    }
-
-                    // None of the above, some middle path node
-                    path.push(ancestor);
-                    node = ancestor;
-                }
-                // We are done here
-                break 'outer;
-            }
-        }
-    }
-    if path.len() > 0 {
-        // Users will probably need to follow the path of the negative cycle
-        // so it should be in the reverse order than it was found by the algorithm.
-        path.reverse();
-        Some(path)
-    } else {
-        None
-    }
-}
-
-// Perform Step 1 and Step 2 of the Bellman-Ford algorithm.
-fn bellman_ford_initialize_relax<G>(
-    g: G,
-    source: G::NodeId,
-) -> (Vec<G::EdgeWeight>, Vec<Option<G::NodeId>>)
-where
-    G: NodeCount + IntoNodeIdentifiers + IntoEdges + NodeIndexable,
-    G::EdgeWeight: FloatMeasure,
-{
-    // Step 1: initialize graph
-    let mut predecessor = vec![None; g.node_bound()];
-    let mut distance = vec![<_>::infinite(); g.node_bound()];
-    let ix = |i| g.to_index(i);
-    distance[ix(source)] = <_>::zero();
-
-    // Step 2: relax edges repeatedly
-    for _ in 1..g.node_count() {
-        let mut did_update = false;
-        for i in g.node_identifiers() {
-            for edge in g.edges(i) {
-                let j = edge.target();
-                let w = *edge.weight();
-                if distance[ix(i)] + w < distance[ix(j)] {
-                    distance[ix(j)] = distance[ix(i)] + w;
-                    predecessor[ix(j)] = Some(i);
-                    did_update = true;
-                }
-            }
-        }
-        if !did_update {
-            break;
-        }
-    }
-    (distance, predecessor)
-}
 
 /// Return `true` if the graph is bipartite. A graph is bipartite if it's nodes can be divided into
 /// two disjoint and indepedent sets U and V such that every edge connects U to one in V. This

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -872,7 +872,7 @@ where
 /// let path = find_negative_cycle(&graph_with_neg_cycle, NodeIndex::new(0));
 /// assert_eq!(
 ///     path,
-///     Some([NodeIndex::new(1), NodeIndex::new(3), NodeIndex::new(2), NodeIndex::new(1)].to_vec())
+///     Some([NodeIndex::new(1), NodeIndex::new(3), NodeIndex::new(2)].to_vec())
 /// );
 /// ```
 pub fn find_negative_cycle<G>(g: G, source: G::NodeId) -> Option<Vec<G::NodeId>>
@@ -904,8 +904,6 @@ where
                     // We have only 2 ways to find the cycle and break the loop:
                     // 1. start is reached
                     if ancestor == start {
-                        // Insert the ancestor at the beginning and at the end of the path
-                        path.insert(0, ancestor);
                         path.push(ancestor);
                         break;
                     }

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -826,6 +826,7 @@ Row   : [0, 2, 5]   <- value index of row start
 mod tests {
     use super::Csr;
     use crate::algo::bellman_ford;
+    use crate::algo::find_negative_cycle;
     use crate::algo::tarjan_scc;
     use crate::visit::Dfs;
     use crate::visit::VisitMap;
@@ -994,6 +995,59 @@ mod tests {
         .unwrap();
         let result = bellman_ford(&m, 0);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_neg_cycle1() {
+        let m: Csr<(), _> = Csr::from_sorted_edges(&[
+            (0, 1, 0.5),
+            (0, 2, 2.),
+            (1, 0, 1.),
+            (1, 1, -1.),
+            (1, 2, 1.),
+            (1, 3, 1.),
+            (2, 3, 3.),
+        ])
+        .unwrap();
+        let result = find_negative_cycle(&m, 0);
+        assert_eq!(result, Some([1, 1].to_vec()));
+    }
+
+    #[test]
+    fn test_find_neg_cycle2() {
+        let m: Csr<(), _> = Csr::from_sorted_edges(&[
+            (0, 1, 0.5),
+            (0, 2, 2.),
+            (1, 0, 1.),
+            (1, 2, 1.),
+            (1, 3, 1.),
+            (2, 3, 3.),
+        ])
+        .unwrap();
+        let result = find_negative_cycle(&m, 0);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_find_neg_cycle3() {
+        let m: Csr<(), _> = Csr::from_sorted_edges(&[
+            (0, 1, 1.),
+            (0, 2, 1.),
+            (0, 3, 1.),
+            (1, 3, 1.),
+            (2, 1, 1.),
+            (3, 2, -3.),
+        ])
+        .unwrap();
+        let result = find_negative_cycle(&m, 0);
+        assert_eq!(result, Some([1, 3, 2, 1].to_vec()));
+    }
+
+    #[test]
+    fn test_find_neg_cycle4() {
+        let m: Csr<(), _> = Csr::from_sorted_edges(&[(0, 0, -1.)]).unwrap();
+        let result = find_negative_cycle(&m, 0);
+        assert_eq!(result, Some([0, 0].to_vec()));
     }
 
     #[test]

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1010,7 +1010,7 @@ mod tests {
         ])
         .unwrap();
         let result = find_negative_cycle(&m, 0);
-        assert_eq!(result, Some([1, 1].to_vec()));
+        assert_eq!(result, Some([1].to_vec()));
     }
 
     #[test]

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1040,14 +1040,14 @@ mod tests {
         ])
         .unwrap();
         let result = find_negative_cycle(&m, 0);
-        assert_eq!(result, Some([1, 3, 2, 1].to_vec()));
+        assert_eq!(result, Some([1, 3, 2].to_vec()));
     }
 
     #[test]
     fn test_find_neg_cycle4() {
         let m: Csr<(), _> = Csr::from_sorted_edges(&[(0, 0, -1.)]).unwrap();
         let result = find_negative_cycle(&m, 0);
-        assert_eq!(result, Some([0, 0].to_vec()));
+        assert_eq!(result, Some([0].to_vec()));
     }
 
     #[test]

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -913,7 +913,7 @@ quickcheck! {
         for (i, start) in gr.node_indices().enumerate() {
             if i >= 10 { break; } // testing all is too slow
             if let Some(path) = find_negative_cycle(&gr, start) {
-                assert!(path.len() >= 2);
+                assert!(path.len() >= 1);
             }
         }
         true

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -22,10 +22,10 @@ use itertools::cloned;
 use rand::Rng;
 
 use petgraph::algo::{
-    bellman_ford, condensation, dijkstra, floyd_warshall, greedy_feedback_arc_set, greedy_matching,
-    is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
-    k_shortest_path, kosaraju_scc, maximum_matching, min_spanning_tree, tarjan_scc, toposort,
-    Matching,
+    bellman_ford, condensation, dijkstra, find_negative_cycle, floyd_warshall,
+    greedy_feedback_arc_set, greedy_matching, is_cyclic_directed, is_cyclic_undirected,
+    is_isomorphic, is_isomorphic_matching, k_shortest_path, kosaraju_scc, maximum_matching,
+    min_spanning_tree, tarjan_scc, toposort, Matching,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -899,6 +899,22 @@ quickcheck! {
         for (i, start) in gr.node_indices().enumerate() {
             if i >= 10 { break; } // testing all is too slow
             bellman_ford(&gr, start).unwrap();
+        }
+        true
+    }
+}
+
+quickcheck! {
+    fn test_find_negative_cycle(gr: Graph<(), f32>) -> bool {
+        let gr = gr;
+        if gr.node_count() == 0 {
+            return true;
+        }
+        for (i, start) in gr.node_indices().enumerate() {
+            if i >= 10 { break; } // testing all is too slow
+            if let Some(path) = find_negative_cycle(&gr, start) {
+                assert!(path.len() >= 2);
+            }
         }
         true
     }


### PR DESCRIPTION
Had been using a custom extension of the `bellman_ford` algorithm from this library in order to find paths of negative cycles in directed graphs. I decided to give it a shot and try to introduce it as a library algo.

## Motivation

- Matlab's `shortestpath` function do return negative cycles path (even if they do it as an error string).
- There are at least 2 use cases for this where the most obvious one seems to be arbitrage.

## Details

The new algorithm is the first of 2 presented on this paper: https://blogs.asarkar.com/assets/docs/algorithms-curated/Negative-Weight%20Cycle%20Algorithms%20-%20Huang.pdf

As the `find_negative_cycle` algo introduced here is the same as the bellman-ford for the first part i moved steps 1 and 2 form the original into a common function that both algorithms can use.

I am unsure if this PR haves enough quality to be included but i also don't know if it haves the enough use cases and acceptance (https://github.com/petgraph/petgraph/issues/195) to be considered as part of the library so i preferred to post it as it is and see what happens.

If it not get included i hope some people could find it useful.