### PR TITLE
Make ensure_len use resize_with

### DIFF
--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -897,12 +897,7 @@ fn extend_lower_triangular_matrix<T: Default>(
 
 /// Grow a Vec by appending the type's default value until the `size` is reached.
 fn ensure_len<T: Default>(v: &mut Vec<T>, size: usize) {
-    if let Some(n) = size.checked_sub(v.len()) {
-        v.reserve(n);
-        for _ in 0..n {
-            v.push(T::default());
-        }
-    }
+    v.resize_with(size, T::default);
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This change has greatly improved the performance of my application, in which I create large `MatrixGraph`s.