### PR TITLE
Fix minor clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,16 @@ categories = ["data-structures"]
 
 edition = "2018"
 
+[package.metadata.docs.rs]
+features = ["serde-1", "quickcheck"]
+
+[package.metadata.release]
+no-dev-version = true
+
 [lib]
+bench = false
 
 name = "petgraph"
-bench = false
 
 [profile.release]
 
@@ -30,37 +36,31 @@ debug = true
 
 [dependencies]
 fixedbitset = { version = "0.4.0", default-features = false }
-quickcheck = { optional = true, version = "0.8", default-features = false }
 indexmap = { version = "1.6.2" }
+quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
-rand = "0.5.5"
-odds = { version = "0.4.0" }
+bincode = "1.3.3"
 defmac = "0.2.1"
 itertools = { version = "0.10.1", default-features = false }
-bincode = "1.3.3"
+odds = { version = "0.4.0" }
+rand = "0.5.5"
 
 [features]
-default = ["graphmap", "stable_graph", "matrix_graph"]
-graphmap = []
-serde-1 = ["serde", "serde_derive"]
-stable_graph = []
-matrix_graph = []
-
-# For unstable features
-generate = []
-unstable = ["generate"]
 
 # feature flags for testing use only
 all = ["unstable", "quickcheck", "matrix_graph", "stable_graph", "graphmap"]
+default = ["graphmap", "stable_graph", "matrix_graph"]
+
+generate = [] # For unstable features
+
+graphmap = []
+matrix_graph = []
+serde-1 = ["serde", "serde_derive"]
+stable_graph = []
+unstable = ["generate"]
 
 [workspace]
 members = ["serialization-tests"]
-
-[package.metadata.docs.rs]
-features = ["serde-1", "quickcheck"]
-
-[package.metadata.release]
-no-dev-version = true

--- a/src/adj.rs
+++ b/src/adj.rs
@@ -507,18 +507,16 @@ impl<'a, E, Ix: IndexType> Clone for EdgeReferences<'a, E, Ix> {
     }
 }
 
-fn proj1<'a, E, Ix: IndexType>(
-    ((successor_index, edge), from): ((usize, &'a WSuc<E, Ix>), Ix),
-) -> EdgeReference<'a, E, Ix> {
+fn proj1<E, Ix: IndexType>(
+    ((successor_index, edge), from): ((usize, &WSuc<E, Ix>), Ix),
+) -> EdgeReference<E, Ix> {
     let id = EdgeIndex {
         from,
         successor_index,
     };
     EdgeReference { id, edge }
 }
-fn proj2<'a, E, Ix: IndexType>(
-    (row_index, row): (usize, &'a Vec<WSuc<E, Ix>>),
-) -> SomeIter<'a, E, Ix> {
+fn proj2<E, Ix: IndexType>((row_index, row): (usize, &Vec<WSuc<E, Ix>>)) -> SomeIter<E, Ix> {
     row.iter()
         .enumerate()
         .zip(std::iter::repeat(Ix::new(row_index)))

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -186,7 +186,7 @@ where
             }
         }
     }
-    if path.len() > 0 {
+    if !path.is_empty() {
         // Users will probably need to follow the path of the negative cycle
         // so it should be in the reverse order than it was found by the algorithm.
         path.reverse();

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -85,7 +85,7 @@ where
     pub fn immediately_dominated_by(&self, node: N) -> DominatedByIter<N> {
         DominatedByIter {
             iter: self.dominators.iter(),
-            node: node,
+            node,
         }
     }
 }

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -89,7 +89,7 @@ where
         vertex_sets.union(g.to_index(a), g.to_index(b));
     }
     let mut labels = vertex_sets.into_labeling();
-    labels.sort();
+    labels.sort_unstable();
     labels.dedup();
     labels.len()
 }
@@ -504,7 +504,7 @@ where
     let mut sccs = Vec::new();
     {
         let mut tarjan_scc = TarjanScc::new();
-        tarjan_scc.run(g, |scc| sccs.push(scc.iter().cloned().collect()));
+        tarjan_scc.run(g, |scc| sccs.push(scc.to_vec()));
     }
     sccs
 }

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -177,10 +177,9 @@ where
         {
             let mut rows = self_.row.iter_mut();
 
-            let mut node = 0;
             let mut rstart = 0;
             let mut last_target;
-            'outer: for r in &mut rows {
+            'outer: for (node, r) in (&mut rows).enumerate() {
                 *r = rstart;
                 last_target = None;
                 'inner: loop {
@@ -222,7 +221,6 @@ where
                     }
                     iter.next();
                 }
-                node += 1;
             }
             for r in rows {
                 *r = rstart;

--- a/src/floyd_warshall.rs
+++ b/src/floyd_warshall.rs
@@ -127,5 +127,5 @@ where
         }
     }
 
-    return Ok(distance_map);
+    Ok(distance_map)
 }

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -442,8 +442,8 @@ fn index_twice<T>(slc: &mut [T], a: usize, b: usize) -> Pair<&mut T> {
         // safe because a, b are in bounds and distinct
         unsafe {
             let ptr = slc.as_mut_ptr();
-            let ar = &mut *ptr.offset(a as isize);
-            let br = &mut *ptr.offset(b as isize);
+            let ar = &mut *ptr.add(a);
+            let br = &mut *ptr.add(b);
             Pair::Both(ar, br)
         }
     }

--- a/src/isomorphism.rs
+++ b/src/isomorphism.rs
@@ -381,17 +381,13 @@ mod matching {
             return false;
         }
         // R_pred
-        if st.0.graph.is_directed() {
-            if r_pred!(0) > r_pred!(1) {
-                return false;
-            }
+        if st.0.graph.is_directed() && r_pred!(0) > r_pred!(1) {
+            return false;
         }
 
         // // semantic feasibility: compare associated data for nodes
-        if NM::enabled() {
-            if !node_match.eq(st.0.graph, st.1.graph, nodes.0, nodes.1) {
-                return false;
-            }
+        if NM::enabled() && !node_match.eq(st.0.graph, st.1.graph, nodes.0, nodes.1) {
+            return false;
         }
         // semantic feasibility: compare associated data for edges
         if EM::enabled() {

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -81,6 +81,11 @@ where
     pub fn len(&self) -> usize {
         self.n_edges
     }
+
+    /// Returns `true` if the number of matched **edges** is 0.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl<G> Matching<G>
@@ -283,8 +288,8 @@ impl<G: GraphBase> Label<G> {
         !self.is_outer()
     }
 
-    fn to_vertex(self) -> Option<G::NodeId> {
-        match self {
+    fn to_vertex(&self) -> Option<G::NodeId> {
+        match *self {
             Label::Vertex(v) => Some(v),
             _ => None,
         }
@@ -488,7 +493,7 @@ where
 fn find_join<G, F>(
     graph: &G,
     edge: G::EdgeRef,
-    mate: &Vec<Option<G::NodeId>>,
+    mate: &[Option<G::NodeId>],
     label: &mut Vec<Label<G>>,
     first_inner: &mut Vec<usize>,
     mut visitor: F,
@@ -573,8 +578,8 @@ fn augment_path<G>(
     graph: &G,
     outer: G::NodeId,
     other: G::NodeId,
-    mate: &mut Vec<Option<G::NodeId>>,
-    label: &Vec<Label<G>>,
+    mate: &mut [Option<G::NodeId>],
+    label: &[Label<G>],
 ) where
     G: NodeIndexable,
 {

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -128,10 +128,10 @@ impl<T: Zero> Nullable for NotZero<T> {
     }
 }
 
-impl<T: Zero> Into<Option<T>> for NotZero<T> {
-    fn into(self) -> Option<T> {
-        if !self.is_null() {
-            Some(self.0)
+impl<T: Zero> From<NotZero<T>> for Option<T> {
+    fn from(not_zero: NotZero<T>) -> Self {
+        if !not_zero.is_null() {
+            Some(not_zero.0)
         } else {
             None
         }
@@ -380,9 +380,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         let p = self
             .to_edge_position(a, b)
             .expect("No edge found between the nodes.");
-        let old_weight = mem::replace(&mut self.node_adjacencies[p], Default::default())
-            .into()
-            .unwrap();
+        let old_weight = mem::take(&mut self.node_adjacencies[p]).into().unwrap();
         let old_weight: Option<_> = old_weight.into();
         self.nb_edges -= 1;
         old_weight.unwrap()

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -139,7 +139,7 @@ pub trait IntoNeighbors : GraphRef {
     type Neighbors: Iterator<Item=Self::NodeId>;
     @section self
     /// Return an iterator of the neighbors of node `a`.
-    fn neighbors(self: Self, a: Self::NodeId) -> Self::Neighbors;
+    fn neighbors(self, a: Self::NodeId) -> Self::Neighbors;
 }
 }
 


### PR DESCRIPTION
I noticed there is quite a number of clippy warnings here. I fixed some of them; let me know what you think :)

BTW, I fixed the ones I deemed safe to change. Some of the fixes are targeting a relatively new version of Rust, for example introducing the `matches!` macro might break some builds with older compilers, so I didn't touch them.
Some of the remaining ones seem rather hard to fix to me, unfortunately :)
