### PR TITLE
Update remove_node doc comment in graphmap.rs

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -282,7 +282,7 @@ where
         n
     }
 
-    /// Return `true` if node `n` was removed.
+    /// Return `true` if it did exist.
     ///
     /// Computes in **O(V)** time, due to the removal of edges with other nodes.
     pub fn remove_node(&mut self, n: N) -> bool {


### PR DESCRIPTION
The doc comment for `GraphMap::remove_node` confused me initially, making me think it was a fallible method, so this makes it match `GraphMap::remove_single_edge`. 