### PR TITLE
Add a `convert_edge/node_weight` method for `(Stable)Graph`

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1013,6 +1013,24 @@ where
         }
     }
 
+    /// Convert this graph into a new graph with nodes' weight converted with a
+    /// function `FnMut(N) -> NewN`
+    pub fn convert_node_weight<NewN, F>(self, mut f: F) -> Graph<NewN, E, Ty, Ix>
+    where
+        F: FnMut(N) -> NewN
+    {
+        Graph { 
+            nodes: self.nodes.into_iter().map(|n| {
+                Node { 
+                    weight: f(n.weight),
+                    next: n.next
+                }
+            }).collect(), 
+            edges: self.edges, 
+            ty: self.ty
+        }
+    }
+
     /// Return an iterator over the edge indices of the graph
     pub fn edge_indices(&self) -> EdgeIndices<Ix> {
         EdgeIndices {
@@ -1046,6 +1064,25 @@ where
     pub fn edge_weights_mut(&mut self) -> EdgeWeightsMut<E, Ix> {
         EdgeWeightsMut {
             edges: self.edges.iter_mut(),
+        }
+    }
+
+    /// Convert this graph into a new graph with edges' weight converted with a
+    /// function `FnMut(E) -> NewE`
+    pub fn convert_edge_weight<NewE, F>(self, mut f: F) -> Graph<N, NewE, Ty, Ix>
+    where
+        F: FnMut(E) -> NewE
+    {
+        Graph {
+            nodes: self.nodes,
+            edges: self.edges.into_iter().map(|e| {
+                Edge { 
+                    weight: f(e.weight),
+                    next: e.next,
+                    node: e.node
+                }
+            }).collect(),
+            ty: self.ty
         }
     }
 

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -506,6 +506,42 @@ where
         }
     }
 
+    /// Convert this graph into a new graph with nodes' weight converted with a
+    /// function `FnMut(N) -> NewN`
+    pub fn convert_node_weight<NewN, F>(self, mut f: F) -> StableGraph<NewN, E, Ty, Ix>
+    where
+        F: FnMut(N) -> NewN
+    {
+        StableGraph {
+            g: self.g.convert_node_weight(|opt_node| match opt_node {
+                Some(node) => Some(f(node)),
+                None => None
+            }),
+            node_count: self.node_count,
+            edge_count: self.node_count,
+            free_node: self.free_node,
+            free_edge: self.free_edge
+        }
+    }
+
+    /// Convert this graph into a new graph with edges' weight converted with a
+    /// function `FnMut(E) -> NewE`
+    pub fn convert_edge_weight<NewE, F>(self, mut f: F) -> StableGraph<N, NewE, Ty, Ix>
+    where
+        F: FnMut(E) -> NewE
+    {
+        StableGraph {
+            g: self.g.convert_edge_weight(|opt_edge| match opt_edge {
+                Some(edge) => Some(f(edge)),
+                None => None
+            }),
+            node_count: self.node_count,
+            edge_count: self.node_count,
+            free_node: self.free_node,
+            free_edge: self.free_edge
+        }
+    }
+
     /// Access the weight for edge `e`.
     ///
     /// Also available with indexing syntax: `&graph[e]`.

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1202,6 +1202,38 @@ fn test_weight_iterators() {
 }
 
 #[test]
+fn test_weight_converter() {
+    let mut gr = Graph::<_, _>::new();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    let e = gr.add_node("E");
+    let f = gr.add_node("F");
+    let g = gr.add_node("G");
+    gr.add_edge(a, b, 7.0);
+    gr.add_edge(a, d, 5.);
+    gr.add_edge(d, b, 9.);
+    gr.add_edge(b, c, 8.);
+    gr.add_edge(b, e, 7.);
+    let c_e = gr.add_edge(c, e, 5.);
+    gr.add_edge(d, e, 15.);
+    gr.add_edge(d, f, 6.);
+    gr.add_edge(f, e, 8.);
+    gr.add_edge(f, g, 11.);
+    gr.add_edge(e, g, 9.);
+
+    let gr = gr.convert_edge_weight(|s| -s);
+    assert_eq!(*(gr.edge_weight(c_e).unwrap()), -5.);
+
+    let gr = gr.convert_edge_weight(|s| format!("{}", s));
+    assert_eq!(*(gr.edge_weight(c_e).unwrap()), "-5");
+
+    let gr = gr.convert_node_weight(|n| n.to_ascii_lowercase());
+    assert_eq!(*(gr.node_weight(a).unwrap()), "a".to_string());
+}
+
+#[test]
 fn walk_edges() {
     let mut gr = Graph::<_, _>::new();
     let a = gr.add_node(0.);

--- a/tests/stable_graph.rs
+++ b/tests/stable_graph.rs
@@ -313,6 +313,38 @@ fn iterators_undir() {
 }
 
 #[test]
+fn test_weight_converter() {
+    let mut gr = StableGraph::<_, _>::new();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    let e = gr.add_node("E");
+    let f = gr.add_node("F");
+    let g = gr.add_node("G");
+    gr.add_edge(a, b, 7.0);
+    gr.add_edge(a, d, 5.);
+    gr.add_edge(d, b, 9.);
+    gr.add_edge(b, c, 8.);
+    gr.add_edge(b, e, 7.);
+    let c_e = gr.add_edge(c, e, 5.);
+    gr.add_edge(d, e, 15.);
+    gr.add_edge(d, f, 6.);
+    gr.add_edge(f, e, 8.);
+    gr.add_edge(f, g, 11.);
+    gr.add_edge(e, g, 9.);
+
+    let gr = gr.convert_edge_weight(|s| -s);
+    assert_eq!(*(gr.edge_weight(c_e).unwrap()), -5.);
+
+    let gr = gr.convert_edge_weight(|s| format!("{}", s));
+    assert_eq!(*(gr.edge_weight(c_e).unwrap()), "-5");
+
+    let gr = gr.convert_node_weight(|n| n.to_ascii_lowercase());
+    assert_eq!(*(gr.node_weight(a).unwrap()), "a".to_string());
+}
+
+#[test]
 fn dot() {
     let mut gr = StableGraph::new();
     let a = gr.add_node("x");


### PR DESCRIPTION
Added a `convert_edge/node_weight` method for both `Graph` and `StableGraph`. 

These methods enables users to convert value and even type for the weight of nodes/edges in a graph while ensuring the node and edge indices not changed.

These methods are useful particularly when you want to build a graph from a `StableGraph` with different weight type of nodes or edges with node and edge indices unchanged.