### PR TITLE
Organize visit trait implementations

### DIFF
--- a/src/csr.rs
+++ b/src/csr.rs
@@ -7,9 +7,9 @@ use std::ops::{Index, IndexMut, Range};
 use std::slice::Windows;
 
 use crate::visit::{
-    Data, EdgeRef, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
-    IntoNeighbors, IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeCount,
-    NodeIndexable, Visitable,
+    Data, EdgeCount, EdgeRef, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences,
+    IntoEdges, IntoNeighbors, IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable,
+    NodeCount, NodeIndexable, Visitable,
 };
 
 use crate::util::zip;
@@ -716,6 +716,17 @@ where
 {
     fn node_count(&self) -> usize {
         (*self).node_count()
+    }
+}
+
+impl<N, E, Ty, Ix> EdgeCount for Csr<N, E, Ty, Ix>
+where
+    Ty: EdgeType,
+    Ix: IndexType,
+{
+    #[inline]
+    fn edge_count(&self) -> usize {
+        self.edge_count()
     }
 }
 

--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -5,8 +5,9 @@ use crate::data::{DataMap, DataMapMut};
 use crate::graph::Graph;
 use crate::graph::{GraphIndex, IndexType};
 use crate::visit::{
-    Data, EdgeCount, EdgeIndexable, GetAdjacencyMatrix, GraphProp, IntoEdges, IntoEdgesDirected,
-    IntoNeighborsDirected, IntoNodeIdentifiers, NodeCompactIndexable, NodeCount, NodeIndexable,
+    Data, EdgeCount, EdgeIndexable, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdges,
+    IntoEdgesDirected, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCompactIndexable, NodeCount,
+    NodeIndexable,
 };
 use crate::visit::{IntoEdgeReferences, IntoNeighbors, IntoNodeReferences, Visitable};
 use crate::{Direction, EdgeType};
@@ -76,6 +77,14 @@ macro_rules! access0 {
     ($e:expr) => {
         $e.0
     };
+}
+
+impl<'a, G> GraphBase for Frozen<'a, G>
+where
+    G: GraphBase,
+{
+    type NodeId = G::NodeId;
+    type EdgeId = G::EdgeId;
 }
 
 Data! {delegate_impl [['a, G], G, Frozen<'a, G>, deref_twice]}

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -15,7 +15,7 @@ use crate::{Directed, Direction, EdgeType, IntoWeightedEdge, Outgoing, Undirecte
 use crate::graph::NodeIndex as GraphNodeIndex;
 
 use crate::visit::{
-    Data, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+    Data, EdgeCount, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
     IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
     IntoNodeReferences, NodeCount, NodeIndexable, Visitable,
 };
@@ -1073,6 +1073,15 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> NodeCount
 {
     fn node_count(&self) -> usize {
         MatrixGraph::node_count(self)
+    }
+}
+
+impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> EdgeCount
+    for MatrixGraph<N, E, Ty, Null, Ix>
+{
+    #[inline]
+    fn edge_count(&self) -> usize {
+        self.edge_count()
     }
 }
 

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -36,6 +36,29 @@
 //! [in]: trait.IntoNeighbors.html
 //! [vis]: trait.Visitable.html
 //!
+//! ### Graph Trait Implementations
+//!
+//! The following table lists the traits that are implemented for each graph type:
+//!
+//! |                       | Graph | StableGraph | GraphMap | MatrixGraph | Csr   | List  |
+//! | --------------------- | :---: | :---------: | :------: | :---------: | :---: | :---: |
+//! | GraphBase             | x     |  x          |    x     | x           | x     |  x    |
+//! | GraphProp             | x     |  x          |    x     | x           | x     |  x    |
+//! | NodeCount             | x     |  x          |    x     | x           | x     |  x    |
+//! | NodeIndexable         | x     |  x          |    x     | x           | x     |  x    |
+//! | NodeCompactIndexable  | x     |             |    x     |             | x     |  x    |
+//! | EdgeCount             | x     |  x          |    x     | x           | x     |  x    |
+//! | EdgeIndexable         | x     |  x          |    x     |             |       |       |
+//! | Data                  | x     |  x          |    x     | x           | x     |  x    |
+//! | IntoNodeIdentifiers   | x     |  x          |    x     | x           | x     |  x    |
+//! | IntoNodeReferences    | x     |  x          |    x     | x           | x     |  x    |
+//! | IntoEdgeReferences    | x     |  x          |    x     | x           | x     |  x    |
+//! | IntoNeighbors         | x     |  x          |    x     | x           | x     |  x    |
+//! | IntoNeighborsDirected | x     |  x          |    x     | x           |       |       |
+//! | IntoEdges             | x     |  x          |    x     | x           | x     |  x    |
+//! | IntoEdgesDirected     | x     |  x          |    x     | x           |       |       |
+//! | Visitable             | x     |  x          |    x     | x           | x     |  x    |
+//! | GetAdjacencyMatrix    | x     |  x          |    x     | x           | x     |  x    |
 
 // filter, reversed have their `mod` lines at the end,
 // so that they can use the trait template macros

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -54,23 +54,10 @@ use fixedbitset::FixedBitSet;
 use std::collections::HashSet;
 use std::hash::{BuildHasher, Hash};
 
-use super::{graph, EdgeType};
-use crate::graph::NodeIndex;
-#[cfg(feature = "graphmap")]
-use crate::prelude::GraphMap;
-#[cfg(feature = "stable_graph")]
-use crate::prelude::StableGraph;
-use crate::prelude::{Direction, Graph};
+use super::EdgeType;
+use crate::prelude::Direction;
 
-use crate::csr::Csr;
-use crate::graph::Frozen;
 use crate::graph::IndexType;
-#[cfg(feature = "graphmap")]
-use crate::graphmap::{self, NodeTrait};
-#[cfg(feature = "matrix_graph")]
-use crate::matrix_graph::MatrixGraph;
-#[cfg(feature = "stable_graph")]
-use crate::stable_graph;
 
 trait_template! {
 /// Base graph trait: defines the associated node identifier and
@@ -94,38 +81,6 @@ GraphBase! {delegate_impl [['a, G], G, &'a mut G, deref]}
 pub trait GraphRef: Copy + GraphBase {}
 
 impl<'a, G> GraphRef for &'a G where G: GraphBase {}
-
-impl<'a, G> GraphBase for Frozen<'a, G>
-where
-    G: GraphBase,
-{
-    type NodeId = G::NodeId;
-    type EdgeId = G::EdgeId;
-}
-
-#[cfg(feature = "stable_graph")]
-impl<'a, N, E: 'a, Ty, Ix> IntoNeighbors for &'a StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type Neighbors = stable_graph::Neighbors<'a, E, Ix>;
-    fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
-        (*self).neighbors(n)
-    }
-}
-
-#[cfg(feature = "graphmap")]
-impl<'a, N: 'a, E, Ty> IntoNeighbors for &'a GraphMap<N, E, Ty>
-where
-    N: Copy + Ord + Hash,
-    Ty: EdgeType,
-{
-    type Neighbors = graphmap::Neighbors<'a, N, Ty>;
-    fn neighbors(self, n: Self::NodeId) -> Self::Neighbors {
-        self.neighbors(n)
-    }
-}
 
 trait_template! {
 /// Access to the neighbors of each node
@@ -161,56 +116,6 @@ pub trait IntoNeighborsDirected : IntoNeighbors {
     fn neighbors_directed(self, n: Self::NodeId, d: Direction)
         -> Self::NeighborsDirected;
 }
-}
-
-impl<'a, N, E: 'a, Ty, Ix> IntoNeighbors for &'a Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type Neighbors = graph::Neighbors<'a, E, Ix>;
-    fn neighbors(self, n: graph::NodeIndex<Ix>) -> graph::Neighbors<'a, E, Ix> {
-        Graph::neighbors(self, n)
-    }
-}
-
-impl<'a, N, E: 'a, Ty, Ix> IntoNeighborsDirected for &'a Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type NeighborsDirected = graph::Neighbors<'a, E, Ix>;
-    fn neighbors_directed(
-        self,
-        n: graph::NodeIndex<Ix>,
-        d: Direction,
-    ) -> graph::Neighbors<'a, E, Ix> {
-        Graph::neighbors_directed(self, n, d)
-    }
-}
-
-#[cfg(feature = "stable_graph")]
-impl<'a, N, E: 'a, Ty, Ix> IntoNeighborsDirected for &'a StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type NeighborsDirected = stable_graph::Neighbors<'a, E, Ix>;
-    fn neighbors_directed(self, n: graph::NodeIndex<Ix>, d: Direction) -> Self::NeighborsDirected {
-        StableGraph::neighbors_directed(self, n, d)
-    }
-}
-
-#[cfg(feature = "graphmap")]
-impl<'a, N: 'a, E, Ty> IntoNeighborsDirected for &'a GraphMap<N, E, Ty>
-where
-    N: Copy + Ord + Hash,
-    Ty: EdgeType,
-{
-    type NeighborsDirected = graphmap::NeighborsDirected<'a, N, Ty>;
-    fn neighbors_directed(self, n: N, dir: Direction) -> Self::NeighborsDirected {
-        self.neighbors_directed(n, dir)
-    }
 }
 
 trait_template! {
@@ -273,51 +178,6 @@ pub trait IntoNodeIdentifiers : GraphRef {
 }
 
 IntoNodeIdentifiers! {delegate_impl []}
-
-impl<'a, N, E: 'a, Ty, Ix> IntoNodeIdentifiers for &'a Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type NodeIdentifiers = graph::NodeIndices<Ix>;
-    fn node_identifiers(self) -> graph::NodeIndices<Ix> {
-        Graph::node_indices(self)
-    }
-}
-
-impl<N, E, Ty, Ix> NodeCount for Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    fn node_count(&self) -> usize {
-        self.node_count()
-    }
-}
-
-#[cfg(feature = "stable_graph")]
-impl<'a, N, E: 'a, Ty, Ix> IntoNodeIdentifiers for &'a StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type NodeIdentifiers = stable_graph::NodeIndices<'a, N, Ix>;
-    fn node_identifiers(self) -> Self::NodeIdentifiers {
-        StableGraph::node_indices(self)
-    }
-}
-
-#[cfg(feature = "stable_graph")]
-impl<N, E, Ty, Ix> NodeCount for StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    fn node_count(&self) -> usize {
-        self.node_count()
-    }
-}
-
 IntoNeighborsDirected! {delegate_impl []}
 
 trait_template! {
@@ -435,16 +295,6 @@ pub trait IntoEdgeReferences : Data + GraphRef {
 
 IntoEdgeReferences! {delegate_impl [] }
 
-#[cfg(feature = "graphmap")]
-impl<N, E, Ty> Data for GraphMap<N, E, Ty>
-where
-    N: Copy + PartialEq,
-    Ty: EdgeType,
-{
-    type NodeWeight = N;
-    type EdgeWeight = E;
-}
-
 trait_template! {
     /// Edge kind property (directed or undirected edges)
 pub trait GraphProp : GraphBase {
@@ -460,44 +310,6 @@ pub trait GraphProp : GraphBase {
 }
 
 GraphProp! {delegate_impl []}
-
-impl<N, E, Ty, Ix> GraphProp for Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type EdgeType = Ty;
-}
-
-#[cfg(feature = "stable_graph")]
-impl<N, E, Ty, Ix> GraphProp for StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type EdgeType = Ty;
-}
-
-#[cfg(feature = "graphmap")]
-impl<N, E, Ty> GraphProp for GraphMap<N, E, Ty>
-where
-    N: NodeTrait,
-    Ty: EdgeType,
-{
-    type EdgeType = Ty;
-}
-
-impl<'a, N: 'a, E: 'a, Ty, Ix> IntoEdgeReferences for &'a Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type EdgeRef = graph::EdgeReference<'a, E, Ix>;
-    type EdgeReferences = graph::EdgeReferences<'a, E, Ix>;
-    fn edge_references(self) -> Self::EdgeReferences {
-        (*self).edge_references()
-    }
-}
 
 trait_template! {
     /// The graph’s `NodeId`s map to indices
@@ -551,32 +363,6 @@ pub trait NodeCompactIndexable : NodeIndexable + NodeCount { }
 
 NodeCompactIndexable! {delegate_impl []}
 
-impl<N, E, Ty, Ix> NodeIndexable for Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    #[inline]
-    fn node_bound(&self) -> usize {
-        self.node_count()
-    }
-    #[inline]
-    fn to_index(&self, ix: NodeIndex<Ix>) -> usize {
-        ix.index()
-    }
-    #[inline]
-    fn from_index(&self, ix: usize) -> Self::NodeId {
-        NodeIndex::new(ix)
-    }
-}
-
-impl<N, E, Ty, Ix> NodeCompactIndexable for Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-}
-
 /// A mapping for storing the visited status for NodeId `N`.
 pub trait VisitMap<N> {
     /// Mark `a` as visited.
@@ -628,89 +414,6 @@ pub trait Visitable : GraphBase {
 }
 Visitable! {delegate_impl []}
 
-impl<N, E, Ty, Ix> GraphBase for Graph<N, E, Ty, Ix>
-where
-    Ix: IndexType,
-{
-    type NodeId = graph::NodeIndex<Ix>;
-    type EdgeId = graph::EdgeIndex<Ix>;
-}
-
-impl<N, E, Ty, Ix> Visitable for Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type Map = FixedBitSet;
-    fn visit_map(&self) -> FixedBitSet {
-        FixedBitSet::with_capacity(self.node_count())
-    }
-
-    fn reset_map(&self, map: &mut Self::Map) {
-        map.clear();
-        map.grow(self.node_count());
-    }
-}
-
-#[cfg(feature = "stable_graph")]
-impl<N, E, Ty, Ix> GraphBase for StableGraph<N, E, Ty, Ix>
-where
-    Ix: IndexType,
-{
-    type NodeId = graph::NodeIndex<Ix>;
-    type EdgeId = graph::EdgeIndex<Ix>;
-}
-
-#[cfg(feature = "stable_graph")]
-impl<N, E, Ty, Ix> Visitable for StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type Map = FixedBitSet;
-    fn visit_map(&self) -> FixedBitSet {
-        FixedBitSet::with_capacity(self.node_bound())
-    }
-    fn reset_map(&self, map: &mut Self::Map) {
-        map.clear();
-        map.grow(self.node_bound());
-    }
-}
-
-#[cfg(feature = "stable_graph")]
-impl<N, E, Ty, Ix> Data for StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    type NodeWeight = N;
-    type EdgeWeight = E;
-}
-
-#[cfg(feature = "graphmap")]
-impl<N, E, Ty> GraphBase for GraphMap<N, E, Ty>
-where
-    N: Copy + PartialEq,
-{
-    type NodeId = N;
-    type EdgeId = (N, N);
-}
-
-#[cfg(feature = "graphmap")]
-impl<N, E, Ty> Visitable for GraphMap<N, E, Ty>
-where
-    N: Copy + Ord + Hash,
-    Ty: EdgeType,
-{
-    type Map = HashSet<N>;
-    fn visit_map(&self) -> HashSet<N> {
-        HashSet::with_capacity(self.node_count())
-    }
-    fn reset_map(&self, map: &mut Self::Map) {
-        map.clear();
-    }
-}
-
 trait_template! {
 /// Create or access the adjacency matrix of a graph.
 ///
@@ -732,22 +435,6 @@ pub trait GetAdjacencyMatrix : GraphBase {
 
 GetAdjacencyMatrix! {delegate_impl []}
 
-#[cfg(feature = "graphmap")]
-/// The `GraphMap` keeps an adjacency matrix internally.
-impl<N, E, Ty> GetAdjacencyMatrix for GraphMap<N, E, Ty>
-where
-    N: Copy + Ord + Hash,
-    Ty: EdgeType,
-{
-    type AdjMatrix = ();
-    #[inline]
-    fn adjacency_matrix(&self) {}
-    #[inline]
-    fn is_adjacent(&self, _: &(), a: N, b: N) -> bool {
-        self.contains_edge(a, b)
-    }
-}
-
 trait_template! {
 /// A graph with a known edge count.
 pub trait EdgeCount : GraphBase {
@@ -758,64 +445,6 @@ pub trait EdgeCount : GraphBase {
 }
 
 EdgeCount! {delegate_impl []}
-
-impl<N, E, Ty, Ix> EdgeCount for Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    #[inline]
-    fn edge_count(&self) -> usize {
-        self.edge_count()
-    }
-}
-
-#[cfg(feature = "stable_graph")]
-impl<N, E, Ty, Ix> EdgeCount for StableGraph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    #[inline]
-    fn edge_count(&self) -> usize {
-        self.edge_count()
-    }
-}
-
-#[cfg(feature = "graphmap")]
-impl<N, E, Ty> EdgeCount for GraphMap<N, E, Ty>
-where
-    N: NodeTrait,
-    Ty: EdgeType,
-{
-    #[inline]
-    fn edge_count(&self) -> usize {
-        self.edge_count()
-    }
-}
-
-#[cfg(feature = "matrix_graph")]
-impl<N, E, Ty> EdgeCount for MatrixGraph<N, E, Ty>
-where
-    N: NodeTrait,
-    Ty: EdgeType,
-{
-    #[inline]
-    fn edge_count(&self) -> usize {
-        self.edge_count()
-    }
-}
-
-impl<N, E, Ty, Ix> EdgeCount for Csr<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
-    #[inline]
-    fn edge_count(&self) -> usize {
-        self.edge_count()
-    }
-}
 
 mod filter;
 mod reversed;


### PR DESCRIPTION
Some graphs had their visit trait implementations in the visit modules, while others had them in the graph module (and normally it was a mix between the two).
This commit moves all the impls to the respective graph modules, to make the organization of the code more consistent.
The public API remains the same

I also added a table to the visit module documentation listing which graph implements which trait, as it may come useful to have a quick view of that.