### PR TITLE
Add articulation points implementation

### DIFF
--- a/benches/articulation_points.rs
+++ b/benches/articulation_points.rs
@@ -1,0 +1,28 @@
+
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use petgraph::algo::articulation_points::articulation_points;
+use petgraph::prelude::*;
+use test::Bencher;
+
+
+#[bench]
+fn bridges_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 1000;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).into_iter().map(|i| g.add_node(i)).collect();
+    for i in 0..NODE_COUNT {
+        let n1 = nodes[i];
+        let neighbour_count = i % 8 + 1;
+
+        for j in (i % 117)..(i % 117) + neighbour_count {
+            let n2 = nodes[j];
+            g.add_edge(n1, n2, ());
+        }
+    }
+
+    bench.iter(|| articulation_points(&g).into_iter().collect::<Vec<_>>());
+}

--- a/benches/articulation_points.rs
+++ b/benches/articulation_points.rs
@@ -1,4 +1,3 @@
-
 #![feature(test)]
 
 extern crate petgraph;
@@ -7,7 +6,6 @@ extern crate test;
 use petgraph::algo::articulation_points::articulation_points;
 use petgraph::prelude::*;
 use test::Bencher;
-
 
 #[bench]
 fn bridges_bench(bench: &mut Bencher) {

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -1,0 +1,78 @@
+use std::cmp::min;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+
+use crate::visit::{EdgeRef, IntoEdges, IntoNodeReferences, NodeIndexable, NodeRef};
+
+pub fn articulation_points<G>(g: G) -> HashSet<G::NodeId>
+where
+    G: IntoNodeReferences + IntoEdges + NodeIndexable,
+    G::NodeWeight: Clone,
+    G::EdgeWeight: Clone + PartialOrd,
+    G::NodeId: Eq + Hash,
+{
+    let mut visited = HashSet::with_capacity(g.node_references().size_hint().0);
+    let mut parent = HashMap::with_capacity(g.node_references().size_hint().0);
+    let mut low = HashMap::with_capacity(g.node_references().size_hint().0);
+    let mut disc = HashMap::with_capacity(g.node_references().size_hint().0);
+    let mut ap = HashSet::with_capacity(g.node_references().size_hint().0);
+    let mut time = 0;
+
+    for node in g.node_references() {
+        let node_id = g.to_index(node.id());
+        if !visited.contains(&node_id) {
+            dfs(
+                &g,
+                node_id,
+                &mut visited,
+                &mut parent,
+                &mut low,
+                &mut disc,
+                &mut ap,
+                &mut time,
+            );
+        }
+    }
+
+    ap.into_iter().map(|id| g.from_index(id)).collect()
+}
+
+fn dfs<G>(
+    g: &G,
+    u: usize,
+    visited: &mut HashSet<usize>,
+    parent: &mut HashMap<usize, usize>,
+    low: &mut HashMap<usize, usize>,
+    disc: &mut HashMap<usize, usize>,
+    ap: &mut HashSet<usize>,
+    time: &mut usize,
+) where
+    G: IntoEdges + NodeIndexable,
+{
+    visited.insert(u);
+    *time += 1;
+    disc.insert(u, *time);
+    low.insert(u, *time);
+    let mut children = 0;
+
+    for edge in g.edges(g.from_index(u)) {
+        let v = g.to_index(edge.target());
+        if !visited.contains(&v) {
+            children += 1;
+            parent.insert(v, u);
+            dfs(g, v, visited, parent, low, disc, ap, time);
+
+            low.insert(u, min(low[&u], low[&v]));
+
+            if parent.contains_key(&u) && low[&v] >= disc[&u] {
+                ap.insert(u);
+            }
+        } else if v != parent.get(&u).cloned().unwrap_or(usize::MAX) {
+            low.insert(u, min(low[&u], disc[&v]));
+        }
+    }
+
+    if parent.get(&u).is_none() && children > 1 {
+        ap.insert(u);
+    }
+}

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -1,27 +1,65 @@
+use crate::visit;
+use crate::visit::{EdgeRef, IntoEdges, IntoNodeReferences, NodeIndexable, NodeRef};
 use std::cmp::min;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
-use crate::visit::{EdgeRef, IntoEdges, IntoNodeReferences, NodeIndexable, NodeRef};
-
+/// \[Generic\] Find articulation points in a graph using [Tarjan's algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm).
+///
+/// Compute the articulation points of a graph (Nodes, which would increase the number of connected components in the graph.
+///
+/// # Arguments
+/// * `graph`: A directed graph
+///
+/// # Returns
+/// * `HashSet`: Hashset of the node ids which correspond to the articulation points of the grpah.
+///
+/// # Examples
+/// ```rust
+/// use petgraph::{
+///     algo::articulation_points,
+///     graph::{NodeIndex, UnGraph},
+///     algo::articulation_points::articulation_points,
+/// };
+///
+/// fn main() {
+///     let mut gr = UnGraph::<&str, ()>::new_undirected();
+///     let a = gr.add_node("A");
+///     let b = gr.add_node("B");
+///     let c = gr.add_node("C");
+///
+///     gr.add_edge(a, b, ());
+///     gr.add_edge(b, c, ());
+///
+///     let articulation_points: Vec<&str> = articulation_points(&gr)
+///         .into_iter()
+///         .map(|node_idx| gr[node_idx])
+///         .collect();
+///
+///     // Articulation Points: ["B"]
+///     println!("Articulation Points: {:?}", articulation_points);
+/// }
+/// ```
 pub fn articulation_points<G>(g: G) -> HashSet<G::NodeId>
 where
-    G: IntoNodeReferences + IntoEdges + NodeIndexable,
+    G: IntoNodeReferences + IntoEdges + NodeIndexable + visit::GraphProp,
     G::NodeWeight: Clone,
     G::EdgeWeight: Clone + PartialOrd,
     G::NodeId: Eq + Hash,
 {
-    let mut visited = HashSet::with_capacity(g.node_references().size_hint().0);
-    let mut parent = HashMap::with_capacity(g.node_references().size_hint().0);
-    let mut low = HashMap::with_capacity(g.node_references().size_hint().0);
-    let mut disc = HashMap::with_capacity(g.node_references().size_hint().0);
-    let mut ap = HashSet::with_capacity(g.node_references().size_hint().0);
+    let graph_size = g.node_references().size_hint().0;
+
+    let mut visited = vec![false; graph_size];
+    let mut disc = vec![usize::MAX; graph_size];
+    let mut low = vec![usize::MAX; graph_size];
+    let mut parent = vec![usize::MAX; graph_size];
+    let mut ap = HashSet::with_capacity(graph_size);
     let mut time = 0;
 
     for node in g.node_references() {
         let node_id = g.to_index(node.id());
-        if !visited.contains(&node_id) {
-            dfs(
+        if !visited[node_id] {
+            _dfs(
                 &g,
                 node_id,
                 &mut visited,
@@ -37,42 +75,70 @@ where
     ap.into_iter().map(|id| g.from_index(id)).collect()
 }
 
-fn dfs<G>(
+
+/// Small helper enum that defines the various splitup recursion steps of Tarjan's algorithm.
+enum RecursionStep {
+    BaseStep(usize),
+    ProcessChildStep(usize, usize),
+    NoBackEdgeConditionCheck(usize, usize),
+    RootMoreThanTwoChildrenCheck(usize),
+}
+
+/// Helper that performs the required DFS in an iterative manner.
+fn _dfs<G>(
     g: &G,
-    u: usize,
-    visited: &mut HashSet<usize>,
-    parent: &mut HashMap<usize, usize>,
-    low: &mut HashMap<usize, usize>,
-    disc: &mut HashMap<usize, usize>,
+    target_node: usize,
+    visited: &mut Vec<bool>,
+    parent: &mut Vec<usize>,
+    low: &mut Vec<usize>,
+    disc: &mut Vec<usize>,
     ap: &mut HashSet<usize>,
     time: &mut usize,
 ) where
     G: IntoEdges + NodeIndexable,
 {
-    visited.insert(u);
-    *time += 1;
-    disc.insert(u, *time);
-    low.insert(u, *time);
-    let mut children = 0;
+    let mut stack: Vec<RecursionStep> = vec![RecursionStep::BaseStep(target_node)];
+    let mut children_count: HashMap<usize, usize> = HashMap::new();
 
-    for edge in g.edges(g.from_index(u)) {
-        let v = g.to_index(edge.target());
-        if !visited.contains(&v) {
-            children += 1;
-            parent.insert(v, u);
-            dfs(g, v, visited, parent, low, disc, ap, time);
+    while let Some(recursionStep) = stack.pop() {
+        match recursionStep {
+            RecursionStep::BaseStep(current_node) => {
+                visited[current_node] = true;
+                disc[current_node] = *time;
+                low[current_node] = *time;
+                *time += 1;
 
-            low.insert(u, min(low[&u], low[&v]));
-
-            if parent.contains_key(&u) && low[&v] >= disc[&u] {
-                ap.insert(u);
+                stack.push(RecursionStep::RootMoreThanTwoChildrenCheck(current_node));
+                for edge in g.edges(g.from_index(current_node)) {
+                    let child_node = g.to_index(edge.target());
+                    stack.push(RecursionStep::ProcessChildStep(current_node, child_node));
+                }
             }
-        } else if v != parent.get(&u).cloned().unwrap_or(usize::MAX) {
-            low.insert(u, min(low[&u], disc[&v]));
-        }
-    }
+            RecursionStep::ProcessChildStep(current_node, child_node) => {
+                if !visited[child_node] {
+                    parent[child_node] = current_node;
+                    *children_count.entry(current_node).or_insert(0) += 1;
 
-    if parent.get(&u).is_none() && children > 1 {
-        ap.insert(u);
+                    stack.push(RecursionStep::NoBackEdgeConditionCheck(current_node, child_node));
+                    stack.push(RecursionStep::BaseStep(child_node));
+                } else if child_node != parent[current_node] {
+                    low[current_node] = min(low[current_node], disc[child_node]);
+                }
+            }
+            RecursionStep::NoBackEdgeConditionCheck(current_node, child_node) => {
+                low[current_node] = min(low[current_node], low[child_node]);
+
+                if parent[current_node] != usize::MAX && low[child_node] >= disc[current_node] {
+                    ap.insert(current_node);
+                }
+            }
+
+            RecursionStep::RootMoreThanTwoChildrenCheck(current_node) => {
+                let child_count = children_count.get(&current_node).cloned().unwrap_or(0);
+                if parent[current_node] == usize::MAX && child_count > 1 {
+                    ap.insert(current_node);
+                }
+            }
+        }
     }
 }

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -12,7 +12,7 @@ use std::hash::Hash;
 /// * `graph`: A directed graph
 ///
 /// # Returns
-/// * `HashSet`: Hashset of the node ids which correspond to the articulation points of the grpah.
+/// * `HashSet`: Hashset of the node ids which correspond to the articulation points of the graph.
 ///
 /// # Examples
 /// ```rust

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -1,5 +1,6 @@
 use crate::visit;
 use crate::visit::{EdgeRef, IntoEdges, IntoNodeReferences, NodeIndexable, NodeRef};
+use fixedbitset::FixedBitSet;
 use std::cmp::min;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
@@ -74,7 +75,7 @@ enum RecursionStep {
 
 /// Internal auxiliary helper struct for global variables.
 struct ArticulationPointTracker {
-    visited: Vec<bool>,
+    visited: FixedBitSet,
     low: Vec<usize>,
     disc: Vec<usize>,
     parent: Vec<usize>,
@@ -85,7 +86,7 @@ struct ArticulationPointTracker {
 impl ArticulationPointTracker {
     fn new(graph_size: usize) -> Self {
         Self {
-            visited: vec![false; graph_size],
+            visited: FixedBitSet::with_capacity(graph_size),
             low: vec![usize::MAX; graph_size],
             disc: vec![usize::MAX; graph_size],
             parent: vec![usize::MAX; graph_size],
@@ -106,7 +107,7 @@ where
     while let Some(recursion_step) = stack.pop() {
         match recursion_step {
             RecursionStep::BaseStep(current_node) => {
-                constants.visited[current_node] = true;
+                constants.visited.toggle(current_node);
                 constants.disc[current_node] = constants.time;
                 constants.low[current_node] = constants.time;
                 constants.time += 1;
@@ -118,7 +119,7 @@ where
                 }
             }
             RecursionStep::ProcessChildStep(current_node, child_node) => {
-                if !constants.visited[child_node] {
+                if !constants.visited.contains(child_node) {
                     constants.parent[child_node] = current_node;
                     *children_count.entry(current_node).or_insert(0) += 1;
 

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -75,7 +75,6 @@ where
     ap.into_iter().map(|id| g.from_index(id)).collect()
 }
 
-
 /// Small helper enum that defines the various splitup recursion steps of Tarjan's algorithm.
 enum RecursionStep {
     BaseStep(usize),
@@ -119,7 +118,10 @@ fn _dfs<G>(
                     parent[child_node] = current_node;
                     *children_count.entry(current_node).or_insert(0) += 1;
 
-                    stack.push(RecursionStep::NoBackEdgeConditionCheck(current_node, child_node));
+                    stack.push(RecursionStep::NoBackEdgeConditionCheck(
+                        current_node,
+                        child_node,
+                    ));
                     stack.push(RecursionStep::BaseStep(child_node));
                 } else if child_node != parent[current_node] {
                     low[current_node] = min(low[current_node], disc[child_node]);

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -121,7 +121,10 @@ where
             RecursionStep::ProcessChildStep(current_node, child_node) => {
                 if !articulation_point_tracker.visited.contains(child_node) {
                     articulation_point_tracker.parent[child_node] = current_node;
-                    children_count.entry(current_node).and_modify(|c| *c += 1).or_insert(1);
+                    children_count
+                        .entry(current_node)
+                        .and_modify(|c| *c += 1)
+                        .or_insert(1);
 
                     stack.push(RecursionStep::NoBackEdgeConditionCheck(
                         current_node,
@@ -129,25 +132,35 @@ where
                     ));
                     stack.push(RecursionStep::BaseStep(child_node));
                 } else if child_node != articulation_point_tracker.parent[current_node] {
-                    articulation_point_tracker.low[current_node] =
-                        min(articulation_point_tracker.low[current_node], articulation_point_tracker.disc[child_node]);
+                    articulation_point_tracker.low[current_node] = min(
+                        articulation_point_tracker.low[current_node],
+                        articulation_point_tracker.disc[child_node],
+                    );
                 }
             }
             RecursionStep::NoBackEdgeConditionCheck(current_node, child_node) => {
-                articulation_point_tracker.low[current_node] =
-                    min(articulation_point_tracker.low[current_node], articulation_point_tracker.low[child_node]);
+                articulation_point_tracker.low[current_node] = min(
+                    articulation_point_tracker.low[current_node],
+                    articulation_point_tracker.low[child_node],
+                );
 
                 if articulation_point_tracker.parent[current_node] != usize::MAX
-                    && articulation_point_tracker.low[child_node] >= articulation_point_tracker.disc[current_node]
+                    && articulation_point_tracker.low[child_node]
+                        >= articulation_point_tracker.disc[current_node]
                 {
-                    articulation_point_tracker.articulation_points.insert(current_node);
+                    articulation_point_tracker
+                        .articulation_points
+                        .insert(current_node);
                 }
             }
 
             RecursionStep::RootMoreThanTwoChildrenCheck(current_node) => {
                 let child_count = children_count.get(&current_node).cloned().unwrap_or(0);
-                if articulation_point_tracker.parent[current_node] == usize::MAX && child_count > 1 {
-                    articulation_point_tracker.articulation_points.insert(current_node);
+                if articulation_point_tracker.parent[current_node] == usize::MAX && child_count > 1
+                {
+                    articulation_point_tracker
+                        .articulation_points
+                        .insert(current_node);
                 }
             }
         }

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -99,8 +99,8 @@ fn _dfs<G>(
     let mut stack: Vec<RecursionStep> = vec![RecursionStep::BaseStep(target_node)];
     let mut children_count: HashMap<usize, usize> = HashMap::new();
 
-    while let Some(recursionStep) = stack.pop() {
-        match recursionStep {
+    while let Some(recursion_step) = stack.pop() {
+        match recursion_step {
             RecursionStep::BaseStep(current_node) => {
                 visited[current_node] = true;
                 disc[current_node] = *time;

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -4,6 +4,7 @@
 //! so that they are generally applicable. For now, some of these still require
 //! the `Graph` type.
 
+pub mod articulation_points;
 pub mod astar;
 pub mod bellman_ford;
 pub mod coloring;

--- a/tests/articulation_points.rs
+++ b/tests/articulation_points.rs
@@ -1,0 +1,45 @@
+use petgraph::{
+    algo::articulation_points::articulation_points,
+    csr::IndexType,
+    dot::Dot,
+    graph::{NodeIndex, UnGraph},
+    visit::{IntoEdges, NodeRef},
+    Graph, Undirected,
+};
+
+use std::collections::HashSet;
+
+#[test]
+fn art_simple1() {
+    let mut gr = Graph::<&str, ()>::new();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+    gr.add_edge(b, d, ());
+
+    let set: HashSet<NodeIndex> = [b].iter().cloned().collect();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[test]
+fn art_simple2() {
+    let mut gr = Graph::<&str, ()>::new();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    let e = gr.add_node("E");
+
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+    gr.add_edge(b, d, ());
+    gr.add_edge(d, e, ());
+
+    let set: HashSet<NodeIndex> = [b, d].iter().cloned().collect();
+
+    assert_eq!(articulation_points(&gr), set);
+}

--- a/tests/articulation_points.rs
+++ b/tests/articulation_points.rs
@@ -1,6 +1,5 @@
 use petgraph::{
     algo::articulation_points::articulation_points,
-    csr::IndexType,
     graph::{NodeIndex, UnGraph},
 };
 

--- a/tests/articulation_points.rs
+++ b/tests/articulation_points.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 #[test]
 fn art_single_node() {
     let mut gr = UnGraph::<&str, ()>::new_undirected();
-    let a = gr.add_node("A");
+    let _a = gr.add_node("A");
 
     let set: HashSet<NodeIndex> = HashSet::new();
 

--- a/tests/articulation_points.rs
+++ b/tests/articulation_points.rs
@@ -1,17 +1,102 @@
 use petgraph::{
     algo::articulation_points::articulation_points,
     csr::IndexType,
-    dot::Dot,
     graph::{NodeIndex, UnGraph},
-    visit::{IntoEdges, NodeRef},
-    Graph, Undirected,
 };
 
 use std::collections::HashSet;
 
 #[test]
+fn art_single_node() {
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
+    let a = gr.add_node("A");
+
+    let set: HashSet<NodeIndex> = HashSet::new();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[test]
+fn art_two_connected_components() {
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    let e = gr.add_node("E");
+    let f = gr.add_node("F");
+
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+
+    gr.add_edge(d, e, ());
+    gr.add_edge(e, f, ());
+
+    let articulation_lables: Vec<&str> = articulation_points(&gr)
+        .into_iter()
+        .map(|node_idx| gr[node_idx])
+        .collect();
+    println!("{:?}", articulation_lables);
+
+    let set: HashSet<NodeIndex> = [b, e].iter().cloned().collect();
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[test]
+fn art_linear_chain() {
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+    gr.add_edge(c, d, ());
+
+    let set: HashSet<NodeIndex> = [b, c].iter().cloned().collect();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[test]
+fn art_star_graph() {
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
+    let center = gr.add_node("Center");
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+
+    gr.add_edge(center, a, ());
+    gr.add_edge(center, b, ());
+    gr.add_edge(center, c, ());
+    gr.add_edge(center, d, ());
+
+    let set: HashSet<NodeIndex> = [center].iter().cloned().collect();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[test]
+fn art_clique() {
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+    gr.add_edge(c, a, ());
+
+    let set: HashSet<NodeIndex> = HashSet::new();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[test]
 fn art_simple1() {
-    let mut gr = Graph::<&str, ()>::new();
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
     let a = gr.add_node("A");
     let b = gr.add_node("B");
     let c = gr.add_node("C");
@@ -26,8 +111,61 @@ fn art_simple1() {
 }
 
 #[test]
+fn art_disconnected_graph() {
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    let e = gr.add_node("E");
+
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+    gr.add_edge(d, e, ());
+
+    let set: HashSet<NodeIndex> = [b].iter().cloned().collect();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[test]
+fn art_3x3_grid() {
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    let e = gr.add_node("E");
+    let f = gr.add_node("F");
+    let g = gr.add_node("G");
+    let h = gr.add_node("H");
+    let i = gr.add_node("I");
+
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+
+    gr.add_edge(a, d, ());
+    gr.add_edge(b, e, ());
+    gr.add_edge(c, f, ());
+
+    gr.add_edge(d, e, ());
+    gr.add_edge(e, f, ());
+
+    gr.add_edge(d, g, ());
+    gr.add_edge(e, h, ());
+    gr.add_edge(f, i, ());
+
+    gr.add_edge(g, h, ());
+    gr.add_edge(h, i, ());
+
+    let set: HashSet<NodeIndex> = HashSet::new();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[test]
 fn art_simple2() {
-    let mut gr = Graph::<&str, ()>::new();
+    let mut gr = UnGraph::<&str, ()>::new_undirected();
     let a = gr.add_node("A");
     let b = gr.add_node("B");
     let c = gr.add_node("C");

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -23,10 +23,11 @@ use quickcheck::{Arbitrary, Gen};
 use rand::Rng;
 
 use petgraph::algo::{
-    bellman_ford, condensation, dijkstra, dsatur_coloring, find_negative_cycle, floyd_warshall,
-    ford_fulkerson, greedy_feedback_arc_set, greedy_matching, is_cyclic_directed,
-    is_cyclic_undirected, is_isomorphic, is_isomorphic_matching, k_shortest_path, kosaraju_scc,
-    maximum_matching, min_spanning_tree, page_rank, tarjan_scc, toposort, Matching,
+    bellman_ford, condensation, connected_components, dijkstra, dsatur_coloring,
+    find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
+    is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
+    k_shortest_path, kosaraju_scc, maximum_matching, min_spanning_tree, page_rank, tarjan_scc,
+    toposort, Matching,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -50,6 +51,7 @@ where
     Graph::from_elements(min_spanning_tree(&g))
 }
 
+use petgraph::algo::articulation_points::articulation_points;
 use std::fmt;
 
 quickcheck! {
@@ -1452,6 +1454,25 @@ quickcheck! {
     fn dsatur_coloring_quickcheck(g: Graph<(), (), Undirected>) -> bool {
         let (coloring, _) = dsatur_coloring(&g);
         assert!(is_proper_coloring(&g, &coloring), "dsatur_coloring returned a non proper coloring");
+        true
+    }
+}
+
+quickcheck! {
+    // Test that removal of articulation points will always increase the amount of connected components.
+    fn test_articulation_points(g: Graph<(), u32, Undirected>) -> bool {
+
+        let articulation_points = articulation_points(&g);
+        let original_components = connected_components(&g);
+
+        for point in articulation_points {
+        let mut modified_graph = g.clone();
+        modified_graph.remove_node(point);
+        let new_components = connected_components(&modified_graph);
+        if new_components <= original_components {
+            return false;
+        }
+    }
         true
     }
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -24,12 +24,9 @@ use rand::Rng;
 
 use petgraph::algo::{
     bellman_ford, condensation, connected_components, dijkstra, dsatur_coloring,
-    find_negative_cycle,
-    floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
-    is_cyclic_directed,
-    is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
-    k_shortest_path, kosaraju_scc,
-    maximum_matching, min_spanning_tree, page_rank, tarjan_scc,
+    find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
+    is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
+    k_shortest_path, kosaraju_scc, maximum_matching, min_spanning_tree, page_rank, tarjan_scc,
     toposort, Matching,
 };
 use petgraph::data::FromElements;

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -24,9 +24,12 @@ use rand::Rng;
 
 use petgraph::algo::{
     bellman_ford, condensation, connected_components, dijkstra, dsatur_coloring,
-    find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
-    is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
-    k_shortest_path, kosaraju_scc, maximum_matching, min_spanning_tree, page_rank, tarjan_scc,
+    find_negative_cycle,
+    floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
+    is_cyclic_directed,
+    is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
+    k_shortest_path, kosaraju_scc,
+    maximum_matching, min_spanning_tree, page_rank, tarjan_scc,
     toposort, Matching,
 };
 use petgraph::data::FromElements;


### PR DESCRIPTION
### Motivation

This pull request adds a function to compute articulation points in a graph using Tarjan's algorithm, implemented with an iterative approach. Articulation points are nodes whose removal increases the number of connected components in the graph. 
Currently, `petgraph` lacks an implementation for this functionality. This makes it impossible to for instance determine if a vertex of a graph is cutting with petgraph.

*Note*: This approach is not a direct replication of existing implementations (e.g., [[here](https://www.geeksforgeeks.org/tarjan-algorithm-find-strongly-connected-components/)](https://www.geeksforgeeks.org/tarjan-algorithm-find-strongly-connected-components/)), as it avoids recursion entirely.

### Runtime

Tarjan's algorithm is an efficient solution to this problem, with a time complexity of \(O(V + E)\), making it well-suited for large graphs.