### PR TITLE
Potential fix for `index_twice_mut` to work with stacked borrows

### DIFF
--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -772,6 +772,8 @@ where
         assert!(T::is_node_index() != U::is_node_index() || i.index() != j.index());
 
         // Allow two mutable indexes here -- they are nonoverlapping
+        //
+        // See more extensive notes in Graph::index_twice_mut.
         unsafe {
             let self_mut = self as *mut _;
             (
@@ -1178,7 +1180,10 @@ where
     Ix: IndexType,
 {
     fn index_mut(&mut self, index: NodeIndex<Ix>) -> &mut N {
-        self.node_weight_mut(index).unwrap()
+        crate::util::index_mut_no_sb_invalidation(&mut self.g.nodes, index.index())
+            .weight
+            .as_mut()
+            .unwrap()
     }
 }
 
@@ -1205,7 +1210,10 @@ where
     Ix: IndexType,
 {
     fn index_mut(&mut self, index: EdgeIndex<Ix>) -> &mut E {
-        self.edge_weight_mut(index).unwrap()
+        crate::util::index_mut_no_sb_invalidation(&mut self.g.edges, index.index())
+            .weight
+            .as_mut()
+            .unwrap()
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,3 +14,24 @@ where
 {
     i.into_iter().zip(j)
 }
+
+/// Mutably index a `Vec` without invalidating extant references under stacked borrows.
+#[inline]
+pub fn index_mut_no_sb_invalidation<T>(vec: &mut Vec<T>, index: usize) -> &mut T {
+    #[inline(never)]
+    #[cold]
+    fn index_len_fail(index: usize, len: usize) -> ! {
+        panic!("index {} is out of range for Vec length {}", index, len);
+    }
+    // Note, `Vec::len` isn't explicitly guaranteed to preserve validity of existing pointers but I
+    // don't see any particular reason why it would and there is at least a test in the standard
+    // library that would notice if this changes.
+    let len = vec.len();
+    if index < len {
+        let ptr = vec.as_mut_ptr();
+        // SAFETY: This is in bounds.
+        unsafe { &mut *ptr.add(index) }
+    } else {
+        index_len_fail(index, len)
+    }
+}

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1236,6 +1236,42 @@ fn index_twice_mut() {
     }
 }
 
+// Test that index_twice_mut can be used to get two nodes, two edges, or a mixture.
+//
+// This is useful for testing the unsafe implementation with miri.
+#[test]
+fn index_twice_mut_variations() {
+    let mut gr = Graph::<_, _>::new();
+    let a = gr.add_node(1);
+    let b = gr.add_node(2);
+    let c = gr.add_node(3);
+    let ab = gr.add_edge(a, b, 4);
+    let ac = gr.add_edge(a, c, 5);
+    let (a_mut, b_mut) = gr.index_twice_mut(a, b);
+    // Mutate each twice to ensure both remain valid even after the other reference is used.
+    for _ in 0..2 {
+        *a_mut += 1;
+        *b_mut += 1;
+    }
+    let (ab_mut, ac_mut) = gr.index_twice_mut(ab, ac);
+    for _ in 0..2 {
+        *ab_mut += 1;
+        *ac_mut += 1;
+    }
+    let (a_mut, ab_mut) = gr.index_twice_mut(a, ab);
+    for _ in 0..2 {
+        *a_mut += 1;
+        *ab_mut += 1;
+    }
+    // Check that all additions happened as expected.
+    for (node, value) in [(a, 5), (b, 4), (c, 3)] {
+        assert_eq!(gr[node], value);
+    }
+    for (edge, value) in [(ab, 8), (ac, 7)] {
+        assert_eq!(gr[edge], value);
+    }
+}
+
 fn make_edge_iterator_graph<Ty: EdgeType>() -> Graph<f64, f64, Ty> {
     let mut gr = Graph::default();
     let a = gr.add_node(0.);


### PR DESCRIPTION
Fixes #582.

This is done via a new utility method that uses pointer arithmetic instead of Vec indexing to avoid materializing a reference to the whole slice.

I assume that `GraphIndex` is meant to be only implemented in this crate since it has `doc(hidden)` methods. Thus, more strictly enforcing this by sealing the trait can be considered a non-breaking change. This is done because we need to trust the values returned by `GraphIndex` for `twice_index_mut` to be sound.

 I'm assuming this will all be replaced in https://github.com/petgraph/petgraph/pull/567 (as noted by https://github.com/petgraph/petgraph/issues/582#issuecomment-1699803181). And it seems like with a breaking change there is room for rearranging traits to make this cleaner or some other solution.