### PR TITLE
Add `UnionFind::new_set`

### DIFF
--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -26,6 +26,15 @@ pub struct UnionFind<K> {
     rank: Vec<u8>,
 }
 
+impl<K> Default for UnionFind<K> {
+    fn default() -> Self {
+        Self {
+            parent: Vec::new(),
+            rank: Vec::new(),
+        }
+    }
+}
+
 #[inline]
 unsafe fn get_unchecked<K>(xs: &[K], index: usize) -> &K {
     debug_assert!(index < xs.len());
@@ -50,6 +59,24 @@ where
         UnionFind { parent, rank }
     }
 
+    /// Create a new `UnionFind` with no elements.
+    pub const fn new_empty() -> Self {
+        Self {
+            parent: Vec::new(),
+            rank: Vec::new(),
+        }
+    }
+
+    /// Returns the number of elements in the union-find data-structure.
+    pub fn len(&self) -> usize {
+        self.parent.len()
+    }
+
+    /// Returns true if there are no elements in the union-find data-structure.
+    pub fn is_empty(&self) -> bool {
+        self.parent.is_empty()
+    }
+
     /// Adds a new disjoint set and returns the index of the new set.
     ///
     /// The new disjoint set is always added to the end, so the returned
@@ -68,7 +95,7 @@ where
     ///
     /// **Panics** if `x` is out of bounds.
     pub fn find(&self, x: K) -> K {
-        assert!(x.index() < self.parent.len());
+        assert!(x.index() < self.len());
         unsafe {
             let mut x = x;
             loop {
@@ -90,7 +117,7 @@ where
     ///
     /// **Panics** if `x` is out of bounds.
     pub fn find_mut(&mut self, x: K) -> K {
-        assert!(x.index() < self.parent.len());
+        assert!(x.index() < self.len());
         unsafe { self.find_mut_recursive(x) }
     }
 
@@ -149,7 +176,7 @@ where
     pub fn into_labeling(mut self) -> Vec<K> {
         // write in the labeling of each element
         unsafe {
-            for ix in 0..self.parent.len() {
+            for ix in 0..self.len() {
                 let k = *get_unchecked(&self.parent, ix);
                 let xrep = self.find_mut_recursive(k);
                 *self.parent.get_unchecked_mut(ix) = xrep;

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -50,6 +50,20 @@ where
         UnionFind { parent, rank }
     }
 
+    /// Adds a new disjoint set and returns the index of the new set.
+    ///
+    /// The new disjoint set is always added to the end, so the returned
+    /// index is the same as the number of elements before calling this function.
+    ///
+    /// **Time Complexity**
+    /// Takes amortized O(1) time.
+    pub fn new_set(&mut self) -> K {
+        let retval = K::new(self.parent.len());
+        self.rank.push(0);
+        self.parent.push(retval);
+        retval
+    }
+
     /// Return the representative for `x`.
     ///
     /// **Panics** if `x` is out of bounds.

--- a/tests/unionfind.rs
+++ b/tests/unionfind.rs
@@ -103,3 +103,36 @@ fn labeling() {
     let v = u.into_labeling();
     assert!(v.iter().all(|x| *x == v[0]));
 }
+
+#[test]
+fn uf_incremental() {
+    let mut u = UnionFind::<u32>::new_empty();
+    assert_eq!(u.new_set(), 0);
+    assert_eq!(u.new_set(), 1);
+    assert_eq!(u.len(), 2);
+    u.union(0, 1);
+    assert_eq!(u.find(0), u.find(1));
+    assert_eq!(u.new_set(), 2);
+    assert_eq!(u.new_set(), 3);
+    u.union(1, 3);
+    assert_eq!(u.new_set(), 4);
+    u.union(1, 4);
+    assert_eq!(u.new_set(), 5);
+    assert_eq!(u.new_set(), 6);
+    assert_eq!(u.new_set(), 7);
+    assert_eq!(u.len(), 8);
+    u.union(4, 7);
+    assert_eq!(u.find(0), u.find(3));
+    assert_eq!(u.find(1), u.find(3));
+    assert!(u.find(0) != u.find(2));
+    assert_eq!(u.find(7), u.find(0));
+    u.union(5, 6);
+    assert_eq!(u.find(6), u.find(5));
+    assert!(u.find(6) != u.find(7));
+
+    // check that there are now 3 disjoint sets
+    let set = (0..u.len() as u32)
+        .map(|i| u.find(i))
+        .collect::<HashSet<_>>();
+    assert_eq!(set.len(), 3);
+}


### PR DESCRIPTION
Adds `UnionFind::new_set` to add a new set to an existing `UnionFind`, which is helpful when you want to incrementally use the `UnionFind` algorithm and don't know how many elements you have ahead of time.

Fixes: #683

Also adds additional utility methods since `UnionFind` doesn't have fixed length anymore:
* `UnionFind::new_empty()` -- equivalent to `Vec::new()` for when you need a `const` empty `UnionFind`.
* `UnionFind::is_empty()`/`UnionFind::len()` -- returns the number of elements, like `Vec::is_empty()`/`Vec::len()`
* `impl Default for UnionFind` -- makes an empty `UnionFind`

I also switched `self.parent.len()` calls to use `self.len()` since that's more canonical.

I also added a test checking that `UnionFind::new_set()` works correctly.