### PR TITLE
[FIX-BIPARTITE-CHECK] check should identify disconnected cycles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.41.0  # MSRV
+          - rust: 1.46.0  # MSRV
           - rust: stable
             features: unstable quickcheck
             test_all: --all

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.41.0"
+msrv = "1.46.0" # This will fix https://github.com/rust-lang/rust/issues/58957

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -765,9 +765,12 @@ pub struct NegativeCycle(pub ());
 /// Always treats the input graph as if undirected.
 pub fn is_bipartite_undirected<G, N, VM>(g: G, start: N) -> bool
 where
-    G: GraphRef + Visitable<NodeId = N, Map = VM> + IntoNeighbors<NodeId = N> + IntoNodeIdentifiers<NodeId = N>,
+    G: GraphRef
+        + Visitable<NodeId = N, Map = VM>
+        + IntoNeighbors<NodeId = N>
+        + IntoNodeIdentifiers<NodeId = N>,
     N: Copy + PartialEq + std::fmt::Debug,
-    VM: VisitMap<N>, 
+    VM: VisitMap<N>,
 {
     let mut node_ids: Vec<N> = g.node_identifiers().map(|id| id).collect();
     let mut n_blue_nodes = 0;

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -348,6 +348,35 @@ fn bipartite() {
 
         assert!(!is_bipartite_undirected(&gr, a));
     }
+    {
+        let mut gr = Graph::new_undirected();
+        let a = gr.add_node("A");
+        let b = gr.add_node("B");
+        let c = gr.add_node("C");
+        let d = gr.add_node("D");
+        
+        let e = gr.add_node("E");
+        let f = gr.add_node("F");
+        let g = gr.add_node("G");
+        let h = gr.add_node("H");
+
+        gr.add_edge(a, f, 6.);
+
+        gr.add_edge(b, g, 6.);
+        gr.add_edge(b, h, 6.);
+
+        gr.add_edge(c, f, 6.);
+
+        gr.add_edge(d, e, 6.);
+        gr.add_edge(d, f, 6.);
+
+        assert!(is_bipartite_undirected(&gr, a));
+
+        // b -> g -> h -> b is a disconnected cycle
+        gr.add_edge(g, h, 6.);
+
+        assert!(!is_bipartite_undirected(&gr, a));
+    }
 }
 
 #[test]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -354,7 +354,7 @@ fn bipartite() {
         let b = gr.add_node("B");
         let c = gr.add_node("C");
         let d = gr.add_node("D");
-        
+
         let e = gr.add_node("E");
         let f = gr.add_node("F");
         let g = gr.add_node("G");


### PR DESCRIPTION
The existing function do not check disconnected components,