### PR TITLE
Release `0.6.4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 authors = [

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,3 +1,10 @@
+Version 0.6.4 (2023-08-21)
+==========================
+
+- Update `indexmap` to 2.0.0 (`#568`_)
+
+.. _`#568`: https://github.com/petgraph/petgraph/pull/568
+
 Version 0.6.3 (2023-02-07)
 ==========================
 
@@ -530,7 +537,7 @@ Version 0.1.11 (2015-08-16)
 
 Version 0.1.10 (2015-06-22)
 ===========================
-  
+
 - Fix bug in WalkEdges::next_neighbor()
 
 Version 0.1.9 (2015-06-17)

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,8 +1,10 @@
 Version 0.6.4 (2023-08-21)
 ==========================
 
-- Update `indexmap` to 2.0.0 (`#568`_)
+- Update ``indexmap`` to 2.0.0 (`#568`_)
+- Fix typos (`#544`_)
 
+.. _`#544`: https://github.com/petgraph/petgraph/pull/544
 .. _`#568`: https://github.com/petgraph/petgraph/pull/568
 
 Version 0.6.3 (2023-02-07)


### PR DESCRIPTION
Release `0.6.4` of the petgraph crate.

Sorry for the delay! My personal life has been a bit stressful lately, so projects like these have been on the afterburner.

This is my first release with petgraph, so let's hope everything goes alright!