### PR TITLE
Replace `copyclone!` macro by `Clone` derivation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,20 +170,9 @@ pub mod graph {
 #[cfg(feature = "stable_graph")]
 pub use crate::graph_impl::stable_graph;
 
-macro_rules! copyclone {
-    ($name:ident) => {
-        impl Clone for $name {
-            #[inline]
-            fn clone(&self) -> Self {
-                *self
-            }
-        }
-    };
-}
-
 // Index into the NodeIndex and EdgeIndex arrays
 /// Edge direction.
-#[derive(Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 #[repr(usize)]
 pub enum Direction {
     /// An `Outgoing` edge is an outward edge *from* the current node.
@@ -191,8 +180,6 @@ pub enum Direction {
     /// An `Incoming` edge is an inbound edge *to* the current node.
     Incoming = 1,
 }
-
-copyclone!(Direction);
 
 impl Direction {
     /// Return the opposite `Direction`.
@@ -215,14 +202,12 @@ impl Direction {
 pub use crate::Direction as EdgeDirection;
 
 /// Marker type for a directed graph.
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Directed {}
-copyclone!(Directed);
 
 /// Marker type for an undirected graph.
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Undirected {}
-copyclone!(Undirected);
 
 /// A graph's edge type determines whether it has directed edges or not.
 pub trait EdgeType {


### PR DESCRIPTION
`Clone` can be derived at the same time as `Copy`: Rust will generate an implementation which does a bitwise copy of the value.
