### PR TITLE
Extra features for #650

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -46,7 +46,7 @@ pub use k_shortest_path::k_shortest_path;
 pub use matching::{greedy_matching, maximum_matching, Matching};
 pub use min_spanning_tree::min_spanning_tree;
 pub use page_rank::page_rank;
-pub use simple_paths::{all_simple_paths, all_simple_paths_from};
+pub use simple_paths::{all_simple_edge_paths, all_simple_edge_paths_from, all_simple_node_paths};
 
 /// \[Generic\] Return the number of connected components of the graph.
 ///


### PR DESCRIPTION
This commit ends up touching a fair chunk of code outside of the (proposed) `all_simple_paths_from` function.
* rename `all_simple_paths` -> `all_simple_node_paths`
* rename `all_simple_paths_from` -> `all_simple_edge_paths_from`
* add analogous function `all_simple_edge_paths` that gives an iterable over paths, specified by edges
* function signature altered to clarify language + remove opaque counting feature
* checking added, both functions will panic instead of quietly fixing things for the user
* tests added, including negative tests