### PR TITLE
Require the index to be valid in NodeIndexable::from_index

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -1029,6 +1029,11 @@ where
         i
     }
     fn from_index(&self, ix: usize) -> Self::NodeId {
+        assert!(
+            ix < self.nodes.len(),
+            "The requested index {} is out-of-bounds.",
+            ix
+        );
         let (&key, _) = self.nodes.get_index(ix).unwrap();
         key
     }
@@ -1056,6 +1061,11 @@ where
     }
 
     fn from_index(&self, ix: usize) -> Self::EdgeId {
+        assert!(
+            ix < self.edges.len(),
+            "The requested index {} is out-of-bounds.",
+            ix
+        );
         let (&key, _) = self.edges.get_index(ix).unwrap();
         key
     }

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -508,7 +508,7 @@ trait_template! {
         fn node_bound(self: &Self) -> usize;
         /// Convert `a` to an integer index.
         fn to_index(self: &Self, a: Self::NodeId) -> usize;
-        /// Convert `i` to a node index
+        /// Convert `i` to a node index. `i` must be a valid value in the graph.
         fn from_index(self: &Self, i: usize) -> Self::NodeId;
     }
 }
@@ -524,7 +524,7 @@ trait_template! {
         fn edge_bound(self: &Self) -> usize;
         /// Convert `a` to an integer index.
         fn to_index(self: &Self, a: Self::EdgeId) -> usize;
-        /// Convert `i` to a node index
+        /// Convert `i` to an edge index. `i` must be a valid value in the graph.
         fn from_index(self: &Self, i: usize) -> Self::EdgeId;
     }
 }


### PR DESCRIPTION
Some graphs such as GraphMap do not have any way to create new NodeIndex values if given an invalid integer in `NodeIndexable::from_index`. Similar case for `EdgeIndexable`.
It makes sense to require the input to be valid, but this was not specified anywhere and as such was wrongfully used in the matching algorithm (see #439).

This is just a documentation update to clarify that requirement, and an assertion in GraphMap to give a better error.