### PR TITLE
Chore: Minor - Bumped actions/checkout to version 4.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             bench: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -58,7 +58,7 @@ jobs:
             rustfmt: rustfmt
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -72,7 +72,7 @@ jobs:
   miri:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri


### PR DESCRIPTION
A high level summary of the migration guide ( from version 2 -> version 4 ) :-

* Internally "node 12"( 2019 ) becomes "node 20" ( Oct 2023 ).

* The caching stratergy is improved, less network activity and better performance.