### PR TITLE
Cycle Basis Algorithm

### DIFF
--- a/benches/cycle_basis.rs
+++ b/benches/cycle_basis.rs
@@ -1,0 +1,31 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use petgraph::prelude::*;
+use std::cmp::{max, min};
+use test::Bencher;
+
+use petgraph::algo::cycle_basis;
+
+#[bench]
+fn cycle_basis_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 100;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).map(|i| g.add_node(i)).collect();
+    for i in 0..NODE_COUNT {
+        let n1 = nodes[i];
+        let neighbour_count = i % 8 + 1;
+        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
+        let j_to = min(NODE_COUNT, j_from + neighbour_count);
+        for j in j_from..j_to {
+            let n2 = nodes[j];
+            g.add_edge(n1, n2, 0);
+        }
+    }
+
+    bench.iter(|| {
+        let _c = cycle_basis(&g, None);
+    });
+}

--- a/src/algo/cycle_basis.rs
+++ b/src/algo/cycle_basis.rs
@@ -5,6 +5,45 @@ use std::{
 
 use crate::visit::{IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable};
 
+
+/// \[Generic\] An algorithm for determining the cycle basis of a graph.
+///
+/// A set of basis for cycles of a graph is a minimal collection of cycles such that
+/// any cycle in the graph can be derived as a sum of the cycles in the cycle basis.
+/// 
+/// Note that graphs may have multiple, correct cycle basis (see the example below). 
+/// 
+/// If no root is selected, then the first node from the 'node_identifiers' iterator is used
+/// as the initial root.
+/// 
+/// This algorithm works for disconnected graphs.
+///
+/// Returns a `Vec` of 'Vec', each containing a cycle. Returns None if no cycles are present.
+/// # Example
+/// ```rust
+/// use petgraph::algo::cycle_basis;
+/// use petgraph::{Graph, Undirected};
+/// use petgraph::visit::NodeIndexable;
+///
+/// let mut graph: Graph<(), u16, Undirected> = Graph::from_edges(&[
+/// (0,1),(1,2),(2,3),(3,0),(0,2),]);
+/// 
+/// // 0 -----> 1
+/// // ^  \     |
+/// // |   \    |
+/// // |    \   |
+/// // |     \  |
+/// // |      > v
+/// // 3 <----- 2
+///
+/// let expected_res: Vec<Vec<usize>> = vec![vec![0,2,3], vec![0,1,2,3]];
+/// let res: Vec<Vec<usize>> = cycle_basis(&graph, Some(graph.to_index(3.into()))).unwrap();
+/// assert_eq!(res, expected_res);
+/// 
+/// // Note that the cycle [0,1,2] is equal to the cycle [0,1,2,3] minus [0,2,3].
+/// // Also note that [0,1,2] and [0,3,2] is an equally correct cycle basis,
+/// // as [0,1,2,3] = [0,1,2] plus [0,3,2] (the edge between 0-2 cancels out).
+/// ```
 pub fn cycle_basis<G>(
     g: G, 
     root_choice_index: Option<usize>,

--- a/src/algo/cycle_basis.rs
+++ b/src/algo/cycle_basis.rs
@@ -1,0 +1,88 @@
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    hash::Hash,
+    vec::Vec,
+};
+
+use crate::visit::{IntoEdges, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable};
+
+pub fn cycle_basis<G>(
+    g: G, 
+    root_choice_index: Option<usize>,
+) -> Option<Vec<Vec<usize>>>
+where
+    G: IntoNeighborsDirected + IntoNodeIdentifiers + IntoEdges + NodeCount + NodeIndexable,
+    G::NodeId: Eq + Hash + Copy,
+{
+    let g_node_count: usize = g.node_count();
+    if g_node_count == 0 {
+        return None  //Handle the trivial case of an empty graph
+    }
+    let mut processed_nodes: HashSet<usize> = HashSet::with_capacity(g_node_count);
+    let mut cycles: Vec<Vec<usize>> = Vec::new();
+
+    let node_vec: VecDeque<G::NodeId> = match root_choice_index {
+        Some(n) => {
+            let mut v: VecDeque<G::NodeId> = g.node_identifiers().collect();
+            v.swap(0,n);
+            v
+        }
+        None => {
+            let w: VecDeque<G::NodeId> = g.node_identifiers().collect();
+            w
+        }
+    };
+    let mut node_iter = node_vec.iter();
+
+    while let Some(root) = node_iter.next() {
+        let rooti = g.to_index(*root);
+        if processed_nodes.contains(&rooti) {
+            continue
+        }
+        let mut stack: Vec<usize> = vec![rooti];
+        let mut pred: HashMap<usize, usize> = HashMap::from([(rooti, rooti)]);
+        let mut used:HashMap<usize, HashSet<usize>> = HashMap::from([(rooti, HashSet::new())]);
+        loop {
+            let z = match stack.pop() {
+                None => break,
+                Some(q) => q
+            };
+            for nbr in g.neighbors(g.from_index(z)) {
+                let nbri = g.to_index(nbr);
+                if !used.contains_key(&nbri) {
+                    pred.insert(nbri, z);
+                    stack.push(nbri);
+                    used.insert(nbri, HashSet::from([z,]));
+                } 
+                else if nbri == z {
+                    cycles.push(vec![z]);
+                } 
+                else if !((used.get(&z).unwrap()).contains(&nbri)) {
+                    let pn: &HashSet<usize> = used.get(&nbri).unwrap();
+                    let mut cycle: Vec<usize> = vec![nbri, z];
+                    let mut p = pred.get(&z).unwrap();
+                    loop {
+                        cycle.push(*p);
+                        p = pred.get(&p).unwrap();
+                        if pn.contains(&p) {
+                            break
+                        }
+                    }
+                    cycle.push(*p);
+                    cycle.dedup(); //As we have an explicit self-loop conditional, this is ok
+                    cycles.push(cycle);
+                    used.get_mut(&nbri).unwrap().insert(z);
+                }
+            }
+            let mut iter_pred = pred.iter();
+            while let Some((key, _value)) = iter_pred.next() {
+                processed_nodes.insert(*key);
+            }
+        }
+        processed_nodes.insert(rooti);
+    }
+    if !cycles.is_empty() {
+        return Some(cycles)
+    }
+    None
+}

--- a/src/algo/cycle_basis.rs
+++ b/src/algo/cycle_basis.rs
@@ -1,18 +1,16 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    hash::Hash,
     vec::Vec,
 };
 
-use crate::visit::{IntoEdges, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable};
+use crate::visit::{IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIndexable};
 
 pub fn cycle_basis<G>(
     g: G, 
     root_choice_index: Option<usize>,
 ) -> Option<Vec<Vec<usize>>>
 where
-    G: IntoNeighborsDirected + IntoNodeIdentifiers + IntoEdges + NodeCount + NodeIndexable,
-    G::NodeId: Eq + Hash + Copy,
+    G: IntoNeighborsDirected + IntoNodeIdentifiers + NodeCount + NodeIndexable
 {
     let g_node_count: usize = g.node_count();
     if g_node_count == 0 {

--- a/src/algo/cycle_basis.rs
+++ b/src/algo/cycle_basis.rs
@@ -36,8 +36,9 @@ use crate::visit::{IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, NodeIn
 /// // |      > v
 /// // 3 <----- 2
 ///
-/// let expected_res: Vec<Vec<usize>> = vec![vec![0,2,3], vec![0,1,2,3]];
+/// let expected_res: Vec<Vec<usize>> = vec![vec![0,1,2,3], vec![0,2,3]];
 /// let res: Vec<Vec<usize>> = cycle_basis(&graph, Some(graph.to_index(3.into()))).unwrap();
+/// res.sort();
 /// assert_eq!(res, expected_res);
 /// 
 /// // Note that the cycle [0,1,2] is equal to the cycle [0,1,2,3] minus [0,2,3].

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod astar;
 pub mod bellman_ford;
+pub mod cycle_basis;
 pub mod dijkstra;
 pub mod dominators;
 pub mod feedback_arc_set;
@@ -34,6 +35,7 @@ use crate::visit::Walker;
 
 pub use astar::astar;
 pub use bellman_ford::{bellman_ford, find_negative_cycle};
+pub use cycle_basis::cycle_basis;
 pub use dijkstra::dijkstra;
 pub use feedback_arc_set::greedy_feedback_arc_set;
 pub use floyd_warshall::floyd_warshall;

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -1,0 +1,24 @@
+use petgraph::algo::cycle_basis;
+use petgraph::{Graph, Undirected};
+use petgraph::visit::NodeIndexable;
+
+#[test]
+fn test_cycle_basis() {
+    //Borrowing the tests from Networkx
+    let mut graph: Graph<(), u16, Undirected> = Graph::from_edges(&[
+        (0,1),(1,2),(2,3),(3,4),(4,5),(3,0),(5,0),(1,6),(6,7),(7,8),(8,0),(8,9),
+    ]);
+    let mut cy = cycle_basis(&graph, Some(graph.to_index(0.into()))).unwrap();
+    cy.sort();
+    assert_eq!(cy, vec![vec![1,2,3,0], vec![1,6,7,8,0], vec![5,4,3,0]]);
+    //test disconnected subgraph
+    graph.extend_with_edges(&[(10,11),(11,12),(12,10)]);
+    cy = cycle_basis(&graph, Some(graph.to_index(0.into()))).unwrap();
+    cy.sort();
+    assert_eq!(cy, vec![vec![1,2,3,0], vec![1,6,7,8,0], vec![5,4,3,0], vec![11,12,10]]);
+    graph.clear();
+    graph.extend_with_edges(&[(0,1),(1,2),(2,3),(3,0),(0,2)]);
+    cy = cycle_basis(&graph, Some(graph.to_index(3.into()))).unwrap();
+    cy.sort();
+    assert_eq!(cy, vec![vec![0,1,2,3], vec![0,2,3]]);
+}

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -8,41 +8,58 @@ fn test_cycle_basis() {
         (0,1),(1,2),(2,3),(3,4),(4,5),(3,0),(5,0),(1,6),(6,7),(7,8),(8,0),(8,9),
     ]);
     let mut cy = cycle_basis(&graph, Some(0.into())).unwrap();
+    cy.iter_mut().for_each(|x| x.sort());
     cy.sort();
     let mut res: Vec<Vec<NodeIndex>> = vec![
-        vec![1,2,3,0].into_iter().map(NodeIndex::new).collect(),
-        vec![1,6,7,8,0].into_iter().map(NodeIndex::new).collect(),
-        vec![5,4,3,0].into_iter().map(NodeIndex::new).collect(),
+        vec![0,1,2,3].into_iter().map(NodeIndex::new).collect(),
+        vec![0,1,6,7,8].into_iter().map(NodeIndex::new).collect(),
+        vec![0,3,4,5].into_iter().map(NodeIndex::new).collect(),
     ];
     assert_eq!(cy, res);
     //test disconnected subgraph
     graph.extend_with_edges(&[(10,11),(11,12),(12,10)]);
     cy = cycle_basis(&graph, Some(0.into())).unwrap();
+    cy.iter_mut().for_each(|x| x.sort());
     cy.sort();
     res = vec![
-        vec![1,2,3,0].into_iter().map(NodeIndex::new).collect(),
-        vec![1,6,7,8,0].into_iter().map(NodeIndex::new).collect(),
-        vec![5,4,3,0].into_iter().map(NodeIndex::new).collect(),
-        vec![11,12,10].into_iter().map(NodeIndex::new).collect(),
+        vec![0,1,2,3].into_iter().map(NodeIndex::new).collect(),
+        vec![0,1,6,7,8].into_iter().map(NodeIndex::new).collect(),
+        vec![0,3,4,5].into_iter().map(NodeIndex::new).collect(),
+        vec![10,11,12].into_iter().map(NodeIndex::new).collect(),
     ];
     assert_eq!(cy, res);
     graph.clear();
     graph.extend_with_edges(&[(0,1),(1,2),(2,3),(3,0),(0,2)]);
     cy = cycle_basis(&graph, Some(3.into())).unwrap();
+    cy.iter_mut().for_each(|x| x.sort());
     cy.sort();
     res = vec![
-        vec![0,1,2,3].into_iter().map(NodeIndex::new).collect(),
+        vec![0,1,2].into_iter().map(NodeIndex::new).collect(),
         vec![0,2,3].into_iter().map(NodeIndex::new).collect(),
     ];
     assert_eq!(cy, res);
      // test self loop
     graph.add_edge(0.into(), 0.into(), 0);
     cy = cycle_basis(&graph, Some(0.into())).unwrap();
+    cy.iter_mut().for_each(|x| x.sort());
     cy.sort();
     res = vec![
         vec![0].into_iter().map(NodeIndex::new).collect(),
-        vec![2,1,0].into_iter().map(NodeIndex::new).collect(),
-        vec![2,3,0].into_iter().map(NodeIndex::new).collect(),
+        vec![0,1,2].into_iter().map(NodeIndex::new).collect(),
+        vec![0,2,3].into_iter().map(NodeIndex::new).collect(),
+    ];
+    assert_eq!(cy, res);
+    // test parallel edge, and parallel self-loop
+    graph.add_edge(0.into(), 1.into(), 0);
+    graph.add_edge(0.into(), 1.into(), 0);
+    graph.add_edge(0.into(), 0.into(), 0);
+    cy = cycle_basis(&graph, Some(0.into())).unwrap();
+    cy.iter_mut().for_each(|x| x.sort());
+    cy.sort();
+    res = vec![
+        vec![0].into_iter().map(NodeIndex::new).collect(),
+        vec![0,1,2].into_iter().map(NodeIndex::new).collect(),
+        vec![0,2,3].into_iter().map(NodeIndex::new).collect(),
     ];
     assert_eq!(cy, res);
 }

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -1,28 +1,48 @@
+use petgraph::prelude::*;
 use petgraph::algo::cycle_basis;
 use petgraph::{Graph, Undirected};
-use petgraph::visit::NodeIndexable;
 
 #[test]
 fn test_cycle_basis() {
     let mut graph: Graph<(), u16, Undirected> = Graph::from_edges(&[
         (0,1),(1,2),(2,3),(3,4),(4,5),(3,0),(5,0),(1,6),(6,7),(7,8),(8,0),(8,9),
     ]);
-    let mut cy = cycle_basis(&graph, Some(graph.to_index(0.into()))).unwrap();
+    let mut cy = cycle_basis(&graph, Some(0.into())).unwrap();
     cy.sort();
-    assert_eq!(cy, vec![vec![1,2,3,0], vec![1,6,7,8,0], vec![5,4,3,0]]);
+    let mut res: Vec<Vec<NodeIndex>> = vec![
+        vec![1,2,3,0].into_iter().map(NodeIndex::new).collect(),
+        vec![1,6,7,8,0].into_iter().map(NodeIndex::new).collect(),
+        vec![5,4,3,0].into_iter().map(NodeIndex::new).collect(),
+    ];
+    assert_eq!(cy, res);
     //test disconnected subgraph
     graph.extend_with_edges(&[(10,11),(11,12),(12,10)]);
-    cy = cycle_basis(&graph, Some(graph.to_index(0.into()))).unwrap();
+    cy = cycle_basis(&graph, Some(0.into())).unwrap();
     cy.sort();
-    assert_eq!(cy, vec![vec![1,2,3,0], vec![1,6,7,8,0], vec![5,4,3,0], vec![11,12,10]]);
+    res = vec![
+        vec![1,2,3,0].into_iter().map(NodeIndex::new).collect(),
+        vec![1,6,7,8,0].into_iter().map(NodeIndex::new).collect(),
+        vec![5,4,3,0].into_iter().map(NodeIndex::new).collect(),
+        vec![11,12,10].into_iter().map(NodeIndex::new).collect(),
+    ];
+    assert_eq!(cy, res);
     graph.clear();
     graph.extend_with_edges(&[(0,1),(1,2),(2,3),(3,0),(0,2)]);
-    cy = cycle_basis(&graph, Some(graph.to_index(3.into()))).unwrap();
+    cy = cycle_basis(&graph, Some(3.into())).unwrap();
     cy.sort();
-    assert_eq!(cy, vec![vec![0,1,2,3], vec![0,2,3]]);
+    res = vec![
+        vec![0,1,2,3].into_iter().map(NodeIndex::new).collect(),
+        vec![0,2,3].into_iter().map(NodeIndex::new).collect(),
+    ];
+    assert_eq!(cy, res);
      // test self loop
-     graph.add_edge(0.into(), 0.into(), 0);
-     cy = cycle_basis(&graph, Some(graph.to_index(3.into()))).unwrap();
-     cy.sort();
-     assert_eq!(cy, vec![vec![0],vec![0,1,2,3], vec![0,2,3]]);
+    graph.add_edge(0.into(), 0.into(), 0);
+    cy = cycle_basis(&graph, Some(0.into())).unwrap();
+    cy.sort();
+    res = vec![
+        vec![0].into_iter().map(NodeIndex::new).collect(),
+        vec![2,1,0].into_iter().map(NodeIndex::new).collect(),
+        vec![2,3,0].into_iter().map(NodeIndex::new).collect(),
+    ];
+    assert_eq!(cy, res);
 }

--- a/tests/cycles.rs
+++ b/tests/cycles.rs
@@ -4,7 +4,6 @@ use petgraph::visit::NodeIndexable;
 
 #[test]
 fn test_cycle_basis() {
-    //Borrowing the tests from Networkx
     let mut graph: Graph<(), u16, Undirected> = Graph::from_edges(&[
         (0,1),(1,2),(2,3),(3,4),(4,5),(3,0),(5,0),(1,6),(6,7),(7,8),(8,0),(8,9),
     ]);
@@ -21,4 +20,9 @@ fn test_cycle_basis() {
     cy = cycle_basis(&graph, Some(graph.to_index(3.into()))).unwrap();
     cy.sort();
     assert_eq!(cy, vec![vec![0,1,2,3], vec![0,2,3]]);
+     // test self loop
+     graph.add_edge(0.into(), 0.into(), 0);
+     cy = cycle_basis(&graph, Some(graph.to_index(3.into()))).unwrap();
+     cy.sort();
+     assert_eq!(cy, vec![vec![0],vec![0,1,2,3], vec![0,2,3]]);
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1391,9 +1391,7 @@ quickcheck! {
         let n = gr.node_count();
         let l = gr.edge_count();
         let k = connected_components(&gr);
-        dbg!(&k);
         let c = cycle_basis(&gr, None).unwrap();
-        dbg!(&c);
         //cyclomatic number for undirected graphs with n nodes, l edges, k connected components
         // ignoring parallel edges
         let theory = l + k - n - count_parallel_edges(&gr);
@@ -1409,7 +1407,6 @@ fn count_parallel_edges<N, E>(graph: &UnGraph<N, E>) -> usize {
     for edge in graph.edge_references() {
         // In an undirected graph, (u, v) is the same as (v, u), so sort the nodes to handle this
         let mut nodes = [edge.source(), edge.target()];
-        dbg!(nodes);
         nodes.sort();
 
         let key = (nodes[0], nodes[1]);


### PR DESCRIPTION
A [cycle basis](https://en.wikipedia.org/wiki/Cycle_basis) algorithm based on algorithm [CACM 491]( https://dl.acm.org/doi/pdf/10.1145/363219.363232), and adapted from the [networkx implementation](https://networkx.org/documentation/stable/_modules/networkx/algorithms/cycles.html#cycle_basis).

This algorithm is for undirected graphs, and counts self-loops as cycle basis. I have adapted it to handle graphs with parallel edges (by ignoring subsequent edges beyond the first between nodes).

I have included a quickcheck that check against the cyclometric number, and a bench test.

I'm still new to rust, so any suggestions on how to make this more idiomatic (and performant) gratefully received. Also suggestions on any traits or existing petgraph features that could be better utilised.