### PR TITLE
[Bug] Walker bug after `remove_edge`

### DIFF
--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -2508,3 +2508,21 @@ fn test_dominators_simple_fast() {
         "nodes that aren't reachable from the root do not have an idom"
     );
 }
+
+#[test]
+fn test_detach_and_remove_edge() {
+    let mut graph = Graph::new();
+    let nodes: Vec<_> = (0..2u32).map(|_| graph.add_node(())).collect();
+    let src_node = graph.add_node(());
+    let edge_to_remove = graph.add_edge(nodes[0], nodes[1], ());
+    graph.add_edge(src_node, nodes[0], ());
+    graph.add_edge(src_node, nodes[1], ());
+    graph.remove_edge(edge_to_remove);
+
+    let mut walker = graph.neighbors_directed(src_node, petgraph::Direction::Outgoing).detach();
+    while let Some(edge) = walker.next_edge(&graph) {
+        walker.remove_edge(&mut graph, edge);
+    }
+    assert_eq!(graph.neighbors(src_node).count(), 0);
+}
+


### PR DESCRIPTION
Hi,

When using `NeighborsWalker` to remove all edges for a given node, sometimes not all the edges are removed.
this happens because the walker keeps index to the next edge, which might be swapped by the remove_edge.

Code example to reproduce the error:
```rust
 #[test]
  fn test_detach_and_remove_edge() {
      let mut graph: Graph<(), ()> = Graph::new();
      let nodes: Vec<_> = (0..2u32).map(|_| graph.add_node(weight: ())).collect();
      let src_node: NodeIndex = graph.add_node(weight: ());
      let edge_to_remove: EdgeIndex = graph.add_edge(a: nodes[0], b: nodes[1], weight: ());
      graph.add_edge(a: src_node, b: nodes[0], weight: ());
      graph.add_edge(a: src_node, b: nodes[1], weight: ());
      graph.remove_edge(edge_to_remove);

      let mut walker: WalkNeighbors<u32> = graph.neighbors_directed(a: src_node, dir: petgraph::Direction::Outgoing).detach();
      while let Some(edge: EdgeIndex) = walker.next_edge(&graph) {
          graph.remove_edge(edge);
      }
      assert_eq!(graph.neighbors(src_node).count(), 0);
  }
```

The proposed solution is to create a new API for the walker to remove the edge, which will check if the next edge is the swapped one.
