### PR TITLE
Fix a formatting issue in the algo module's docs

### DIFF
--- a/src/simple_paths.rs
+++ b/src/simple_paths.rs
@@ -10,10 +10,10 @@ use crate::{
     Direction::Outgoing,
 };
 
-/// Returns iterator that produces all simple paths from `from` node to `to`, which contains at least `min_intermediate_nodes` nodes
-/// and at most `max_intermediate_nodes`, if given, limited by graph's order otherwise
-/// Simple path is path without repetitions
-/// Algorithm is adopted from https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.simple_paths.all_simple_paths.html
+/// Returns an iterator that produces all simple paths from `from` node to `to`, which contains at least `min_intermediate_nodes` nodes
+/// and at most `max_intermediate_nodes`, if given, or limited by the graph's order otherwise. The simple path is a path without repetitions.
+///
+/// This algorithm is adapted from https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.simple_paths.all_simple_paths.html
 ///
 /// # Example
 /// ```


### PR DESCRIPTION
The (long) URL in the doc comment of `fn all_simple_paths` causes a formatting issue on  <https://docs.rs/petgraph/0.5.1/petgraph/algo/index.html> by preventing a line wrap.

This commit moves it to a new paragraph so that it gets omitted from the module's short description.

<img width="1189" alt="image" src="https://user-images.githubusercontent.com/95046/122228190-8459ac00-ceaf-11eb-85bc-683cc16de80e.png">
