### PR TITLE
Stoer–Wagner algorithm for minimum cut

### DIFF
--- a/benches/minimum_cut.rs
+++ b/benches/minimum_cut.rs
@@ -1,0 +1,32 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use petgraph::prelude::*;
+use std::cmp::{max, min};
+use test::Bencher;
+
+use petgraph::algo::minimum_cut;
+
+#[bench]
+fn minimum_cut_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 100;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).into_iter().map(|i| g.add_node(i)).collect();
+    for i in 0..NODE_COUNT {
+        let n1 = nodes[i];
+        let neighbour_count = i % 8 + 3;
+        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
+        let j_to = min(NODE_COUNT, j_from + neighbour_count);
+        for j in j_from..j_to {
+            let n2 = nodes[j];
+            let weight = (i + 3) % 10;
+            g.add_edge(n1, n2, weight);
+        }
+    }
+
+    bench.iter(|| {
+        let _scores = minimum_cut(&g, |e| *e.weight());
+    });
+}

--- a/src/algo/minimum_cut.rs
+++ b/src/algo/minimum_cut.rs
@@ -148,10 +148,10 @@ where
     let len = seen_list.len();
     let last = seen_list[len-1];
     let before_last = seen_list[len-2];
-    let edges: Vec<_> = graph.edges(last).map(|e| e.weight().0).collect();
-    let weight = sum(graph.edges(last).map(|e| e.weight().1));
+    let cut: Vec<_> = graph.edges(last).map(|e| e.weight().0).collect();
+    let cut_weight = sum(graph.edges(last).map(|e| e.weight().1));
     
-    (edges, weight, last, before_last)
+    (cut, cut_weight, last, before_last)
 }
 
 fn minimum_cut_aux<N, EdgeId, K, Ix>(

--- a/src/algo/minimum_cut.rs
+++ b/src/algo/minimum_cut.rs
@@ -7,8 +7,10 @@ use crate::scored::MaxScored;
 use crate::visit::{EdgeRef, IntoNodeIdentifiers, IntoEdgeReferences, Visitable, VisitMap};
 
 /// \[Generic\] Stoer–Wagner algorithm to solve the minimum cut problem on undirected weighted graphs.
+/// https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm
 ///
 /// A (global) minimum cut of a graph is a set of edges of minimum weight whose deletion disconnects the graph.
+/// https://en.wikipedia.org/wiki/Minimum_cut
 /// 
 /// The graph must be undirected. It must implement `IntoNodeIdentifiers` and `IntoEdgeReferences`.
 /// The function `edge_cost` should return the cost for a particular edge. Edge costs must be

--- a/src/algo/minimum_cut.rs
+++ b/src/algo/minimum_cut.rs
@@ -1,0 +1,184 @@
+use std::collections::{BinaryHeap, HashMap};
+use std::hash::Hash;
+use crate::algo::Measure;
+use crate::{Graph, Undirected};
+use crate::graph::{IndexType, NodeIndex};
+use crate::scored::MaxScored;
+use crate::visit::{EdgeRef, IntoNodeIdentifiers, IntoEdgeReferences, Visitable, VisitMap};
+
+/// \[Generic\] Stoer–Wagner algorithm to solve the minimum cut problem on undirected weighted graphs.
+///
+/// A (global) minimum cut of a graph is a set of edges of minimum weight whose deletion disconnects the graph.
+/// 
+/// The graph must be undirected. It must implement `IntoNodeIdentifiers` and `IntoEdgeReferences`.
+/// The function `edge_cost` should return the cost for a particular edge. Edge costs must be
+/// non-negative.
+/// Returns a tuple composed of a vector of `EdgeId` that represents the cut and the cut weight.
+/// 
+/// Computes in **O(|V| |E| + |V|²*log(|V|)))** time
+///
+/// # Example
+/// ```rust
+/// use petgraph::{Graph, Undirected};
+/// use petgraph::algo::minimum_cut;
+/// 
+/// let mut graph: Graph<(), u32, Undirected> = Graph::new_undirected();
+/// let a = graph.add_node(());
+/// let b = graph.add_node(());
+/// let c = graph.add_node(());
+/// let d = graph.add_node(());
+/// let e = graph.add_node(());
+/// let f = graph.add_node(());
+/// let g = graph.add_node(());
+/// let h = graph.add_node(());
+///
+/// graph.extend_with_edges(&[
+///     (a, b, 7),
+///     (b, c, 2),
+///     (c, d, 8),
+///     (d, a, 3),
+///     (e, f, 6),
+///     (b, e, 1),
+///     (f, g, 1),
+///     (g, h, 5),
+///     (h, e, 4),
+///     (c, h, 3),
+/// ]);
+///
+/// // a --7-- b --1-- e --6-- f
+/// // |       |       |       |
+/// // 3       2       4       1
+/// // |       |       |       |
+/// // d --8-- c---3-- h --5-- g
+///
+/// let (cut, weight) = minimum_cut(&graph, |e| *e.weight());
+/// assert_eq!(cut.len(), 2);
+/// assert_eq!(weight, 4);
+/// ```
+
+pub fn minimum_cut<G, F, K>(
+    graph: G,
+    edge_cost: F,
+    ) -> (Vec<G::EdgeId>, K)
+where
+    G: IntoNodeIdentifiers + IntoEdgeReferences,
+    F: Fn(G::EdgeRef) -> K,
+    G::NodeId: Eq + Hash,
+    K: Measure + Copy,
+{
+    let mut node_to_node = HashMap::new();
+    let mut graph2 = Graph::new_undirected();
+    for node in graph.node_identifiers() {
+        let node2 = graph2.add_node(node);
+        node_to_node.insert(node, node2);
+    }
+
+    for edge in graph.edge_references() {
+        graph2.add_edge(
+            node_to_node[&edge.source()],
+            node_to_node[&edge.target()],
+            (edge.id(), edge_cost(edge))
+        );
+    }
+
+    minimum_cut_aux(&mut graph2)
+}
+
+// same as .sum() but don't require the Sum trait
+#[inline]
+fn sum<I,K>(iter: I) -> K
+    where
+        I: Iterator<Item = K>,
+        K: Measure,
+{
+    iter.fold(K::default(), |a, b| a + b)
+}
+
+fn merge_vertices<N, E, Ix>(
+    graph: &mut Graph<N, E, Undirected, Ix>,
+    node1: NodeIndex<Ix>,
+    node2: NodeIndex<Ix>,
+)
+where
+    Ix: IndexType,
+    E: Copy,
+{
+    let edges: Vec<_> = graph.edges(node2).map(|e| (node1, e.target(), *e.weight())).collect();
+    for (s, t, w) in edges {
+        if t != node1 && t != node2 {
+            graph.add_edge(s, t, w);
+        }
+    }
+    graph.remove_node(node2);
+}
+
+fn minimum_cut_phase<N, EdgeId, K, Ix>(
+    graph: &Graph<N, (EdgeId, K), Undirected, Ix>,
+    start: NodeIndex<Ix>,
+) -> (Vec<EdgeId>, K, NodeIndex<Ix>, NodeIndex<Ix>) 
+where
+    Ix: IndexType,
+    K: Measure + Copy,
+    EdgeId: Copy,
+{
+    let mut queue = BinaryHeap::new();
+    let mut seen = graph.visit_map();
+    let mut seen_list = Vec::new();
+    let mut max_adj_map: HashMap<NodeIndex<Ix>, K> = HashMap::new();
+    queue.push(MaxScored(Default::default(), start));
+
+    while let Some(MaxScored(_, node)) = queue.pop() {
+        if !seen.is_visited(&node) {
+            seen.visit(node);
+            seen_list.push(node);
+            for edge in graph.edges(node) {
+                let target = edge.target();
+                let max_adj = max_adj_map
+                                .get(&edge.target())
+                                .map_or_else(|| edge.weight().1
+                                            , |&w| w + edge.weight().1);
+                max_adj_map.insert(target, max_adj);
+                queue.push(MaxScored(max_adj, target));
+            }
+        }
+    }
+
+    let len = seen_list.len();
+    let last = seen_list[len-1];
+    let before_last = seen_list[len-2];
+    let edges: Vec<_> = graph.edges(last).map(|e| e.weight().0).collect();
+    let weight = sum(graph.edges(last).map(|e| e.weight().1));
+    
+    (edges, weight, last, before_last)
+}
+
+fn minimum_cut_aux<N, EdgeId, K, Ix>(
+    graph: &mut Graph<N, (EdgeId, K), Undirected, Ix>
+) -> (Vec<EdgeId>, K)
+where
+    Ix: IndexType,
+    K: Measure + Copy,
+    EdgeId: Copy,
+{
+    if graph.node_count() == 0 {
+        return (vec![], K::default());
+    }
+    
+    let a = graph.node_indices().next().unwrap();
+    let mut best_cut = graph.edges(a).map(|e| e.weight().0).collect();
+    let mut best_weight = sum(graph.edges(a).map(|e| e.weight().1));
+
+    while graph.node_count() > 1 {
+        let a = graph.node_indices().next().unwrap();
+        if graph.edges(a).next().is_none() {
+            return (vec! [], Default::default());
+        }
+        let (cut, weight, node1, node2) = minimum_cut_phase(&graph, a);
+        if weight < best_weight {
+            best_cut = cut;
+            best_weight = weight;
+        }
+        merge_vertices(graph, node1, node2);
+    }
+    (best_cut, best_weight)
+}

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -13,6 +13,7 @@ pub mod floyd_warshall;
 pub mod isomorphism;
 pub mod k_shortest_path;
 pub mod matching;
+pub mod minimum_cut;
 pub mod simple_paths;
 pub mod tred;
 
@@ -44,6 +45,7 @@ pub use isomorphism::{
 };
 pub use k_shortest_path::k_shortest_path;
 pub use matching::{greedy_matching, maximum_matching, Matching};
+pub use minimum_cut::minimum_cut;
 pub use simple_paths::all_simple_paths;
 
 /// \[Generic\] Return the number of connected components of the graph.

--- a/src/scored.rs
+++ b/src/scored.rs
@@ -50,3 +50,44 @@ impl<K: PartialOrd, T> Ord for MinScored<K, T> {
         }
     }
 }
+
+#[derive(Copy, Clone, Debug)]
+pub struct MaxScored<K, T>(pub K, pub T);
+
+impl<K: PartialOrd, T> PartialEq for MaxScored<K, T> {
+    #[inline]
+    fn eq(&self, other: &MaxScored<K, T>) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<K: PartialOrd, T> Eq for MaxScored<K, T> {}
+
+impl<K: PartialOrd, T> PartialOrd for MaxScored<K, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &MaxScored<K, T>) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K: PartialOrd, T> Ord for MaxScored<K, T> {
+    #[inline]
+    fn cmp(&self, other: &MaxScored<K, T>) -> Ordering {
+        let a = &self.0;
+        let b = &other.0;
+        if a == b {
+            Ordering::Equal
+        } else if a < b {
+            Ordering::Less
+        } else if a > b {
+            Ordering::Greater
+        } else if a.ne(a) && b.ne(b) {
+            // these are the NaN cases
+            Ordering::Equal
+        } else if a.ne(a) {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        }
+    }
+}

--- a/tests/minimum_cut.rs
+++ b/tests/minimum_cut.rs
@@ -91,3 +91,40 @@ fn minimum_cut_disconnected() {
     assert_eq!(cut.len(), 0);
     assert_eq!(weight, 0);
 }
+
+#[test]
+fn minimum_cut_two_cliques() {
+    let mut graph: Graph<(), u32, Undirected> = Graph::new_undirected();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+    let e = graph.add_node(());
+    let f = graph.add_node(());
+
+    let g = graph.add_node(());
+    let h = graph.add_node(());
+    let i = graph.add_node(());
+    let j = graph.add_node(());
+    let k = graph.add_node(());
+    let l = graph.add_node(());
+
+    let clique1 = vec!(a, b, c, d, e, f);
+    let clique2 = vec!(g, h, i, j, k, l);
+
+    for idx in 0 .. clique1.len() - 1 {
+        for idx2 in idx+1 .. clique1.len() {
+            graph.add_edge(clique1[idx], clique1[idx2], 1);
+            graph.add_edge(clique2[idx], clique2[idx2], 1);
+        }
+    }
+    graph.extend_with_edges(&[
+        (a, g, 1),
+        (b, h, 1),
+        (c, i, 1),
+    ]);
+
+    let (cut, weight) = minimum_cut(&graph, |e| *e.weight());
+    assert_eq!(cut.len(), 3);
+    assert_eq!(weight, 3);
+}

--- a/tests/minimum_cut.rs
+++ b/tests/minimum_cut.rs
@@ -1,0 +1,93 @@
+use petgraph::algo::minimum_cut;
+use petgraph::prelude::*;
+use petgraph::Graph;
+
+#[test]
+fn minimum_cut_test1() {
+    let mut graph: Graph<(), u32, Undirected> = Graph::new_undirected();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+    let e = graph.add_node(());
+    let f = graph.add_node(());
+    let g = graph.add_node(());
+    let h = graph.add_node(());
+
+    graph.extend_with_edges(&[
+        (a, b, 7),
+        (b, c, 2),
+        (c, d, 8),
+        (d, a, 3),
+        (e, f, 6),
+        
+        (f, g, 1),
+        (g, h, 5),
+        (h, e, 4),
+       
+    ]);
+    let be = graph.add_edge(b, e, 1);
+    let ch = graph.add_edge(c, h, 3);
+    // a --7-- b --1-- e --6-- f
+    // |       |       |       |
+    // 3       2       4       1
+    // |       |       |       |
+    // d --8-- c---3-- h --5-- g
+
+    let (edges, weight) = minimum_cut(&graph, |e| *e.weight());
+    assert_eq!(edges.len(), 2);
+    assert!(edges[0] == be && edges[1] == ch || edges[1] == be && edges[0] == ch);
+    assert_eq!(weight, 4);
+}
+
+
+#[test]
+fn minimum_cut_one_vertex() {
+    let mut graph: Graph<(), u32, Undirected> = Graph::new_undirected();
+    graph.add_node(());
+
+    let (cut, weight) = minimum_cut(&graph, |e| *e.weight());
+    assert_eq!(cut.len(), 0);
+    assert_eq!(weight, 0);
+}
+
+
+#[test]
+fn minimum_cut_two_vertices() {
+    let mut graph: Graph<(), u32, Undirected> = Graph::new_undirected();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+
+    graph.extend_with_edges(&[
+        (a, b, 1),
+        (a, b, 3),
+    ]);
+
+    let (cut, weight) = minimum_cut(&graph, |e| *e.weight());
+    assert_eq!(cut.len(), 2);
+    assert_eq!(weight, 4);
+}
+
+#[test]
+fn minimum_cut_disconnected() {
+    let mut graph: Graph<(), u32, Undirected> = Graph::new_undirected();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+    let e = graph.add_node(());
+    let f = graph.add_node(());
+
+    graph.extend_with_edges(&[
+        (a, b, 1),
+        (b, c, 1),
+        (c, a, 1),
+        (d, e, 1),
+        (e, f, 6),
+        (f, d, 1),
+    ]);
+
+    let (cut, weight) = minimum_cut(&graph, |e| *e.weight());
+    assert_eq!(cut.len(), 0);
+    assert_eq!(weight, 0);
+}


### PR DESCRIPTION
Hi,

I propose an implementation of Stoer–Wagner algorithm to solve the (global) minimum cut problem.
https://en.wikipedia.org/wiki/Stoer%E2%80%93Wagner_algorithm

The implementation runs in O(|V| |E| + |V|²*log(|V|).

I'm fairly new to Rust and Petgraph. So I would be happy to have some advice.

The algorithm requires modifying the graph (vertex merging). So, I works on a mutable copy of the graph with the type Graph. 
There may be a more elegant way to do this.

Since I need a max version of `MinScored`, I created the struct `MaxScored`.

I have added tests, quickcheck tests and benchmarks.