### PR TITLE
Fix #586

### DIFF
--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -133,7 +133,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         for next in self.iter.by_ref() {
-            if next.1 == &self.node {
+            if next.1 == &self.node && next.1 != next.0 {
                 return Some(*next.0);
             }
         }
@@ -326,5 +326,6 @@ mod tests {
         let dom_by: Vec<_> = doms.immediately_dominated_by(1).collect();
         assert_eq!(vec![2], dom_by);
         assert_eq!(None, doms.immediately_dominated_by(99).next());
+        assert_eq!(1, doms.immediately_dominated_by(0).count());
     }
 }

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -132,8 +132,10 @@ where
     type Item = N;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for next in self.iter.by_ref() {
-            if next.1 == &self.node && next.1 != next.0 {
+        for (dominator, dominated) in self.iter.by_ref() {
+            // The root node dominates itself, but it should not be included in
+            // the results.
+            if dominated == &self.node && dominated != dominator {
                 return Some(*next.0);
             }
         }

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -136,7 +136,7 @@ where
             // The root node dominates itself, but it should not be included in
             // the results.
             if dominated == &self.node && dominated != dominator {
-                return Some(*next.0);
+                return Some(*dominator);
             }
         }
         None


### PR DESCRIPTION
This makes it so the root of the dominator tree is not returned during
iteration over `dom_tree.immediately_dominated_by(root)`.
