### PR TITLE
feat: Add Bron-Kerbosch algorithm for maximal cliques

### DIFF
--- a/benches/maximal_cliques.rs
+++ b/benches/maximal_cliques.rs
@@ -1,0 +1,37 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use test::Bencher;
+
+use petgraph::algo::maximal_cliques;
+
+#[allow(dead_code)]
+mod common;
+
+use common::directed_fan;
+
+#[bench]
+fn maximal_cliques_fan_10_bench(bench: &mut Bencher) {
+    let g = directed_fan(10);
+    bench.iter(|| maximal_cliques(&g));
+}
+
+#[bench]
+fn maximal_cliques_fan_50_bench(bench: &mut Bencher) {
+    let g = directed_fan(50);
+    bench.iter(|| maximal_cliques(&g));
+}
+
+#[bench]
+fn maximal_cliques_fan_100_bench(bench: &mut Bencher) {
+    let g = directed_fan(100);
+    bench.iter(|| maximal_cliques(&g));
+}
+
+#[bench]
+fn maximal_cliques_fan_200_bench(bench: &mut Bencher) {
+    let g = directed_fan(200);
+    bench.iter(|| maximal_cliques(&g));
+}

--- a/src/algo/maximal_cliques.rs
+++ b/src/algo/maximal_cliques.rs
@@ -1,0 +1,99 @@
+use crate::visit::{GetAdjacencyMatrix, IntoNeighbors, IntoNodeIdentifiers};
+use alloc::vec::Vec;
+use core::hash::Hash;
+use core::iter::FromIterator;
+use hashbrown::HashSet;
+
+/// Finds maximal cliques containing all the vertices in r, some of the
+/// vertices in p, and none of the vertices in x.
+fn bron_kerbosch_pivot<G>(
+    g: G,
+    adj_mat: &G::AdjMatrix,
+    r: HashSet<G::NodeId>,
+    mut p: HashSet<G::NodeId>,
+    mut x: HashSet<G::NodeId>,
+) -> Vec<HashSet<G::NodeId>>
+where
+    G: GetAdjacencyMatrix + IntoNeighbors,
+    G::NodeId: Eq + Hash,
+{
+    let mut cliques = Vec::with_capacity(1);
+    if p.is_empty() {
+        if x.is_empty() {
+            cliques.push(r);
+        }
+        return cliques;
+    }
+    // pick the pivot u to be the vertex with max degree
+    let u = p.iter().max_by_key(|&v| g.neighbors(*v).count()).unwrap();
+    let mut todo = p
+        .iter()
+        .filter(|&v| *u == *v || !g.is_adjacent(adj_mat, *u, *v) || !g.is_adjacent(adj_mat, *v, *u)) //skip neighbors of pivot
+        .cloned()
+        .collect::<Vec<G::NodeId>>();
+    while let Some(v) = todo.pop() {
+        let neighbors = HashSet::from_iter(g.neighbors(v));
+        p.remove(&v);
+        let mut next_r = r.clone();
+        next_r.insert(v);
+
+        let next_p = p
+            .intersection(&neighbors)
+            .cloned()
+            .collect::<HashSet<G::NodeId>>();
+        let next_x = x
+            .intersection(&neighbors)
+            .cloned()
+            .collect::<HashSet<G::NodeId>>();
+
+        cliques.extend(bron_kerbosch_pivot(g, adj_mat, next_r, next_p, next_x));
+
+        x.insert(v);
+    }
+
+    cliques
+}
+
+/// Find all maximal cliques in a graph using Bron–Kerbosch algorithm
+/// with pivoting.
+///
+/// A clique is a set of nodes such that every node connects to
+/// every other. A maximal clique is a clique that cannot be extended
+/// by including one more adjacent vertex. A graph may have multiple
+/// maximal cliques.
+///
+/// Example
+/// ```
+/// use petgraph::algo::maximal_cliques;
+/// use petgraph::graph::UnGraph;
+///
+/// let mut g = UnGraph::<i32, ()>::from_edges([(0, 1), (0, 2), (1, 2), (2, 3)]);
+/// g.add_node(4);
+/// // The example graph:
+/// //
+/// // 0 --- 2 -- 3
+/// //  \   /
+/// //   \ /
+/// //    1       4
+/// //
+/// // maximal cliques: {4}, {2, 3}, {0, 1, 2}
+/// // Output the result
+/// let cliques = maximal_cliques(&g);
+/// println!("{:?}", cliques);
+/// // [
+/// //   {NodeIndex(4)},
+/// //   {NodeIndex(0), NodeIndex(1), NodeIndex(2)},
+/// //   {NodeIndex(2), NodeIndex(3)}
+/// // ]
+/// ```
+pub fn maximal_cliques<G>(g: G) -> Vec<HashSet<G::NodeId>>
+where
+    G: GetAdjacencyMatrix + IntoNodeIdentifiers + IntoNeighbors,
+    G::NodeId: Eq + Hash,
+{
+    let adj_mat = g.adjacency_matrix();
+    let r = HashSet::new();
+    let p = g.node_identifiers().collect::<HashSet<G::NodeId>>();
+    let x = HashSet::new();
+    bron_kerbosch_pivot(g, &adj_mat, r, p, x)
+}

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -16,6 +16,7 @@ pub mod ford_fulkerson;
 pub mod isomorphism;
 pub mod k_shortest_path;
 pub mod matching;
+pub mod maximal_cliques;
 pub mod min_spanning_tree;
 pub mod page_rank;
 pub mod simple_paths;
@@ -50,6 +51,7 @@ pub use isomorphism::{
 };
 pub use k_shortest_path::k_shortest_path;
 pub use matching::{greedy_matching, maximum_matching, Matching};
+pub use maximal_cliques::maximal_cliques;
 pub use min_spanning_tree::{min_spanning_tree, min_spanning_tree_prim};
 pub use page_rank::page_rank;
 pub use simple_paths::all_simple_paths;

--- a/tests/maximal_cliques.rs
+++ b/tests/maximal_cliques.rs
@@ -1,0 +1,229 @@
+extern crate petgraph;
+use core::hash::Hash;
+use hashbrown::HashSet;
+use petgraph::{
+    algo::maximal_cliques,
+    graph::{Graph, NodeIndex},
+    visit::{GetAdjacencyMatrix, IntoNeighbors, IntoNodeIdentifiers},
+    Undirected,
+};
+
+/// (reference implementation)
+/// Finds maximal cliques containing all the vertices in r, some of the
+/// vertices in p, and none of the vertices in x.
+#[allow(dead_code)] //used by tests
+fn bron_kerbosch_ref<G>(
+    g: G,
+    adj_mat: &G::AdjMatrix,
+    r: HashSet<G::NodeId>,
+    mut p: HashSet<G::NodeId>,
+    mut x: HashSet<G::NodeId>,
+) -> Vec<HashSet<G::NodeId>>
+where
+    G: GetAdjacencyMatrix,
+    G: IntoNeighbors,
+    G::NodeId: Eq + Hash,
+{
+    let mut cliques = Vec::with_capacity(1);
+    if p.is_empty() && x.is_empty() {
+        cliques.push(r);
+        return cliques;
+    }
+    let mut todo = p.iter().cloned().collect::<Vec<G::NodeId>>();
+    while let Some(v) = todo.pop() {
+        p.remove(&v);
+        let mut next_r = r.clone();
+        next_r.insert(v);
+
+        let mut neighbors = HashSet::new();
+
+        for u in g.neighbors(v) {
+            if g.is_adjacent(adj_mat, u, v) {
+                neighbors.insert(u);
+            }
+        }
+
+        let next_p = p
+            .intersection(&neighbors)
+            .cloned()
+            .collect::<HashSet<G::NodeId>>();
+        let next_x = x
+            .intersection(&neighbors)
+            .cloned()
+            .collect::<HashSet<G::NodeId>>();
+
+        cliques.extend(bron_kerbosch_ref(g, adj_mat, next_r, next_p, next_x));
+
+        x.insert(v);
+    }
+    cliques
+}
+
+/// (reference implementation)
+/// Find all maximal cliques in a graph.
+#[allow(dead_code)] //used by tests
+pub(crate) fn maximal_cliques_ref<G>(g: G) -> Vec<HashSet<G::NodeId>>
+where
+    G: GetAdjacencyMatrix,
+    G: IntoNodeIdentifiers + IntoNeighbors,
+    G::NodeId: Eq + Hash,
+{
+    let adj_mat = g.adjacency_matrix();
+    let p = g.node_identifiers().collect::<HashSet<G::NodeId>>();
+    bron_kerbosch_ref(g, &adj_mat, HashSet::new(), p, HashSet::new())
+}
+
+#[test]
+fn test_maximal_cliques_ref_directed() {
+    // 5 <- 3 = 4 == 0
+    //      ||  || //
+    //      2 <- 1
+    let mut g = Graph::<i32, ()>::new();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    let e = g.add_node(4);
+    let f = g.add_node(5);
+    g.extend_with_edges([
+        (a, b),
+        (b, a),
+        (a, e),
+        (e, a),
+        (b, e),
+        (e, b),
+        (b, c),
+        (c, d),
+        (d, c),
+        (d, e),
+        (e, d),
+        (e, f),
+    ]);
+
+    let mut cliques = maximal_cliques_ref(&g);
+    println!("{:?}", &cliques);
+
+    let answer = vec![vec![a, b, e], vec![c, d], vec![d, e], vec![f]];
+    assert_eq!(cliques.len(), answer.len());
+
+    for a in answer {
+        let s = a.iter().cloned().collect::<HashSet<NodeIndex>>();
+        cliques.retain(|c| *c != s);
+    }
+    assert!(cliques.is_empty());
+}
+
+#[test]
+fn test_maximal_cliques_ref_undirected() {
+    // 5 - 3 - 4 - 0
+    //     |   | /
+    //     2 - 1
+    let mut g = Graph::<i32, (), Undirected>::new_undirected();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    let e = g.add_node(4);
+    let f = g.add_node(5);
+    g.extend_with_edges([(a, b), (a, e), (b, e), (b, c), (c, d), (d, e), (e, f)]);
+
+    let mut cliques = maximal_cliques_ref(&g);
+    println!("{:?}", &cliques);
+
+    let answer = vec![
+        vec![a, b, e],
+        vec![b, c],
+        vec![c, d],
+        vec![d, e],
+        vec![e, f],
+    ];
+    assert_eq!(cliques.len(), answer.len());
+
+    for a in answer {
+        let s = a.iter().cloned().collect::<HashSet<NodeIndex>>();
+        cliques.retain(|c| *c != s);
+    }
+    assert!(cliques.is_empty());
+}
+
+#[test]
+fn test_maximal_cliques_empty_graph() {
+    // empty graph should not yield any cliques
+    let g = Graph::<i32, ()>::new();
+    let cliques = maximal_cliques(&g);
+    let answer = vec![HashSet::new()];
+    assert_eq!(cliques, answer);
+}
+
+#[test]
+fn test_maximal_cliques_directed() {
+    // 5 <- 3 = 4 == 0
+    //      ||  || //
+    //      2 <- 1
+    let mut g = Graph::<i32, ()>::new();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    let e = g.add_node(4);
+    let f = g.add_node(5);
+    g.extend_with_edges([
+        (a, b),
+        (b, a),
+        (a, e),
+        (e, a),
+        (b, e),
+        (e, b),
+        (b, c),
+        (c, d),
+        (d, c),
+        (d, e),
+        (e, d),
+        (e, f),
+    ]);
+
+    let mut cliques = maximal_cliques_ref(&g);
+    println!("{:?}", &cliques);
+
+    let answer = vec![vec![a, b, e], vec![c, d], vec![d, e], vec![f]];
+    assert_eq!(cliques.len(), answer.len());
+
+    for a in answer {
+        let s = a.iter().cloned().collect::<HashSet<NodeIndex>>();
+        cliques.retain(|c| *c != s);
+    }
+    assert!(cliques.is_empty());
+}
+
+#[test]
+fn test_maximal_cliques_undirected() {
+    // 5 - 3 - 4 - 0
+    //     |   | /
+    //     2 - 1
+    let mut g = Graph::<i32, (), Undirected>::new_undirected();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    let e = g.add_node(4);
+    let f = g.add_node(5);
+    g.extend_with_edges([(a, b), (a, e), (b, e), (b, c), (c, d), (d, e), (e, f)]);
+
+    let mut cliques = maximal_cliques_ref(&g);
+    println!("{:?}", &cliques);
+
+    let answer = vec![
+        vec![a, b, e],
+        vec![b, c],
+        vec![c, d],
+        vec![d, e],
+        vec![e, f],
+    ];
+    assert_eq!(cliques.len(), answer.len());
+
+    for a in answer {
+        let s = a.iter().cloned().collect::<HashSet<NodeIndex>>();
+        cliques.retain(|c| *c != s);
+    }
+    assert!(cliques.is_empty());
+}

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -12,6 +12,7 @@ extern crate defmac;
 extern crate itertools;
 extern crate odds;
 
+mod maximal_cliques;
 mod utils;
 
 use odds::prelude::*;
@@ -32,8 +33,8 @@ use petgraph::algo::{
     bellman_ford, condensation, connected_components, dijkstra, dsatur_coloring,
     find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
     is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
-    k_shortest_path, kosaraju_scc, maximum_matching, min_spanning_tree, page_rank, tarjan_scc,
-    toposort, Matching,
+    k_shortest_path, kosaraju_scc, maximal_cliques as maximal_cliques_algo, maximum_matching,
+    min_spanning_tree, page_rank, tarjan_scc, toposort, Matching,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -1497,4 +1498,28 @@ quickcheck! {
 
         spans_terminals
     }
+}
+
+#[test]
+fn maximal_cliques_matches_ref_impl() {
+    use maximal_cliques::maximal_cliques_ref;
+
+    fn prop<Ty>(g: Graph<(), (), Ty>) -> bool
+    where
+        Ty: EdgeType,
+    {
+        if g.edge_count() <= 200 && g.node_count() <= 200 {
+            let cliques = maximal_cliques_algo(&g);
+            let cliques_ref = maximal_cliques_ref(&g);
+
+            assert!(cliques.len() == cliques_ref.len());
+
+            for c in &cliques_ref {
+                assert!(cliques.contains(c));
+            }
+        }
+        true
+    }
+    quickcheck::quickcheck(prop as fn(Graph<_, _, Undirected>) -> bool);
+    quickcheck::quickcheck(prop as fn(Graph<_, _, Directed>) -> bool);
 }


### PR DESCRIPTION
This PR resurrects https://github.com/petgraph/petgraph/pull/72 by applying @jrraymond's changes to the recent (`0.6.5`) `master` branch with only minor code style changes. This also addresses a recent issue https://github.com/petgraph/petgraph/issues/620.

The added algorithm enumerates maximal cliques in a graph by using Bron-Kerbosch algorithm with pivoting.

Specifically, my added changes include:
- extracting the algorithm to its separate file
- adding a documentation with an example
- moving the reference implementation to the tests file
- modifying test cases so they do not take too long to run

I did not apply the suggestion to use `FixedBitSet` instead of `HashMap` from the original PR as I don't know how to approach it for the generic graph.