### PR TITLE
Make Graph::new(_undirected) const

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -455,7 +455,7 @@ impl<N, E> Graph<N, E, Directed> {
     ///
     /// This is a convenience method. Use `Graph::with_capacity` or `Graph::default` for
     /// a constructor that is generic in all the type parameters of `Graph`.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Graph {
             nodes: Vec::new(),
             edges: Vec::new(),
@@ -469,7 +469,7 @@ impl<N, E> Graph<N, E, Undirected> {
     ///
     /// This is a convenience method. Use `Graph::with_capacity` or `Graph::default` for
     /// a constructor that is generic in all the type parameters of `Graph`.
-    pub fn new_undirected() -> Self {
+    pub const fn new_undirected() -> Self {
         Graph {
             nodes: Vec::new(),
             edges: Vec::new(),


### PR DESCRIPTION
`Graph`'s `new` constructor was previously not `const`, and I can't see why. It is useful to have a value of the type constructable at compile-time, which is why `Vec::new` and other functions like it in `std` are `const`. These constructors should be `const`, so I made this PR to do that. (MSRV note: I wasn't capable of easily finding the MSRV, but this change breaks with any version older than 1.39.)