### PR TITLE
Add ahash as an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ name = "petgraph"
 debug = true
 
 [dependencies]
+ahash = { version = "0.8", optional = true}
 fixedbitset = { version = "0.4.0", default-features = false }
 indexmap = "2.0"
 quickcheck = { optional = true, version = "0.8", default-features = false }
@@ -60,6 +61,7 @@ default = ["graphmap", "stable_graph", "matrix_graph"]
 
 generate = [] # For unstable features
 
+ahash = ["dep:ahash"]
 graphmap = []
 matrix_graph = []
 serde-1 = ["serde", "serde_derive"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Crate feature flags:
 -   `serde-1` (optional) enable serialization for `Graph, StableGraph, GraphMap`
     using serde 1.0. Requires Rust version as required by serde.
 -   `rayon` (optional) enable parallel iterators for the underlying data in `GraphMap`. Requires Rust version as required by Rayon.
+-   `ahash` (optional) enables use of the `aHash` hashing library.
 
 ## Recent Changes
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@
 //!
 //! # Crate features
 //!
+//! * **ahash** -
+//!   Defaults off. Enables use of the [`aHash`](https://crates.io/crates/ahash) hashing library.
 //! * **serde-1** -
 //!   Defaults off. Enables serialization for ``Graph, StableGraph, GraphMap`` using
 //!   [`serde 1.0`](https://crates.io/crates/serde). May require a more recent version


### PR DESCRIPTION
Adding the use of ahash as an optional feature. 

By default we are using the std hasher, however ahash has been proven to be faster and is the standard in hashbrown [LINK](https://github.com/rust-lang/hashbrown#performance) now.

In internal tests this improved performance by at least 20%.

I originally looked at supporting custom hashers through generics, however, this became a very big PR very quickly. This is something that I will look at doing in the future though

Thanks