### PR TITLE
Update `fixedbitset` to `0.5.7` and crate version to `0.7.0`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "petgraph"
-version = "0.6.6"
+version = "0.6.5"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 authors = ["bluss", "mitchmindtree"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "petgraph"
-version = "0.6.5"
+version = "0.6.6"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 authors = ["bluss", "mitchmindtree"]
@@ -34,7 +34,7 @@ name = "petgraph"
 debug = true
 
 [dependencies]
-fixedbitset = { version = "0.4.0", default-features = false }
+fixedbitset = { version = "0.5.7", default-features = false }
 indexmap = "~2.5.0"
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
Heya, this bumps `fixedbitset` to `0.5.7` and also bumps the crate version to `0.7.0`, as brought up a concern in https://github.com/petgraph/petgraph/pull/617.
