### PR TITLE
Allow 'cargo test --features=all' to run under rust 1.41.0

### DIFF
--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -796,7 +796,7 @@ quickcheck! {
                     }
                 } else {
                     // if there are no path between two nodes then floyd_warshall will return maximum value possible
-                    if *fw_res.get(&(node1, node2)).unwrap() != u32::MAX {
+                    if *fw_res.get(&(node1, node2)).unwrap() != core::u32::MAX {
                         return false;
                     }
                 }


### PR DESCRIPTION
This isn't necessary to pass Continuous Integration. However, it's convenient during development just to 'rustup override set "1.41.0"' and run some or all of the tests.