### PR TITLE
Bump MSRV to 1.41, update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.37.0  # MSRV
+          - rust: 1.41.0  # MSRV
           - rust: stable
             features: unstable quickcheck
             test_all: --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,17 +29,17 @@ bench = false
 debug = true
 
 [dependencies]
-fixedbitset = { version = "0.3.0", default-features = false }
+fixedbitset = { version = "0.4.0", default-features = false }
 quickcheck = { optional = true, version = "0.8", default-features = false }
-indexmap = { version = "1.0.2" }
+indexmap = { version = "1.6.2" }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.5.5"
-odds = { version = "0.2.19" }
-defmac = "0.1"
-itertools = { version = "0.8", default-features = false }
+odds = { version = "0.4.0" }
+defmac = "0.2.1"
+itertools = { version = "0.10.1", default-features = false }
 bincode = "1.3.3"
 
 [features]

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 petgraph
 ========
 
-Graph data structure library. Known to support Rust 1.37 and later.
+Graph data structure library. Supports Rust 1.41 and later.
 
 Please read the `API documentation here`__
 

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -15,10 +15,10 @@ repository = "https://github.com/bluss/petgraph"
 
 [dependencies]
 petgraph = { path = "..", features = ["serde-1", "quickcheck"] }
-itertools = { version = "0.6.2" }
+itertools = { version = "0.10.1" }
 
 [dev-dependencies]
 serde_json = "1.0"
 quickcheck = { version = "0.8", default-features = false }
-bincode = "1.0.1"
-defmac = "0.1"
+bincode = "1.3.3"
+defmac = "0.2.1"

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -167,7 +167,7 @@ defmac!(rejson ref g => fromjson!(tojson!(g)));
 #[test]
 fn json_graph_str_i32() {
     let g1: DiGraph<_, _> = make_graph();
-    let g2: Graph<String, i32> = rejson!(g1);
+    let g2: Graph<String, i32> = rejson!(&g1);
     assert_graph_eq(&g1, &g2);
     assert_graph_eq(&g2, &g1);
 }
@@ -176,7 +176,7 @@ fn json_graph_str_i32() {
 fn json_graph_nils() {
     let g1 = make_graph().map(|_, _| (), |_, _| ());
 
-    let g2: Graph<(), ()> = rejson!(g1);
+    let g2: Graph<(), ()> = rejson!(&g1);
     assert_graph_eq(&g1, &g2);
     assert_graph_eq(&g2, &g1);
 }
@@ -212,42 +212,42 @@ type DiGraphStrI32 = DiGraph<String, i32>;
 
 #[test]
 fn from_json_digraph_nils() {
-    let _: DiGraphNils = fromjson!(DIGRAPH_NILS);
+    let _: DiGraphNils = fromjson!(&DIGRAPH_NILS);
 }
 
 #[test]
 #[should_panic(expected = "edge property mismatch")]
 fn from_json_graph_nils_edge_property_mismatch() {
-    let _: UnGraphNils = fromjson!(DIGRAPH_NILS);
+    let _: UnGraphNils = fromjson!(&DIGRAPH_NILS);
 }
 
 #[test]
 #[should_panic(expected = "does not exist")]
 fn from_json_graph_nils_index_oob() {
-    let _: DiGraphNils = fromjson!(DIGRAPH_NILS_INDEX_OOB);
+    let _: DiGraphNils = fromjson!(&DIGRAPH_NILS_INDEX_OOB);
 }
 
 #[test]
 #[should_panic(expected = "expected u8")]
 fn from_json_graph_nils_index_too_large() {
-    let _: DiGraphNilsU8 = fromjson!(DIGRAPH_NILS_INDEX_OUTSIDE_U8);
+    let _: DiGraphNilsU8 = fromjson!(&DIGRAPH_NILS_INDEX_OUTSIDE_U8);
 }
 
 #[test]
 fn from_json_graph_directed_str_i32() {
-    let _: DiGraphStrI32 = fromjson!(DIGRAPH_STRI32);
+    let _: DiGraphStrI32 = fromjson!(&DIGRAPH_STRI32);
 }
 
 #[test]
 #[should_panic(expected = "expected unit")]
 fn from_json_graph_from_edge_type_1() {
-    let _: DiGraphNils = fromjson!(DIGRAPH_STRI32);
+    let _: DiGraphNils = fromjson!(&DIGRAPH_STRI32);
 }
 
 #[test]
 #[should_panic(expected = "expected a string")]
 fn from_json_graph_from_edge_type_2() {
-    let _: DiGraphStrI32 = fromjson!(DIGRAPH_NILS);
+    let _: DiGraphStrI32 = fromjson!(&DIGRAPH_NILS);
 }
 
 #[test]
@@ -268,7 +268,7 @@ fn from_json_digraph_str_i32() {
     type GSI = DiGraph<String, i32>;
     type GSISmall = DiGraph<String, i32, u8>;
 
-    let g4: GSI = fromjson!(DIGRAPH_STRI32);
+    let g4: GSI = fromjson!(&DIGRAPH_STRI32);
 
     for ni in g4.node_indices() {
         assert_eq!(&g4nodes[ni.index()], &g4[ni]);
@@ -283,7 +283,7 @@ fn from_json_digraph_str_i32() {
         assert_eq!(edge_data[2], g4[e.id()]);
     }
 
-    let _g4small: GSISmall = fromjson!(DIGRAPH_STRI32);
+    let _g4small: GSISmall = fromjson!(&DIGRAPH_STRI32);
 }
 
 #[test]
@@ -313,12 +313,12 @@ fn from_json_nodes_too_big() {
     type H1 = DiGraph<i32, i32>;
 
     assert!(from_str::<G8>(j1_big).is_err());
-    let _: G16 = fromjson!(j1_big); // assert
-    let _: G32 = fromjson!(j1_big); // assert
-    let _: G64 = fromjson!(j1_big); // assert
+    let _: G16 = fromjson!(&j1_big); // assert
+    let _: G32 = fromjson!(&j1_big); // assert
+    let _: G64 = fromjson!(&j1_big); // assert
 
     // other edge weight is also ok -- because it has no edges
-    let _: H1 = fromjson!(j1_big); // assert
+    let _: H1 = fromjson!(&j1_big); // assert
 }
 
 #[test]
@@ -343,15 +343,15 @@ fn from_json_edges_too_big() {
 
     assert!(from_str::<G8>(&j1_big).is_err());
     assert!(from_str::<G16>(&j1_big).is_err());
-    let _: G32 = fromjson!(j1_big); // assert
-    let _: G64 = fromjson!(j1_big); // assert
+    let _: G32 = fromjson!(&j1_big); // assert
+    let _: G64 = fromjson!(&j1_big); // assert
 }
 
 #[test]
 fn json_stable_graph_str() {
     let g1 = make_stable_graph();
 
-    let g2: StableGraph<String, i32> = rejson!(g1);
+    let g2: StableGraph<String, i32> = rejson!(&g1);
 
     // map &str -> String
     let g1 = g1.map(|_, s| s.to_string(), |_, &w| w);
@@ -361,7 +361,7 @@ fn json_stable_graph_str() {
 #[test]
 fn json_stable_graph_nils() {
     let g1 = make_stable_graph().map(|_, _| (), |_, _| ());
-    let g2 = rejson!(g1);
+    let g2 = rejson!(&g1);
     assert_stable_graph_eq(&g1, &g2);
 }
 
@@ -373,14 +373,14 @@ defmac!(recode ref g => decode!(encode!(g)));
 #[test]
 fn bincode_stablegraph_to_graph_i32_0() {
     let g1 = StableGraph::<i32, i32>::new();
-    let g2: Graph<i32, i32> = recode!(g1);
+    let g2: Graph<i32, i32> = recode!(&g1);
     assert_graph_eq(&g2, &Graph::<i32, i32>::default());
 }
 
 #[test]
 fn bincode_graph_to_stablegraph_i32_0() {
     let g1 = Graph::<i32, i32>::new();
-    let g2: StableGraph<i32, i32> = recode!(g1);
+    let g2: StableGraph<i32, i32> = recode!(&g1);
     assert_stable_graph_eq(&g2, &StableGraph::<i32, i32>::default());
 }
 
@@ -389,7 +389,7 @@ fn bincode_graph_to_graph_i32_1() {
     let mut g1 = Graph::<i32, i32>::new();
     let x = 1729;
     g1.add_node(x);
-    let g2: Graph<i32, i32> = recode!(g1);
+    let g2: Graph<i32, i32> = recode!(&g1);
 
     assert_graph_eq(&g1, &g2);
 }
@@ -406,7 +406,7 @@ fn bincode_stablegraph_added2_removed2() {
     let b = g1.add_node(x + 1);
     g1.remove_node(a);
     g1.remove_node(b);
-    let g2: StableGraph<i32, i32> = recode!(g1);
+    let g2: StableGraph<i32, i32> = recode!(&g1);
 
     assert_stable_graph_eq(&g1, &g2);
 }
@@ -424,7 +424,7 @@ fn bincode_stablegraph_added3_removed2() {
     let _c = g1.add_node(x + 2);
     g1.remove_node(a);
     g1.remove_node(b);
-    let g2: StableGraph<i32, i32> = recode!(g1);
+    let g2: StableGraph<i32, i32> = recode!(&g1);
 
     assert_stable_graph_eq(&g1, &g2);
 }
@@ -434,7 +434,7 @@ fn bincode_stablegraph_to_graph_i32_1() {
     let mut g1 = StableGraph::<i32, i32>::new();
     let x = 1729;
     g1.add_node(x);
-    let g2: Graph<i32, i32> = recode!(g1);
+    let g2: Graph<i32, i32> = recode!(&g1);
 
     assert_eq!(g2.node_count(), 1);
     assert_eq!(g2.edge_count(), 0);
@@ -443,47 +443,47 @@ fn bincode_stablegraph_to_graph_i32_1() {
 
 quickcheck! {
     fn json_graph_to_stablegraph_to_graph(g1: Graph<i32, i32>) -> () {
-        let sg: StableGraph<i32, i32> = rejson!(g1);
-        let g2: Graph<i32, i32> = rejson!(sg);
+        let sg: StableGraph<i32, i32> = rejson!(&g1);
+        let g2: Graph<i32, i32> = rejson!(&sg);
         assert_graph_eq(&g1, &g2);
     }
 
     fn json_stablegraph_to_stablegraph(g1: StableGraph<i32, i32>) -> () {
-        let sg: StableGraph<i32, i32> = rejson!(g1);
+        let sg: StableGraph<i32, i32> = rejson!(&g1);
         assert_stable_graph_eq(&g1, &sg);
     }
 
     fn json_graph_to_bigger_graph(g1: DiGraph<i32, i32, u16>) -> () {
-        let g2: DiGraph<i32, i32, usize> = rejson!(g1);
-        let g3: DiGraph<i32, i32, u16> = rejson!(g2);
+        let g2: DiGraph<i32, i32, usize> = rejson!(&g1);
+        let g3: DiGraph<i32, i32, u16> = rejson!(&g2);
         assert_graph_eq(&g1, &g3);
     }
 
     fn bincode_graph_to_graph_nils(g1: Graph<(), ()>) -> () {
-        let g2: Graph<(), ()> = recode!(g1);
+        let g2: Graph<(), ()> = recode!(&g1);
         assert_graph_eq(&g1, &g2);
     }
 
     fn bincode_graph_to_stablegraph_to_graph_nils(g1: Graph<(), ()>) -> () {
-        let data = encode!(g1);
-        let sg: StableGraph<(), ()> = decode!(data);
-        let data2 = encode!(sg);
-        let g2: Graph<(), ()> = decode!(data2);
+        let data = encode!(&g1);
+        let sg: StableGraph<(), ()> = decode!(&data);
+        let data2 = encode!(&sg);
+        let g2: Graph<(), ()> = decode!(&data2);
         assert_eq!(data, data2);
         assert_graph_eq(&g1, &g2);
     }
 
     fn bincode_graph_to_stablegraph_to_graph_u16(g1: DiGraph<i32, i32, u16>) -> () {
-        let data = encode!(g1);
-        let sg: StableDiGraph<i32, i32, u16> = decode!(data);
-        let data2 = encode!(sg);
-        let g2: DiGraph<i32, i32, u16> = decode!(data2);
+        let data = encode!(&g1);
+        let sg: StableDiGraph<i32, i32, u16> = decode!(&data);
+        let data2 = encode!(&sg);
+        let g2: DiGraph<i32, i32, u16> = decode!(&data2);
         assert_eq!(data, data2);
         assert_graph_eq(&g1, &g2);
     }
 
     fn bincode_stablegraph_to_stablegraph(g1: StableGraph<i32, i32>) -> () {
-        let g2: StableGraph<i32, i32> = recode!(g1);
+        let g2: StableGraph<i32, i32> = recode!(&g1);
         assert_stable_graph_eq(&g1, &g2);
     }
 }

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -15,7 +15,7 @@ fn random_01<G: Gen>(g: &mut G) -> f64 {
     // from rand
     let bits = 53;
     let scale = 1. / ((1u64 << bits) as f64);
-    let x = g.next_u64();
+    let x: u64 = Arbitrary::arbitrary(g);
     (x >> (64 - bits)) as f64 * scale
 }
 

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -140,9 +140,9 @@ fn test_edges_directed() {
     let gr = make_graph();
     dbg!(&gr);
     let x = n(9);
-    assert_equal(edges!(gr, x), vec![(1, 11), (x, 12), (x, 13)]);
-    assert_equal(edges!(gr, n(0)), vec![(n(3), 1)]);
-    //assert_equal(edges!(gr, n(4)), vec![]);
+    assert_equal(edges!(&gr, x), vec![(1, 11), (x, 12), (x, 13)]);
+    assert_equal(edges!(&gr, n(0)), vec![(n(3), 1)]);
+    //assert_equal(edges!(&gr, n(4)), vec![]);
 }
 
 #[test]

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -19,6 +19,7 @@ use std::hash::Hash;
 
 use itertools::assert_equal;
 use itertools::cloned;
+use quickcheck::{Arbitrary, Gen};
 use rand::Rng;
 
 use petgraph::algo::{
@@ -507,7 +508,7 @@ quickcheck! {
 quickcheck! {
     fn kosaraju_scc_is_topo_sort(g: Graph<(), ()>) -> bool {
         let tsccs = kosaraju_scc(&g);
-        let firsts = vec(tsccs.iter().rev().map(|v| v[0]));
+        let firsts = tsccs.iter().rev().map(|v| v[0]).collect::<Vec<_>>();
         subset_is_topo_order(&g, &firsts)
     }
 }
@@ -515,7 +516,7 @@ quickcheck! {
 quickcheck! {
     fn tarjan_scc_is_topo_sort(g: Graph<(), ()>) -> bool {
         let tsccs = tarjan_scc(&g);
-        let firsts = vec(tsccs.iter().rev().map(|v| v[0]));
+        let firsts = tsccs.iter().rev().map(|v| v[0]).collect::<Vec<_>>();
         subset_is_topo_order(&g, &firsts)
     }
 }
@@ -569,8 +570,8 @@ fn graph_condensation_acyclic() {
 #[derive(Debug, Clone)]
 struct DAG<N: Default + Clone + Send + 'static>(Graph<N, ()>);
 
-impl<N: Default + Clone + Send + 'static> quickcheck::Arbitrary for DAG<N> {
-    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+impl<N: Default + Clone + Send + 'static> Arbitrary for DAG<N> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let nodes = usize::arbitrary(g);
         if nodes == 0 {
             return DAG(Graph::with_capacity(0, 0));
@@ -950,17 +951,17 @@ quickcheck! {
         let sgr = StableGraph::from(gr1.clone());
         let gr2 = Graph::from(sgr);
 
-        assert!(nodes_eq!(gr1, gr2));
-        assert!(edgew_eq!(gr1, gr2));
-        assert!(edges_eq!(gr1, gr2));
+        assert!(nodes_eq!(&gr1, &gr2));
+        assert!(edgew_eq!(&gr1, &gr2));
+        assert!(edges_eq!(&gr1, &gr2));
     }
     fn test_un_from(gr1: UnGraph<i32, i32>) -> () {
         let sgr = StableGraph::from(gr1.clone());
         let gr2 = Graph::from(sgr);
 
-        assert!(nodes_eq!(gr1, gr2));
-        assert!(edgew_eq!(gr1, gr2));
-        assert!(edges_eq!(gr1, gr2));
+        assert!(nodes_eq!(&gr1, &gr2));
+        assert!(edgew_eq!(&gr1, &gr2));
+        assert!(edges_eq!(&gr1, &gr2));
     }
 
     fn test_graph_from_stable_graph(gr1: StableDiGraph<usize, usize>) -> () {
@@ -999,30 +1000,30 @@ quickcheck! {
 
     fn stable_di_graph_map_id(gr1: StableDiGraph<usize, usize>) -> () {
         let gr2 = gr1.map(|_, &nw| nw, |_, &ew| ew);
-        assert!(nodes_eq!(gr1, gr2));
-        assert!(edgew_eq!(gr1, gr2));
-        assert!(edges_eq!(gr1, gr2));
+        assert!(nodes_eq!(&gr1, &gr2));
+        assert!(edgew_eq!(&gr1, &gr2));
+        assert!(edges_eq!(&gr1, &gr2));
     }
 
     fn stable_un_graph_map_id(gr1: StableUnGraph<usize, usize>) -> () {
         let gr2 = gr1.map(|_, &nw| nw, |_, &ew| ew);
-        assert!(nodes_eq!(gr1, gr2));
-        assert!(edgew_eq!(gr1, gr2));
-        assert!(edges_eq!(gr1, gr2));
+        assert!(nodes_eq!(&gr1, &gr2));
+        assert!(edgew_eq!(&gr1, &gr2));
+        assert!(edges_eq!(&gr1, &gr2));
     }
 
     fn stable_di_graph_filter_map_id(gr1: StableDiGraph<usize, usize>) -> () {
         let gr2 = gr1.filter_map(|_, &nw| Some(nw), |_, &ew| Some(ew));
-        assert!(nodes_eq!(gr1, gr2));
-        assert!(edgew_eq!(gr1, gr2));
-        assert!(edges_eq!(gr1, gr2));
+        assert!(nodes_eq!(&gr1, &gr2));
+        assert!(edgew_eq!(&gr1, &gr2));
+        assert!(edges_eq!(&gr1, &gr2));
     }
 
     fn test_stable_un_graph_filter_map_id(gr1: StableUnGraph<usize, usize>) -> () {
         let gr2 = gr1.filter_map(|_, &nw| Some(nw), |_, &ew| Some(ew));
-        assert!(nodes_eq!(gr1, gr2));
-        assert!(edgew_eq!(gr1, gr2));
-        assert!(edges_eq!(gr1, gr2));
+        assert!(nodes_eq!(&gr1, &gr2));
+        assert!(edgew_eq!(&gr1, &gr2));
+        assert!(edges_eq!(&gr1, &gr2));
     }
 
     fn stable_di_graph_filter_map_remove(gr1: Small<StableDiGraph<i32, i32>>,

--- a/tests/stable_graph.rs
+++ b/tests/stable_graph.rs
@@ -177,9 +177,9 @@ defmac!(edges ref gr, x => gr.edges(x).map(|r| (r.target(), *r.weight())));
 fn test_edges_directed() {
     let gr = make_graph::<Directed>();
     let x = n(9);
-    assert_equal(edges!(gr, x), vec![(x, 16), (x, 14), (n(1), 13)]);
-    assert_equal(edges!(gr, n(0)), vec![(n(3), 1)]);
-    assert_equal(edges!(gr, n(4)), vec![]);
+    assert_equal(edges!(&gr, x), vec![(x, 16), (x, 14), (n(1), 13)]);
+    assert_equal(edges!(&gr, n(0)), vec![(n(3), 1)]);
+    assert_equal(edges!(&gr, n(4)), vec![]);
 }
 
 #[test]
@@ -193,11 +193,11 @@ fn test_edges_undirected() {
     let gr = make_graph::<Undirected>();
     let x = n(9);
     assert_equal(
-        edges!(gr, x),
+        edges!(&gr, x),
         vec![(x, 16), (x, 14), (n(1), 13), (n(7), 12)],
     );
-    assert_equal(edges!(gr, n(0)), vec![(n(3), 1)]);
-    assert_equal(edges!(gr, n(4)), vec![]);
+    assert_equal(edges!(&gr, n(0)), vec![(n(3), 1)]);
+    assert_equal(edges!(&gr, n(4)), vec![]);
 }
 
 #[test]
@@ -353,9 +353,9 @@ fn from() {
 
     let gr2 = Graph::from(gr1.clone());
     let gr3 = StableGraph::from(gr2);
-    assert!(nodes_eq!(gr1, gr3));
-    assert!(edgew_eq!(gr1, gr3));
-    assert!(edges_eq!(gr1, gr3));
+    assert!(nodes_eq!(&gr1, &gr3));
+    assert!(edgew_eq!(&gr1, &gr3));
+    assert!(edges_eq!(&gr1, &gr3));
 
     gr1.remove_node(b);
 
@@ -368,12 +368,12 @@ fn from() {
     ans.add_edge(a, a, 10);
     ans.add_edge(a, c, 40);
 
-    assert!(nodes_eq!(gr4, ans));
-    assert!(edges_eq!(gr4, ans));
+    assert!(nodes_eq!(&gr4, &ans));
+    assert!(edges_eq!(&gr4, &ans));
 
-    assert!(nodes_eq!(gr5, ans));
-    assert!(edgew_eq!(gr5, ans));
-    assert!(edges_eq!(gr5, ans));
+    assert!(nodes_eq!(&gr5, &ans));
+    assert!(edgew_eq!(&gr5, &ans));
+    assert!(edges_eq!(&gr5, &ans));
 }
 
 use petgraph::data::FromElements;


### PR DESCRIPTION
Updates the MSRV as discussed in #428, and updates some dependencies with it.

Unfortunately we can't update quickcheck to 1.0 yet because we need to generate floats in the 0..1 range in various tests. See https://github.com/BurntSushi/quickcheck/issues/267.