### PR TITLE
Loose the dependency version for indexmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         include:
           - rust: 1.41.0  # MSRV
+            # Fix an old minor version of some dependencies to ensure they
+            # compile with the MSRV
+            fixed_deps: -p indexmap --precise 1.7.0
           - rust: stable
             features: unstable quickcheck
             test_all: --all
@@ -36,6 +39,7 @@ jobs:
           override: true
       - name: Build
         run: |
+          cargo update ${{ matrix.fixed_deps }}
           cargo build --verbose --no-default-features
           cargo build --verbose --features "${{ matrix.features }}"
       - name: Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ debug = true
 
 [dependencies]
 fixedbitset = { version = "0.4.0", default-features = false }
-indexmap = { version = "~1.7" }
+indexmap = { version = "1.7" }
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # petgraph
 
-Graph data structure library. Supports Rust 1.41 and later.
+Graph data structure library. Please read the [API documentation here][].
 
-Please read the [API documentation here][]
+Supports Rust 1.41 and later (some older versions may require picking the dependency versions [by hand][dependency_hack]).
 
 [![build_status][]](https://github.com/petgraph/petgraph/actions) [![crates][]](https://crates.io/crates/petgraph) [![gitter][]](https://gitter.im/petgraph-rs/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
@@ -33,3 +33,4 @@ be copied, modified, or distributed except according to those terms.
   [crates]: https://img.shields.io/crates/v/petgraph
   [gitter]: https://badges.gitter.im/petgraph-rs/community.svg
   [RELEASES]: RELEASES.rst
+  [dependency_hack]: https://github.com/petgraph/petgraph/pull/493#issuecomment-1134970689


### PR DESCRIPTION
Rolls back the previous hotfix from #493 following the comments there. Instead, it makes the CI specifically set an older version when testing on MSRV.

I also added a comment to the README with a link to the fix as otherwise it's not too clear to the user how to solve the compiler error. We should be able to remove this hack in the next MSRV-bump.