### PR TITLE
chore: bumped itertools to 0.12.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rayon = { version = "1.5.3", optional = true }
 [dev-dependencies]
 bincode = "1.3.3"
 defmac = "0.2.1"
-itertools = { version = "0.11.0", default-features = false }
+itertools = { version = "0.12.1", default-features = false }
 odds = { version = "0.4.0" }
 rand = "0.5.5"
 ahash = "0.7.2"


### PR DESCRIPTION
This is just a minor thing. I want to keep all dependencies upto date.

looking at the output of 
```
cargo outdated 
```

There is a lots to fix... But in this PR I am fixing only the frist.

My preference here is a series of mirco PR  ( maybe more than 5 ) 
where each package is updated in isolation.  

That way if later on another developer has to go through the git blame / or git bisect cycle to find a breaking change
Then the revert is simple.

I have worked with project managers - who prefer all these change to be wrapped up into one PR.

I will be happy to conform to either approach.

PS 
Updating the rand crate from 0.5 to 0.8 is going to take some justififation where the migration guide talks about 
moving from the ChaCha20  to ChaCha12 improving performance with only a small decrease in security 