### PR TITLE
Add edge_weight, edge_weight_mut, and edge_weight_safe methods for CSR graphs

### DIFF
--- a/src/csr.rs
+++ b/src/csr.rs
@@ -351,6 +351,19 @@ where
         &self.edges[p]
     }
 
+    /// Access the weight for edge `e`, mutably.
+    ///
+    /// Also available with indexing syntax: `&mut graph[e]`.
+    /// (NOTE TO MAINTAINERS - NOT SURE ABOUT THIS, NOT ENTIRELY SURE WHAT THIS MEANS)
+    ///
+    /// **Panics** if no edge exists between `a` and `b`.
+    pub fn edge_weight_mut(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> &mut E {
+        let p = self
+            .find_edge_pos(a, b)
+            .expect("No edge found between the nodes.");
+        &mut self.edges[p]
+    }
+
     /// Safely accesses the weight for edge `e`.
     ///
     /// Also available with indexing syntax: `&graph[e]`?

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -338,6 +338,30 @@ where
         self.find_edge_pos(a, b).is_ok()
     }
 
+    /// Accesses the weight for edge `e`.
+    ///
+    /// Also available with indexing syntax: `&graph[e]`?
+    /// (NOTE TO MAINTAINERS - NOT SURE ABOUT THIS, NOT ENTIRELY SURE WHAT THIS MEANS)
+    ///
+    /// **Panics** if no edge exists between `a` and `b`.
+    pub fn edge_weight(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> &E {
+        let p = self
+            .find_edge_pos(a, b)
+            .expect("No edge found between the nodes.");
+        &self.edges[p]
+    }
+
+    /// Safely accesses the weight for edge `e`.
+    ///
+    /// Also available with indexing syntax: `&graph[e]`?
+    /// (NOTE TO MAINTAINERS - NOT SURE ABOUT THIS, NOT ENTIRELY SURE WHAT THIS MEANS)
+    ///
+    /// Returns None if no edge is found.
+    pub fn edge_weight_safe(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<&E> {
+        let p = self.find_edge_pos(a, b).ok()?;
+        Some(&self.edges[p])
+    }
+
     fn neighbors_range(&self, a: NodeIndex<Ix>) -> Range<usize> {
         let index = self.row[a.index()];
         let end = self


### PR DESCRIPTION
While other graph types have edge_weight methods, CSR graphs were lacking these features.
I have also created an edge_weight_safe method for safe accessing of edges between two nodes where you don't know if they are connected. 
I copied the doc comments from MatrixGraph, but I wasn't sure about what exactly was meant by the graph indexing syntax - I thought it was only for nodes.
Some methods which do the same things (has_edge vs contains_edge) are named differently, which might be something to check out.
