### PR TITLE
Extend the parallel iterators for GraphMap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         include:
           - rust: 1.64.0  # MSRV
           - rust: stable
-            features: unstable quickcheck
+            features: unstable quickcheck rayon
             test_all: --all
           - rust: beta
             test_all: --all
           - rust: nightly
-            features: unstable quickcheck
+            features: unstable quickcheck rayon
             test_all: --all
             bench: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.64"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["serde-1", "quickcheck"]
+features = ["rayon", "serde-1", "quickcheck"]
 
 [package.metadata.release]
 no-dev-version = true

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::hash::{self, Hash};
 use std::iter::FromIterator;
-use std::iter::{Cloned, DoubleEndedIterator};
+use std::iter::{Copied, DoubleEndedIterator};
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, Index, IndexMut};
@@ -387,7 +387,7 @@ where
     /// Iterator element type is `N`.
     pub fn nodes(&self) -> Nodes<'_, N> {
         Nodes {
-            iter: self.nodes.keys().cloned(),
+            iter: self.nodes.keys().copied(),
         }
     }
 
@@ -621,7 +621,7 @@ iterator_wrap! {
     #[derive(Debug, Clone)]
     struct Nodes <'a, N> where { N: 'a + NodeTrait }
     item: N,
-    iter: Cloned<Keys<'a, N, Vec<(N, CompactDirection)>>>,
+    iter: Copied<Keys<'a, N, Vec<(N, CompactDirection)>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -1266,10 +1266,10 @@ where
 {
     type Item = N;
 
-    fn drive_unindexed<C>(self, c: C) -> C::Result
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
     where
         C: UnindexedConsumer<Self::Item>,
     {
-        self.iter.cloned().drive_unindexed(c)
+        self.iter.copied().drive_unindexed(consumer)
     }
 }

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -25,7 +25,7 @@ use crate::IntoWeightedEdge;
 #[cfg(feature = "rayon")]
 use indexmap::map::rayon::ParKeys;
 #[cfg(feature = "rayon")]
-use rayon::{iter::plumbing::UnindexedConsumer, prelude::*};
+use rayon::prelude::*;
 
 /// A `GraphMap` with undirected edges.
 ///
@@ -1268,8 +1268,36 @@ where
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
     where
-        C: UnindexedConsumer<Self::Item>,
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
     {
         self.iter.copied().drive_unindexed(consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        self.iter.opt_len()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, N> IndexedParallelIterator for ParNodes<'a, N>
+where
+    N: NodeTrait + Send + Sync,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::Consumer<Self::Item>,
+    {
+        self.iter.copied().drive(consumer)
+    }
+
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: rayon::iter::plumbing::ProducerCallback<Self::Item>,
+    {
+        self.iter.copied().with_producer(callback)
     }
 }

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -385,12 +385,15 @@ where
     /// Return an iterator over the nodes of the graph.
     ///
     /// Iterator element type is `N`.
-    pub fn nodes(&self) -> Nodes<N> {
+    pub fn nodes(&self) -> Nodes<'_, N> {
         Nodes {
             iter: self.nodes.keys().cloned(),
         }
     }
 
+    /// Return a parallel iterator over the nodes of the graph.
+    ///
+    /// Iterator element type is `N`.
     #[cfg(feature = "rayon")]
     pub fn par_nodes(&self) -> ParNodes<'_, N>
     where
@@ -1251,7 +1254,7 @@ where
 #[cfg(feature = "rayon")]
 pub struct ParNodes<'a, N>
 where
-    N: Send + Sync,
+    N: NodeTrait + Send + Sync,
 {
     iter: ParKeys<'a, N, Vec<(N, CompactDirection)>>,
 }
@@ -1259,14 +1262,14 @@ where
 #[cfg(feature = "rayon")]
 impl<'a, N> ParallelIterator for ParNodes<'a, N>
 where
-    N: Send + Sync,
+    N: NodeTrait + Send + Sync,
 {
-    type Item = &'a N;
+    type Item = N;
 
     fn drive_unindexed<C>(self, c: C) -> C::Result
     where
         C: UnindexedConsumer<Self::Item>,
     {
-        self.iter.drive_unindexed(c)
+        self.iter.cloned().drive_unindexed(c)
     }
 }

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -416,4 +416,15 @@ fn test_parallel_iterator() {
     gr.par_nodes()
         .enumerate()
         .for_each(|(i, n)| assert_eq!(i as u32, n));
+
+    for i in 0..1000 {
+        gr.add_edge(i / 2, i, i + i / 2);
+    }
+
+    let serial_sum: u32 = gr.all_edges().map(|(.., &e)| e).sum();
+    let parallel_sum: u32 = gr.par_all_edges().map(|(.., &e)| e).sum();
+    assert_eq!(serial_sum, parallel_sum);
+
+    gr.par_all_edges_mut().for_each(|(n1, n2, e)| *e -= n1 + n2);
+    gr.all_edges().for_each(|(.., &e)| assert_eq!(e, 0));
 }

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -412,4 +412,8 @@ fn test_parallel_iterator() {
     let serial_sum: u32 = gr.nodes().sum();
     let parallel_sum: u32 = gr.par_nodes().sum();
     assert_eq!(serial_sum, parallel_sum);
+
+    gr.par_nodes()
+        .enumerate()
+        .for_each(|(i, n)| assert_eq!(i as u32, n));
 }


### PR DESCRIPTION
I hope you don't mind, I've bundled a few rayon additions together:

- Make `graphmap::ParNodes` produce `N` by value, to be consistent with the serial `Nodes`.
  - This would be a breaking change, but I don't believe rayon support has been published yet.
- `impl IndexedParallelIterator for graphmap::ParNodes`
- Add rayon versions of `AllEdges`[`Mut`]
- Add rayon to the CI workflow and docs.rs config.
