### PR TITLE
Update `indexmap` to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.41.0  # MSRV
-            # Fix an old minor version of some dependencies to ensure they
-            # compile with the MSRV
-            fixed_deps: -p indexmap --precise 1.7.0
+          - rust: 1.64.0  # MSRV
           - rust: stable
             features: unstable quickcheck
             test_all: --all
@@ -39,7 +36,6 @@ jobs:
           override: true
       - name: Build
         run: |
-          cargo update ${{ matrix.fixed_deps }}
           cargo build --verbose --no-default-features
           cargo build --verbose --features "${{ matrix.features }}"
       - name: Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ repository = "https://github.com/petgraph/petgraph"
 keywords = ["data-structure", "graph", "unionfind", "graph-algorithms"]
 categories = ["data-structures"]
 
+rust-version = "1.64"
+
 edition = "2018"
 
 [package.metadata.docs.rs]
@@ -36,7 +38,7 @@ debug = true
 
 [dependencies]
 fixedbitset = { version = "0.4.0", default-features = false }
-indexmap = { version = "1.7", features = ["std"] }
+indexmap = "2.0"
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
@@ -44,7 +46,7 @@ serde_derive = { version = "1.0", optional = true }
 [dev-dependencies]
 bincode = "1.3.3"
 defmac = "0.2.1"
-itertools = { version = "0.10.1", default-features = false }
+itertools = { version = "0.11.0", default-features = false }
 odds = { version = "0.4.0" }
 rand = "0.5.5"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Graph data structure library. Please read the [API documentation here][].
 
-Supports Rust 1.41 and later (some older versions may require picking the dependency versions [by hand][dependency_hack]).
+Supports Rust 1.64 and later.
 
 [![build_status][]](https://github.com/petgraph/petgraph/actions) [![crates][]](https://crates.io/crates/petgraph) [![gitter][]](https://gitter.im/petgraph-rs/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
@@ -33,4 +33,3 @@ be copied, modified, or distributed except according to those terms.
   [crates]: https://img.shields.io/crates/v/petgraph
   [gitter]: https://badges.gitter.im/petgraph-rs/community.svg
   [RELEASES]: RELEASES.rst
-  [dependency_hack]: https://github.com/petgraph/petgraph/pull/493#issuecomment-1134970689


### PR DESCRIPTION
`indexmap` v2.0.0 has just been released, and several prominent crates in the Rust ecosystem such as `serde_json` are already using it. To minimize the number of projects for which Cargo would have to download and build two versions of `indexmap` due to their transitive dependencies, let's update the version `petgraph` depends on.

`indexmap` v2.0.0 does not bring substantial changes for this project, but it bumps our MSRV to 1.64. This should not be a concern, given that 0.7.0 (#567) will bump it to 1.65 anyway.