### PR TITLE
fixes WalkNeighbors::next advancing to removed edge

### DIFF
--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -1525,7 +1525,8 @@ where
     /// neighbors and edges from the origin node.
     ///
     /// Note: The walker does not borrow from the graph, this is to allow mixing
-    /// edge walking with mutating the graph's weights.
+    /// edge walking with mutating the graph's weights. This means that any
+    /// subsequent modification of the graph's structure invalidates the walker.
     pub fn detach(&self) -> WalkNeighbors<Ix> {
         WalkNeighbors {
             inner: super::WalkNeighbors {


### PR DESCRIPTION
I'm not sure if this is what you'd like, but figured it would at least start a conversation that will lead us to that.

Addresses bug outlined in issue [#501](https://github.com/petgraph/petgraph/issues/501)