### PR TITLE
add Topo::with_initials API

### DIFF
--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -344,14 +344,19 @@ where
         topo
     }
 
-    /// Create a new `Topo` with initial nodes
+    /// Create a new `Topo` with initial nodes.
+    ///
+    /// If any incoming edges to the initial nodes will be ignored.
     pub fn with_initials<G, I>(graph: G, i: I) -> Self
     where
-        G: Visitable<NodeId = N, Map = VM>,
+        G: IntoNeighborsDirected + Visitable<NodeId = N, Map = VM>,
         I: IntoIterator<Item = N>,
     {
         Topo {
-            tovisit: i.into_iter().collect(),
+            tovisit: i
+                .into_iter()
+                .filter(|&n| graph.neighbors_directed(n, Incoming).next().is_none())
+                .collect(),
             ordered: graph.visit_map(),
         }
     }

--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -346,14 +346,14 @@ where
 
     /// Create a new `Topo` with initial nodes.
     ///
-    /// If any incoming edges to the initial nodes will be ignored.
-    pub fn with_initials<G, I>(graph: G, i: I) -> Self
+    /// Nodes with incoming edges are ignored.
+    pub fn with_initials<G, I>(graph: G, initials: I) -> Self
     where
         G: IntoNeighborsDirected + Visitable<NodeId = N, Map = VM>,
         I: IntoIterator<Item = N>,
     {
         Topo {
-            tovisit: i
+            tovisit: initials
                 .into_iter()
                 .filter(|&n| graph.neighbors_directed(n, Incoming).next().is_none())
                 .collect(),

--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -344,6 +344,18 @@ where
         topo
     }
 
+    /// Create a new `Topo` with initial nodes
+    pub fn with_initials<G, I>(graph: G, i: I) -> Self
+    where
+        G: Visitable<NodeId = N, Map = VM>,
+        I: IntoIterator<Item = N>,
+    {
+        Topo {
+            tovisit: i.into_iter().collect(),
+            ordered: graph.visit_map(),
+        }
+    }
+
     fn extend_with_initials<G>(&mut self, g: G)
     where
         G: IntoNodeIdentifiers + IntoNeighborsDirected<NodeId = N>,

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1538,6 +1538,20 @@ fn toposort_generic() {
 
     {
         order.clear();
+        let init_nodes = gr.node_identifiers().filter(|n| {
+            gr.neighbors_directed(n.clone(), Direction::Incoming)
+                .next()
+                .is_none()
+        });
+        let mut topo = Topo::with_initials(&gr, init_nodes);
+        while let Some(nx) = topo.next(&gr) {
+            order.push(nx);
+        }
+        assert_is_topo_order(&gr, &order);
+    }
+
+    {
+        order.clear();
         let mut topo = Topo::new(&gr);
         while let Some(nx) = topo.next(&gr) {
             order.push(nx);

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1551,6 +1551,16 @@ fn toposort_generic() {
     }
 
     {
+        // test `with_initials` API using nodes with incoming edges
+        order.clear();
+        let mut topo = Topo::with_initials(&gr, gr.node_identifiers());
+        while let Some(nx) = topo.next(&gr) {
+            order.push(nx);
+        }
+        assert_is_topo_order(&gr, &order);
+    }
+
+    {
         order.clear();
         let mut topo = Topo::new(&gr);
         while let Some(nx) = topo.next(&gr) {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -744,6 +744,18 @@ fn full_topo_generic() {
                 return false;
             }
         }
+
+        {
+            order.clear();
+            let mut topo = Topo::with_initials(&gr, gr.node_identifiers());
+            while let Some(nx) = topo.next(&gr) {
+                order.push(nx);
+            }
+            if !is_topo_order(&gr, &order) {
+                println!("{:?}", gr);
+                return false;
+            }
+        }
         true
     }
     quickcheck::quickcheck(prop_generic as fn(_) -> bool);

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -727,6 +727,23 @@ fn full_topo_generic() {
                 return false;
             }
         }
+
+        {
+            order.clear();
+            let init_nodes = gr.node_identifiers().filter(|n| {
+                gr.neighbors_directed(n.clone(), Direction::Incoming)
+                    .next()
+                    .is_none()
+            });
+            let mut topo = Topo::with_initials(&gr, init_nodes);
+            while let Some(nx) = topo.next(&gr) {
+                order.push(nx);
+            }
+            if !is_topo_order(&gr, &order) {
+                println!("{:?}", gr);
+                return false;
+            }
+        }
         true
     }
     quickcheck::quickcheck(prop_generic as fn(_) -> bool);


### PR DESCRIPTION
Sometimes the user may already know the root nodes, it's convenient to use `Topo::with_initials` to create a Topo instance directly.