### PR TITLE
Add serde support for graphmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Crate feature flags:
 -   `graphmap` (default) enable `GraphMap`.
 -   `stable_graph` (default) enable `StableGraph`.
 -   `matrix_graph` (default) enable `MatrixGraph`.
--   `serde-1` (optional) enable serialization for `Graph, StableGraph`
+-   `serde-1` (optional) enable serialization for `Graph, StableGraph, GraphMap`
     using serde 1.0. Requires Rust version as required by serde.
 
 ## Recent Changes

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 
 description = ""
 documentation = ""
-repository = "https://github.com/bluss/petgraph"
+repository = "https://github.com/petgraph/petgraph"
 
 
 [dependencies]
@@ -18,7 +18,9 @@ petgraph = { path = "..", features = ["serde-1", "quickcheck"] }
 itertools = { version = "0.10.1" }
 
 [dev-dependencies]
+serde = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
 quickcheck = { version = "0.8", default-features = false }
 bincode = "1.3.3"
 defmac = "0.2.1"

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -477,6 +477,37 @@ where
         }
         gr
     }
+
+    /// Creates a `GraphMap` that corresponds to the given `Graph`.
+    ///
+    /// **Warning**: Nodes with the same weight are merged and only the last parallel edge
+    /// is kept. Node and edge indices of the `Graph` are lost. Only use this function
+    /// if the node weights are distinct and there are no parallel edges.
+    ///
+    /// Computes in **O(|V| + |E|)** time (average).
+    pub fn from_graph<Ix>(graph: Graph<N, E, Ty, Ix>) -> Self
+    where
+        Ix: crate::graph::IndexType,
+        E: Clone,
+    {
+        let mut new_graph: GraphMap<N, E, Ty> =
+            GraphMap::with_capacity(graph.node_count(), graph.edge_count());
+
+        for node in graph.raw_nodes() {
+            new_graph.add_node(node.weight);
+        }
+
+        for edge in graph.edge_indices() {
+            let (a, b) = graph.edge_endpoints(edge).unwrap();
+            new_graph.add_edge(
+                *graph.node_weight(a).unwrap(),
+                *graph.node_weight(b).unwrap(),
+                graph.edge_weight(edge).unwrap().clone(),
+            );
+        }
+
+        new_graph
+    }
 }
 
 /// Create a new `GraphMap` from an iterable of edges.

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -116,6 +116,51 @@ impl PartialEq<Direction> for CompactDirection {
     }
 }
 
+#[cfg(feature = "serde-1")]
+impl<N, E, Ty> serde::Serialize for GraphMap<N, E, Ty>
+where
+    Ty: EdgeType,
+    N: NodeTrait + serde::Serialize,
+    E: serde::Serialize,
+    GraphMap<N, E, Ty>: Clone,
+{
+    /// Serializes the given `GraphMap` into the same format as the standard
+    /// `Graph`. Needs feature `serde-1`.
+    ///
+    /// Note: the graph has to be `Clone` for this to work.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let cloned_graph: GraphMap<N, E, Ty> = GraphMap::clone(self);
+        let equivalent_graph: Graph<N, E, Ty, u32> = cloned_graph.into_graph();
+        equivalent_graph.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde-1")]
+impl<'de, N, E, Ty> serde::Deserialize<'de> for GraphMap<N, E, Ty>
+where
+    Ty: EdgeType,
+    N: NodeTrait + serde::Deserialize<'de>,
+    E: Clone + serde::Deserialize<'de>,
+{
+    /// Deserializes into a new `GraphMap` from the same format as the standard
+    /// `Graph`. Needs feature `serde-1`.
+    ///
+    /// **Warning**: When deseralizing a graph that was not originally a `GraphMap`,
+    /// the restrictions from [`from_graph`](#method.from_graph) apply.
+    ///
+    /// Note: The edge weights have to be `Clone` for this to work.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let equivalent_graph: Graph<N, E, Ty, u32> = Graph::deserialize(deserializer)?;
+        Ok(GraphMap::from_graph(equivalent_graph))
+    }
+}
+
 impl<N, E, Ty> GraphMap<N, E, Ty>
 where
     N: NodeTrait,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! # Crate features
 //!
 //! * **serde-1** -
-//!   Defaults off. Enables serialization for ``Graph, StableGraph`` using
+//!   Defaults off. Enables serialization for ``Graph, StableGraph, GraphMap`` using
 //!   [`serde 1.0`](https://crates.io/crates/serde). May require a more recent version
 //!   of Rust than petgraph alone.
 //! * **graphmap** -

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -326,6 +326,26 @@ fn test_into_graph() {
 }
 
 #[test]
+fn test_from_graph() {
+    let mut gr: Graph<u32, u32, Directed> = Graph::new();
+    let node_a = gr.add_node(12);
+    let node_b = gr.add_node(13);
+    let node_c = gr.add_node(14);
+    gr.add_edge(node_a, node_b, 1000);
+    gr.add_edge(node_b, node_c, 999);
+    gr.add_edge(node_c, node_a, 1111);
+    gr.add_node(42);
+    let gr = gr;
+
+    let graph: GraphMap<u32, u32, Directed> = GraphMap::from_graph(gr.clone());
+    println!("{}", Dot::new(&gr));
+    println!("{}", Dot::new(&graph));
+
+    assert!(petgraph::algo::is_isomorphic(&gr, &graph));
+    assert_eq!(graph[(12, 13)], 1000);
+}
+
+#[test]
 fn test_all_edges_mut() {
     // graph with edge weights equal to in+out
     let mut graph: GraphMap<_, u32, Directed> =


### PR DESCRIPTION
This PR adds serde-1 support for the `GraphMap` struct. Unlike #341 two years ago, I addressed the issues of internal data and format stability by depending on the already existing serialization of the `Graph` struct.
This might not be the most performant solution and require the edges to be `Clone` as well, but was sufficiently easy to implement and is less error-prone.
I will try these changes out on my own projects in the coming weeks and obviously fix any issues I find. Let me know if any of you spot any mistakes or have improvement suggestions.