### PR TITLE
Specify data representations for node and edge indices

### DIFF
--- a/src/adj.rs
+++ b/src/adj.rs
@@ -16,6 +16,7 @@ pub type NodeIndex<Ix = DefaultIx> = Ix;
 
 /// Adjacency list edge index type, a pair of integers.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(C)]
 pub struct EdgeIndex<Ix = DefaultIx>
 where
     Ix: IndexType,

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -101,6 +101,7 @@ unsafe impl IndexType for u8 {
 
 /// Node identifier.
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[repr(transparent)]
 pub struct NodeIndex<Ix = DefaultIx>(Ix);
 
 impl<Ix: IndexType> NodeIndex<Ix> {
@@ -160,6 +161,7 @@ pub fn edge_index<Ix: IndexType>(index: usize) -> EdgeIndex<Ix> {
 
 /// Edge identifier.
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[repr(transparent)]
 pub struct EdgeIndex<Ix = DefaultIx>(Ix);
 
 impl<Ix: IndexType> EdgeIndex<Ix> {


### PR DESCRIPTION
Allows accessing original `Ix` representation through transmutation.

I'm working on a layout wrapper library. Given `NodeIndex` I'd like to access `Ix`. Without this change I'd have to use `NodeIndex::index()` which returns `usize` instead of `Ix`, and then cast that to `Ix` through an intermediary trait.