### PR TITLE
Fix UB and add Miri to Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,12 @@ jobs:
       - name: Rustfmt
         if: matrix.rustfmt
         run: cargo fmt -- --check
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - run: cargo miri test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ debug = true
 
 [dependencies]
 fixedbitset = { version = "0.4.0", default-features = false }
-indexmap = { version = "1.7" }
+indexmap = { version = "1.7", features = ["std"] }
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -853,6 +853,7 @@ fn extend_flat_square_matrix<T: Default>(
     for c in (1..old_node_capacity).rev() {
         let pos = c * old_node_capacity;
         let new_pos = c * new_node_capacity;
+        // Move the slices directly if they do not overlap with their new position
         if pos + old_node_capacity <= new_pos {
             // first_chunk = node_adjacencies[pos..]
             let (_, first_chunk) = node_adjacencies.split_at_mut(pos);

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -864,15 +864,8 @@ fn extend_flat_square_matrix<T: Default>(
             let (_, second_chunk) = second_chunk.split_at_mut(new_pos - (pos + old_node_capacity));
             // second_chunk = node_adjacencies[new_pos..new_pos + old_node_capacity]
             let (second_chunk, _) = second_chunk.split_at_mut(old_node_capacity);
-            // SAFETY: Slices cannot overlap as they were created by splitting a slice
-            // The length is equal and valid as they were both created with the same `split_at_mut` argument
-            unsafe {
-                std::ptr::swap_nonoverlapping(
-                    first_chunk.as_mut_ptr(),
-                    second_chunk.as_mut_ptr(),
-                    old_node_capacity,
-                );
-            }
+            // This will not panic as the chunks were both created with the same length (old_node_capacity)
+            first_chunk.swap_with_slice(second_chunk);
         } else {
             for i in (0..old_node_capacity).rev() {
                 node_adjacencies.as_mut_slice().swap(pos + i, new_pos + i);

--- a/tests/iso.rs
+++ b/tests/iso.rs
@@ -294,6 +294,7 @@ fn full_iso() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Takes too long to run in Miri")]
 fn praust_dir_no_iso() {
     let a = str_to_digraph(PRAUST_A);
     let b = str_to_digraph(PRAUST_B);
@@ -302,6 +303,7 @@ fn praust_dir_no_iso() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Takes too long to run in Miri")]
 fn praust_undir_no_iso() {
     let a = str_to_graph(PRAUST_A);
     let b = str_to_graph(PRAUST_B);
@@ -464,6 +466,7 @@ fn iso_matching() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Can't open files with isolation")]
 fn iso_100n_100e() {
     let g0 = graph_from_file("tests/res/graph_100n_100e.txt");
     let g1 = graph_from_file("tests/res/graph_100n_100e_iso.txt");
@@ -471,6 +474,7 @@ fn iso_100n_100e() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Can't open files with isolation")]
 fn iso_large() {
     let g0 = graph_from_file("tests/res/graph_1000n_1000e.txt");
     let g1 = graph_from_file("tests/res/graph_1000n_1000e_iso.txt");
@@ -489,6 +493,7 @@ fn iso_multigraph_failure() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Takes too long to run in Miri")]
 fn iso_subgraph() {
     let g0 = Graph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 0)]);
     let g1 = Graph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 0), (2, 3), (0, 4)]);
@@ -497,6 +502,7 @@ fn iso_subgraph() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore = "Takes too long to run in Miri")]
 fn iter_subgraph() {
     let a = Graph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 0)]);
     let b = Graph::<(), ()>::from_edges(&[(0, 1), (1, 2), (2, 0), (2, 3), (0, 4)]);

--- a/tests/iso.rs
+++ b/tests/iso.rs
@@ -466,18 +466,17 @@ fn iso_matching() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "Can't open files with isolation")]
 fn iso_100n_100e() {
-    let g0 = graph_from_file("tests/res/graph_100n_100e.txt");
-    let g1 = graph_from_file("tests/res/graph_100n_100e_iso.txt");
+    let g0 = str_to_digraph(include_str!("res/graph_100n_100e.txt"));
+    let g1 = str_to_digraph(include_str!("res/graph_100n_100e_iso.txt"));
     assert!(petgraph::algo::is_isomorphic(&g0, &g1));
 }
 
 #[test]
-#[cfg_attr(miri, ignore = "Can't open files with isolation")]
+#[cfg_attr(miri, ignore = "Too large for Miri")]
 fn iso_large() {
     let g0 = graph_from_file("tests/res/graph_1000n_1000e.txt");
-    let g1 = graph_from_file("tests/res/graph_1000n_1000e_iso.txt");
+    let g1 = graph_from_file("tests/res/graph_1000n_1000e.txt");
     assert!(petgraph::algo::is_isomorphic(&g0, &g1));
 }
 


### PR DESCRIPTION
`matrix_graph::extend_flat_square_matrix` caused Miri to report [UB](https://miri.saethlin.dev/ub?crate=petgraph&version=0.6.2) due to taking two mutable pointers into a slice (https://github.com/petgraph/petgraph/blob/ffb085f865b390d12eef7d6ab72a5a7d84a644c5/src/matrix_graph.rs#L858-L865).
This PR fixes that by safely splitting the slices to ensure there is no overlap and that the length is valid, as well as adding Miri to the CI.