### PR TITLE
Fix CI by fixing indexmap minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ debug = true
 
 [dependencies]
 fixedbitset = { version = "0.4.0", default-features = false }
-indexmap = { version = "1.6.2" }
+indexmap = { version = "~1.7" }
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }


### PR DESCRIPTION
`indexmap` changed the MSRV in a minor version, so 1.8 does not compile in rust 1.41

This is a quick fix pinning `indexmap` to `~1.7`.
Ideally, we should bump our MSRV in the next release.