### PR TITLE
Add function that returns an iterator with subgraph isomorphisms

### DIFF
--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -763,11 +763,6 @@ mod matching {
             // number of nodes in graph 1. n! values fit into a 64-bit usize up
             // to n = 20, so we don't estimate an upper limit for n > 20.
             let n = self.st.0.graph.node_count();
-            const MAX_N: usize = 20;
-
-            if n > MAX_N {
-                return (0, None);
-            }
 
             // We hardcode n! values into an array that accounts for architectures
             // with smaller usizes to get our upper bound.
@@ -797,6 +792,10 @@ mod matching {
             .iter()
             .map(|n| usize::try_from(*n).ok())
             .collect();
+
+            if n > upper_bounds.len() {
+                return (0, None);
+            }
 
             (0, upper_bounds[n])
         }

--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -554,7 +554,7 @@ mod matching {
 
     /// Return Some(bool) if isomorphism is decided, else None.
     pub fn try_match<G0, G1, NM, EM>(
-        mut st: &mut (Vf2State<'_, G0>, Vf2State<'_, G1>),
+        st: &mut (Vf2State<'_, G0>, Vf2State<'_, G1>),
         node_match: &mut NM,
         edge_match: &mut EM,
         match_subgraph: bool,
@@ -582,7 +582,7 @@ mod matching {
     }
 
     fn isomorphisms<G0, G1, NM, EM>(
-        mut st: &mut (Vf2State<'_, G0>, Vf2State<'_, G1>),
+        st: &mut (Vf2State<'_, G0>, Vf2State<'_, G1>),
         node_match: &mut NM,
         edge_match: &mut EM,
         match_subgraph: bool,
@@ -613,9 +613,9 @@ mod matching {
         while let Some(frame) = stack.pop() {
             match frame {
                 Frame::Unwind { nodes, open_list } => {
-                    pop_state(&mut st, nodes);
+                    pop_state(st, nodes);
 
-                    match next_from_ix(&mut st, nodes.0, open_list) {
+                    match next_from_ix(st, nodes.0, open_list) {
                         None => continue,
                         Some(nx) => {
                             let f = Frame::Inner {
@@ -626,7 +626,7 @@ mod matching {
                         }
                     }
                 }
-                Frame::Outer => match next_candidate(&mut st) {
+                Frame::Outer => match next_candidate(st) {
                     None => continue,
                     Some((nx, mx, open_list)) => {
                         let f = Frame::Inner {
@@ -637,8 +637,8 @@ mod matching {
                     }
                 },
                 Frame::Inner { nodes, open_list } => {
-                    if is_feasible(&mut st, nodes, node_match, edge_match) {
-                        push_state(&mut st, nodes);
+                    if is_feasible(st, nodes, node_match, edge_match) {
+                        push_state(st, nodes);
                         if st.0.is_complete() {
                             result = Some(st.0.mapping.clone());
                         }
@@ -655,9 +655,9 @@ mod matching {
                             stack.push(Frame::Outer);
                             continue;
                         }
-                        pop_state(&mut st, nodes);
+                        pop_state(st, nodes);
                     }
-                    match next_from_ix(&mut st, nodes.0, open_list) {
+                    match next_from_ix(st, nodes.0, open_list) {
                         None => continue,
                         Some(nx) => {
                             let f = Frame::Inner {

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -40,6 +40,7 @@ pub use feedback_arc_set::greedy_feedback_arc_set;
 pub use floyd_warshall::floyd_warshall;
 pub use isomorphism::{
     is_isomorphic, is_isomorphic_matching, is_isomorphic_subgraph, is_isomorphic_subgraph_matching,
+    subgraph_isomorphisms_iter,
 };
 pub use k_shortest_path::k_shortest_path;
 pub use matching::{greedy_matching, maximum_matching, Matching};


### PR DESCRIPTION
This PR adds `subgraph_isomorphism_iter` to the `isomorphism` module to provide users with the capability of using the isomorphism solutions however they may need them. I will use these changes in my own project so I'll come back to this if there's something to be fixed. Please let me know if you have improvement suggestions.

This PR addresses issue #497 and includes @cojuer subgraph isomorphism fix from PR #472.