### PR TITLE
Use typos-cli for automatic spell-checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,5 +131,13 @@ jobs:
 
       - name: Run tests
         run: just coverage --lcov --output-path lcov.info
+  typos:
+      name: "Spell check"
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - uses: crate-ci/typos@master
+          with:
+            files: .
 
 # TODO: use a tool like codecov to upload the coverage report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ([#369](https://github.com/petgraph/petgraph/issues/369)).
 - Implement Debug and Clone for all the iterators
   ([#418](https://github.com/petgraph/petgraph/issues/418)).
-- Implement multiple mising traits on graph implementations and
+- Implement multiple missing traits on graph implementations and
   adapters ([#405](https://github.com/petgraph/petgraph/issues/405),
   [#429](https://github.com/petgraph/petgraph/issues/429)).
 - Add an EdgeIndexable public trait
@@ -146,7 +146,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Now using github actions as CI
   ([#391](https://github.com/petgraph/petgraph/issues/391)).
-- Replace matchs on [Option\<T\>]{.title-ref} with [map]{.title-ref}
+- Replace matches on [Option\<T\>]{.title-ref} with [map]{.title-ref}
   ([#381](https://github.com/petgraph/petgraph/issues/381)).
 - Added benchmarks for `tarjan_scc`
   ([#421](https://github.com/petgraph/petgraph/issues/421)).

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+ba = "ba"

--- a/crates/adjacency-matrix/src/list.rs
+++ b/crates/adjacency-matrix/src/list.rs
@@ -93,7 +93,7 @@ where
 {
     /// Source of the edge.
     from: NodeIndex<Ix>,
-    /// Index of the sucessor in the successor list.
+    /// Index of the successor in the successor list.
     successor_index: usize,
 }
 
@@ -108,10 +108,10 @@ item: EdgeIndex<Ix>,
 iter: iter::Map<iter::Zip<Range<usize>, iter::Repeat<NodeIndex<Ix>>>, fn((usize, NodeIndex<Ix>)) -> EdgeIndex<Ix>>,
 }
 
-/// Weighted sucessor
+/// Weighted successor
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 struct WSuc<E, Ix: IndexType> {
-    /// Index of the sucessor.
+    /// Index of the successor.
     suc: NodeIndex<Ix>,
     /// Weight of the edge to `suc`.
     weight: E,
@@ -280,7 +280,7 @@ impl<E, Ix: IndexType> AdjacencyList<E, Ix> {
     }
 
     /// Adds a new node to the list by giving its list of successors and the corresponding
-    /// weigths.
+    /// weights.
     pub fn add_node_from_edges<I: Iterator<Item = (NodeIndex<Ix>, E)>>(
         &mut self,
         edges: I,

--- a/crates/algorithms/src/bipartite/check.rs
+++ b/crates/algorithms/src/bipartite/check.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use petgraph_core::deprecated::visit::{GraphRef, IntoNeighbors, VisitMap, Visitable};
 
 /// Return `true` if the graph is bipartite. A graph is bipartite if its nodes can be divided into
-/// two disjoint and indepedent sets U and V such that every edge connects U to one in V. This
+/// two disjoint and independent sets U and V such that every edge connects U to one in V. This
 /// algorithm implements 2-coloring algorithm based on the BFS algorithm.
 ///
 /// Always treats the input graph as if undirected.
@@ -32,14 +32,14 @@ where
         assert!(is_red ^ is_blue);
 
         for neighbour in g.neighbors(node) {
-            let is_neigbour_red = red.is_visited(&neighbour);
-            let is_neigbour_blue = blue.is_visited(&neighbour);
+            let is_neighbour_red = red.is_visited(&neighbour);
+            let is_neighbour_blue = blue.is_visited(&neighbour);
 
-            if (is_red && is_neigbour_red) || (is_blue && is_neigbour_blue) {
+            if (is_red && is_neighbour_red) || (is_blue && is_neighbour_blue) {
                 return false;
             }
 
-            if !is_neigbour_red && !is_neigbour_blue {
+            if !is_neighbour_red && !is_neighbour_blue {
                 //hasn't been visited yet
 
                 match (is_red, is_blue) {

--- a/crates/algorithms/src/components/condensation.rs
+++ b/crates/algorithms/src/components/condensation.rs
@@ -263,8 +263,8 @@ mod tests {
         fn condensation_is_acyclic(graph in any::<Graph<(), (), Directed, u8>>()) {
             let condensed = super::condensation(graph, true);
 
-            let is_cylic = is_cyclic_directed(&condensed);
-            prop_assert!(!is_cylic);
+            let is_cyclic = is_cyclic_directed(&condensed);
+            prop_assert!(!is_cyclic);
         }
     }
 }

--- a/crates/algorithms/src/simple_paths/mod.rs
+++ b/crates/algorithms/src/simple_paths/mod.rs
@@ -56,8 +56,8 @@ where
 
     // list of visited nodes
     let mut visited: IndexSet<G::NodeId> = IndexSet::from_iter(Some(from));
-    // list of childs of currently exploring path nodes,
-    // last elem is list of childs of last visited node
+    // list of children of currently exploring path nodes,
+    // last elem is list of children of last visited node
     let mut stack = vec![graph.neighbors_directed(from, Direction::Outgoing)];
 
     from_fn(move || {

--- a/crates/core/src/edge/compat.rs
+++ b/crates/core/src/edge/compat.rs
@@ -1,4 +1,4 @@
-//! Compatability implementations for deprecated graph traits.
+//! Compatibility implementations for deprecated graph traits.
 #![allow(deprecated)]
 
 use crate::{

--- a/crates/core/src/graph/compat.rs
+++ b/crates/core/src/graph/compat.rs
@@ -1,4 +1,4 @@
-//! Compatability implementations for deprecated graph traits.
+//! Compatibility implementations for deprecated graph traits.
 #![allow(deprecated)]
 
 #[cfg(feature = "alloc")]

--- a/crates/core/src/node/compat.rs
+++ b/crates/core/src/node/compat.rs
@@ -1,4 +1,4 @@
-//! Compatability implementations for deprecated graph traits.
+//! Compatibility implementations for deprecated graph traits.
 #![allow(deprecated)]
 
 use crate::{

--- a/crates/core/src/storage/mod.rs
+++ b/crates/core/src/storage/mod.rs
@@ -675,7 +675,7 @@ pub trait GraphStorage: SequentialGraphStorage + AuxiliaryGraphStorage + Sized {
     /// This will return [`None`] if the node does not exist, and will return the node if it does.
     ///
     /// The [`Node`] type returned by this function contains a reference to the current graph,
-    /// meaning you are able to query for e.g. the neighours of the node.
+    /// meaning you are able to query for e.g. the neighbours of the node.
     ///
     /// # Example
     ///

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -723,7 +723,7 @@ where
         // indices.
         let edge = self.edges.swap_remove(e.index());
         let swap = match self.edges.get(e.index()) {
-            // no elment needed to be swapped.
+            // no element needed to be swapped.
             None => return Some(edge.weight),
             Some(ed) => ed.node,
         };

--- a/crates/graph/tests/test_proptest.rs
+++ b/crates/graph/tests/test_proptest.rs
@@ -167,7 +167,7 @@ where
     let externals_outgoing: Vec<_> = graph.externals(Direction::Outgoing).collect();
     let externals_incoming: Vec<_> = graph.externals(Direction::Incoming).collect();
 
-    let out_degress = graph
+    let out_degrees = graph
         .node_indices()
         .map(|index| graph.neighbors_directed(index, Direction::Outgoing).count())
         .collect::<Vec<_>>();
@@ -182,7 +182,7 @@ where
     let reversed_externals_outgoing: Vec<_> = graph.externals(Direction::Outgoing).collect();
     let reversed_externals_incoming: Vec<_> = graph.externals(Direction::Incoming).collect();
 
-    let reversed_out_degress = graph
+    let reversed_out_degrees = graph
         .node_indices()
         .map(|index| graph.neighbors_directed(index, Direction::Outgoing).count())
         .collect::<Vec<_>>();
@@ -194,16 +194,16 @@ where
 
     assert_eq!(externals_outgoing, reversed_externals_incoming);
     assert_eq!(externals_incoming, reversed_externals_outgoing);
-    assert_eq!(out_degress, reversed_in_degrees);
-    assert_eq!(in_degrees, reversed_out_degress);
+    assert_eq!(out_degrees, reversed_in_degrees);
+    assert_eq!(in_degrees, reversed_out_degrees);
 
     // additional test if we're isomorphic by simply eq out and in
     if !Ty::is_directed() {
         assert_eq!(externals_outgoing, externals_incoming);
         assert_eq!(reversed_externals_outgoing, reversed_externals_incoming);
 
-        assert_eq!(out_degress, in_degrees);
-        assert_eq!(reversed_out_degress, reversed_in_degrees);
+        assert_eq!(out_degrees, in_degrees);
+        assert_eq!(reversed_out_degrees, reversed_in_degrees);
     }
 }
 

--- a/crates/graph/tests/test_serde.rs
+++ b/crates/graph/tests/test_serde.rs
@@ -124,7 +124,7 @@ pub fn assert_stable_graph_eq<N, E, Ix>(
         let last_edge_graph1_index = edge_graph1.id().index();
         let last_edge_graph2_index = edge_graph2.id().index();
 
-        // same edge weigths
+        // same edge weights
         assert_iter_eq(
             (0..last_edge_graph1_index).map(|i| graph1.edge_weight(EdgeIndex::new(i))),
             (0..last_edge_graph2_index).map(|i| graph2.edge_weight(EdgeIndex::new(i))),

--- a/crates/proptest/src/default.rs
+++ b/crates/proptest/src/default.rs
@@ -114,7 +114,7 @@ where
 
             // generate an edge where no self edges are allowed, this allows the use in
             // a lot more graphs
-            // exlude the last node, since in that case we would have no matching end node.
+            // exclude the last node, since in that case we would have no matching end node.
             // `saturating_sub` here, as `0..(0 - 1)` will happen, but will never be selected.
             let edge_endpoints_always = Arc::new((0..nodes_len.saturating_sub(1)).prop_flat_map(
                 move |start| {


### PR DESCRIPTION
Hi! I've been reading through both `master` and `next`. Love what you're doing @indietyp!

I noticed in #605 you mentioned *documentation, documentation, documentation* as part of next steps. I figured it'd be helpful to add some tooling ([`typos`](https://github.com/crate-ci/typos)) to catch typos throughout both the code and, maybe more importantly, in any documentation that's generated.

I also ran `cargo fmt` and manually opted-out of any code-specific formatting in the diff. I did this because I noticed you're using some non-defaults for formatting options like `wrap_comments`.

I'm also happy to checkout upgrading [`actions/checkout@v4`](https://github.com/actions/checkout) if you're interested.

_____

On a side note, if my goal is to get familiar with this code-base, what do you think makes the most sense for me to spend more of my time with `master` or `next`?