### PR TITLE
Add a version of condensation which remembers node indices rather than their weight

### DIFF
--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1021,6 +1021,7 @@ fn tarjan_scc() {
     );
 }
 
+
 #[test]
 fn condensation() {
     let gr: Graph<(), ()> = Graph::from_edges(&[
@@ -1053,6 +1054,44 @@ fn condensation() {
     // make_acyclic = false
 
     let cond = petgraph::algo::condensation(gr.clone(), false);
+
+    assert!(cond.node_count() == 3);
+    assert!(cond.edge_count() == gr.edge_count());
+}
+
+
+#[test]
+fn condensation_indices() {
+    let gr: Graph<(), ()> = Graph::from_edges(&[
+        (6, 0),
+        (0, 3),
+        (3, 6),
+        (8, 6),
+        (8, 2),
+        (2, 3),
+        (2, 5),
+        (5, 8),
+        (7, 5),
+        (1, 7),
+        (7, 4),
+        (4, 1),
+    ]);
+
+    // make_acyclic = true
+
+    let cond = petgraph::algo::condensation_indices(&gr, true);
+
+    assert!(cond.node_count() == 3);
+    assert!(cond.edge_count() == 2);
+    assert!(
+        !petgraph::algo::is_cyclic_directed(&cond),
+        "Assertion failed: {:?} acyclic",
+        cond
+    );
+
+    // make_acyclic = false
+
+    let cond = petgraph::algo::condensation_indices(&gr, false);
 
     assert!(cond.node_count() == 3);
     assert!(cond.edge_count() == gr.edge_count());

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -23,7 +23,7 @@ use quickcheck::{Arbitrary, Gen};
 use rand::Rng;
 
 use petgraph::algo::{
-    bellman_ford, condensation, dijkstra, find_negative_cycle, floyd_warshall,
+    bellman_ford, condensation, condensation_indices, dijkstra, find_negative_cycle, floyd_warshall,
     greedy_feedback_arc_set, greedy_matching, is_cyclic_directed, is_cyclic_undirected,
     is_isomorphic, is_isomorphic_matching, k_shortest_path, kosaraju_scc, maximum_matching,
     min_spanning_tree, tarjan_scc, toposort, Matching,
@@ -566,6 +566,26 @@ fn graph_condensation_acyclic() {
     }
     quickcheck::quickcheck(prop as fn(_) -> bool);
 }
+
+
+#[test]
+fn graph_iso_condensation_condensation_indices() {
+    // condensation and condensation_indices yield the same result, module weights.
+    fn prop(g: Graph<(), ()>) -> bool {
+	let mut res = true;
+	for make_acyclic in [true, false] {
+	    let cond = condensation(g.clone(), make_acyclic);
+	    let cond_ind = condensation_indices(&g, make_acyclic);
+	    let cond_shape = cond.map(|_, _| (), |_, _| ()).edge_references().map(|e| (e.source(), e.target())).collect::<Vec<_>>();
+	    let cond_ind_shape = cond_ind.map(|_, _| (), |_, _| ()).edge_references().map(|e| (e.source(), e.target())).collect::<Vec<_>>();
+	    res = res && cond_shape == cond_ind_shape;
+	}
+	res
+    }
+    quickcheck::quickcheck(prop as fn(_) -> bool);
+}
+
+
 
 #[derive(Debug, Clone)]
 struct DAG<N: Default + Clone + Send + 'static>(Graph<N, ()>);


### PR DESCRIPTION
Currently, there is no way to get the original nodes of g from the nodes of `algo::condensation(g, _)`. This PR adds an `algo::condensation_indices` which has vector of node indices from g as the node weights of its return value. This helps when you use the condensed version as a guide to work with the original graph (for instance for doing layout). The edge weights are `()` since there's hardly another labeling which makes sense with `make_acyclic = true` (as well as `make_acyclic = false`).
