### PR TITLE
Export missing graph::{EdgeWeights,NodeWeights}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,9 +161,9 @@ pub mod prelude;
 pub mod graph {
     pub use crate::graph_impl::{
         edge_index, node_index, DefaultIx, DiGraph, Edge, EdgeIndex, EdgeIndices, EdgeReference,
-        EdgeReferences, EdgeWeightsMut, Edges, EdgesConnecting, Externals, Frozen, Graph,
-        GraphIndex, IndexType, Neighbors, Node, NodeIndex, NodeIndices, NodeReferences,
-        NodeWeightsMut, UnGraph, WalkNeighbors,
+        EdgeReferences, EdgeWeights, EdgeWeightsMut, Edges, EdgesConnecting, Externals, Frozen,
+        Graph, GraphIndex, IndexType, Neighbors, Node, NodeIndex, NodeIndices, NodeReferences,
+        NodeWeights, NodeWeightsMut, UnGraph, WalkNeighbors,
     };
 }
 


### PR DESCRIPTION
The `EdgeWeights` and `NodeWeights` structs weren't exported, so [`node_weights()`](https://docs.rs/petgraph/0.6.0/petgraph/graph/struct.Graph.html#method.node_weights) and [`edge_weights()`](https://docs.rs/petgraph/0.6.0/petgraph/graph/struct.Graph.html#method.edge_weights) weren't usable.