### PR TITLE
Minor: Cargo doc fixup.

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -29,6 +29,8 @@ pub type DefaultIx = u32;
 
 /// Trait for the unsigned integer type used for node and edge indices.
 ///
+/// # Safety
+///
 /// Marked `unsafe` because: the trait must faithfully preserve
 /// and convert index values.
 pub unsafe trait IndexType: Copy + Default + Hash + Ord + fmt::Debug + 'static {


### PR DESCRIPTION
Clippy suggests using this markdown convention when discussing unsafe code.

A new heading and section is added.

This is how the updated page looks 

![Safe](https://github.com/petgraph/petgraph/assets/1259969/da94c8de-46d3-4251-9a72-c5399683d73c)
