### PR TITLE
clarify license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "petgraph"
 version = "0.6.0"
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = [
 "bluss",
 "mitchmindtree",


### PR DESCRIPTION
Per <https://doc.rust-lang.org/cargo/reference/manifest.html#slash>

> Previously multiple licenses could be separated with a /, but that usage is deprecated.

pretty sure from the README that OR rather than AND is intended here, I guess this format has the advantage of making that explicit