### PR TITLE
feat: Add Shortest Path Faster Algorithm Implementation

### DIFF
--- a/benches/spfa.rs
+++ b/benches/spfa.rs
@@ -1,0 +1,35 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use petgraph::prelude::*;
+use std::cmp::{max, min};
+use test::Bencher;
+
+use petgraph::algo::spfa;
+
+#[bench]
+fn spfa_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 100;
+    let mut g = Graph::new();
+    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).map(|i| g.add_node(i)).collect();
+    for i in 0..NODE_COUNT {
+        let n1 = nodes[i];
+        let neighbour_count = i % 8 + 3;
+        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
+        let j_to = min(NODE_COUNT, j_from + neighbour_count);
+        for j in j_from..j_to {
+            let n2 = nodes[j];
+            let mut distance: f64 = ((i + 3) % 10) as f64;
+            if n1 != n2 {
+                distance -= 1.0
+            }
+            g.add_edge(n1, n2, distance);
+        }
+    }
+
+    bench.iter(|| {
+        let _scores = spfa(&g, nodes[0], |edge| *edge.weight());
+    });
+}

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -20,6 +20,7 @@ pub mod maximal_cliques;
 pub mod min_spanning_tree;
 pub mod page_rank;
 pub mod simple_paths;
+pub mod spfa;
 #[cfg(feature = "stable_graph")]
 pub mod steiner_tree;
 pub mod tred;
@@ -55,6 +56,7 @@ pub use maximal_cliques::maximal_cliques;
 pub use min_spanning_tree::{min_spanning_tree, min_spanning_tree_prim};
 pub use page_rank::page_rank;
 pub use simple_paths::all_simple_paths;
+pub use spfa::spfa;
 #[cfg(feature = "stable_graph")]
 pub use steiner_tree::steiner_tree;
 

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -1,9 +1,8 @@
 //! Shortest Path Faster Algorithm.
-use alloc::{collections::VecDeque, vec};
-
 use super::{bellman_ford::Paths, BoundedMeasure, NegativeCycle};
 use crate::prelude::*;
 use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable};
+use alloc::{vec, vec::Vec};
 
 /// \[Generic\] Compute shortest paths from node `source` to all other.
 ///
@@ -87,17 +86,17 @@ where
     distances[ix(source)] = K::default();
 
     // Queue of vertices capable of relaxation of the found shortest distances.
-    let mut queue: VecDeque<G::NodeId> = VecDeque::with_capacity(graph.node_bound());
+    let mut queue: Vec<G::NodeId> = Vec::with_capacity(graph.node_bound());
     let mut in_queue = vec![false; graph.node_bound()];
 
-    queue.push_back(source);
+    queue.push(source);
     in_queue[ix(source)] = true;
 
     // Keep track of how many times each vertex appeared
     // in the queue to be able to detect a negative cycle.
     let mut visits = vec![0; graph.node_bound()];
 
-    while let Some(i) = queue.pop_front() {
+    while let Some(i) = queue.pop() {
         in_queue[ix(i)] = false;
 
         // In a graph without a negative cycle, no vertex can improve
@@ -119,7 +118,7 @@ where
 
                 if !in_queue[ix(j)] {
                     in_queue[ix(j)] = true;
-                    queue.push_back(j);
+                    queue.push(j);
                 }
             }
         }

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -1,0 +1,132 @@
+//! Shortest Path Faster Algorithm.
+use alloc::{collections::VecDeque, vec};
+
+use super::{bellman_ford::Paths, BoundedMeasure, NegativeCycle};
+use crate::prelude::*;
+use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable};
+
+/// \[Generic\] Compute shortest paths from node `source` to all other.
+///
+/// Using the [Shortest Path Faster Algorithm][spfa].
+/// Compute shortest distances from node `source` to all other.
+///
+/// Compute shortest paths lengths in a weighted graph with positive or negative edge weights,
+/// but with no negative cycles.
+///
+/// ## Arguments
+/// * `graph`: weighted graph.
+/// * `source`: the source vertex, for which we calculate the lengths of the shortest paths to all the others.
+/// * `edge_cost`: closure that returns cost of a particular edge
+///
+/// ## Returns
+/// * `Err`: if graph contains negative cycle.
+/// * `Ok`: a pair of a vector of shortest distances and a vector
+///         of predecessors of each vertex along the shortest path.
+///
+/// [spfa]: https://www.geeksforgeeks.org/shortest-path-faster-algorithm/
+///
+/// # Example
+///
+/// ```
+/// use petgraph::Graph;
+/// use petgraph::algo::spfa;
+///
+/// let mut g = Graph::new();
+/// let a = g.add_node(()); // node with no weight
+/// let b = g.add_node(());
+/// let c = g.add_node(());
+/// let d = g.add_node(());
+/// let e = g.add_node(());
+/// let f = g.add_node(());
+/// g.extend_with_edges(&[
+///     (0, 1, 3.0),
+///     (0, 3, 2.0),
+///     (1, 2, 1.0),
+///     (1, 5, 7.0),
+///     (2, 4, -4.0),
+///     (3, 4, -1.0),
+///     (4, 5, 1.0),
+/// ]);
+///
+/// // Graph represented with the weight of each edge.
+/// //
+/// //     3       1
+/// // a ----- b ----- c
+/// // | 2     | 7     |
+/// // d       f       | -4
+/// // | -1    | 1     |
+/// // \------ e ------/
+///
+/// let path = spfa(&g, a, |edge| *edge.weight());
+/// assert!(path.is_ok());
+/// let path = path.unwrap();
+/// assert_eq!(path.distances, vec![0.0 ,     3.0,     4.0,    2.0,     0.0,     1.0]);
+/// assert_eq!(path.predecessors, vec![None, Some(a), Some(b), Some(a), Some(c), Some(e)]);
+///
+///
+/// // Negative cycle.
+/// let graph = Graph::<(), f32>::from_edges(&[
+///     (0, 1, 2.0), (1, 2, 2.0), (2, 0, -10.0)]);
+///
+/// assert!(spfa(&graph, 0.into(), |edge| *edge.weight()).is_err());
+/// ```
+pub fn spfa<G, F, K>(
+    graph: G,
+    source: G::NodeId,
+    mut edge_cost: F,
+) -> Result<Paths<G::NodeId, K>, NegativeCycle>
+where
+    G: IntoEdges + IntoNodeIdentifiers + NodeIndexable,
+    F: FnMut(G::EdgeRef) -> K,
+    K: BoundedMeasure + Copy,
+{
+    let ix = |i| graph.to_index(i);
+
+    let mut predecessors = vec![None; graph.node_bound()];
+    let mut distances = vec![K::max(); graph.node_bound()];
+    distances[ix(source)] = K::default();
+
+    // Queue of vertices capable of relaxation of the found shortest distances.
+    let mut queue: VecDeque<G::NodeId> = VecDeque::with_capacity(graph.node_bound());
+    let mut in_queue = vec![false; graph.node_bound()];
+
+    queue.push_back(source);
+    in_queue[ix(source)] = true;
+
+    // Keep track of how many times each vertex appeared
+    // in the queue to be able to detect a negative cycle.
+    let mut visits = vec![0; graph.node_bound()];
+
+    while let Some(i) = queue.pop_front() {
+        in_queue[ix(i)] = false;
+
+        // In a graph without a negative cycle, no vertex can improve
+        // the shortest distances by more than |V| times.
+        if visits[ix(i)] >= graph.node_bound() {
+            return Err(NegativeCycle(()));
+        }
+        visits[ix(i)] += 1;
+
+        for edge in graph.edges(i) {
+            let j = edge.target();
+            let w = edge_cost(edge);
+
+            let (dist, overflow) = distances[ix(i)].overflowing_add(w);
+
+            if !overflow && dist < distances[ix(j)] {
+                distances[ix(j)] = dist;
+                predecessors[ix(j)] = Some(i);
+
+                if !in_queue[ix(j)] {
+                    in_queue[ix(j)] = true;
+                    queue.push_back(j);
+                }
+            }
+        }
+    }
+
+    Ok(Paths {
+        distances,
+        predecessors,
+    })
+}

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -34,7 +34,7 @@ use petgraph::algo::{
     find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
     is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
     k_shortest_path, kosaraju_scc, maximal_cliques as maximal_cliques_algo, maximum_matching,
-    min_spanning_tree, page_rank, tarjan_scc, toposort, Matching,
+    min_spanning_tree, page_rank, spfa, tarjan_scc, toposort, Matching,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -1522,4 +1522,38 @@ fn maximal_cliques_matches_ref_impl() {
     }
     quickcheck::quickcheck(prop as fn(Graph<_, _, Undirected>) -> bool);
     quickcheck::quickcheck(prop as fn(Graph<_, _, Directed>) -> bool);
+}
+
+quickcheck! {
+    fn test_spfa(gr: Graph<(), f32>) -> bool {
+        let mut gr = gr;
+        for elt in gr.edge_weights_mut() {
+            *elt = elt.abs();
+        }
+        if gr.node_count() == 0 {
+            return true;
+        }
+        for (i, start) in gr.node_indices().enumerate() {
+            if i >= 10 { break; } // testing all is too slow
+            spfa(&gr, start, |edge| *edge.weight()).unwrap();
+        }
+        true
+    }
+}
+
+quickcheck! {
+    fn test_spfa_undir(gr: Graph<(), f32, Undirected>) -> bool {
+        let mut gr = gr;
+        for elt in gr.edge_weights_mut() {
+            *elt = elt.abs();
+        }
+        if gr.node_count() == 0 {
+            return true;
+        }
+        for (i, start) in gr.node_indices().enumerate() {
+            if i >= 10 { break; } // testing all is too slow
+            spfa(&gr, start, |edge| *edge.weight()).unwrap();
+        }
+        true
+    }
 }

--- a/tests/spfa.rs
+++ b/tests/spfa.rs
@@ -1,0 +1,300 @@
+use hashbrown::HashMap;
+use petgraph::algo::spfa;
+use petgraph::visit::NodeIndexable;
+use petgraph::{prelude::*, Directed, Graph, Undirected};
+
+#[test]
+fn spfa_uniform_weight() {
+    let mut graph: Graph<(), (), Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+    let e = graph.add_node(());
+    let f = graph.add_node(());
+    let g = graph.add_node(());
+    let h = graph.add_node(());
+
+    graph.extend_with_edges([
+        (a, b),
+        (b, c),
+        (c, d),
+        (d, a),
+        (e, f),
+        (b, e),
+        (f, g),
+        (g, h),
+        (h, e),
+    ]);
+    // a ----> b ----> e ----> f
+    // ^       |       ^       |
+    // |       v       |       v
+    // d <---- c       h <---- g
+
+    let inf = i32::MAX;
+    let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+        ((a, a), 0),
+        ((a, b), 1),
+        ((a, c), 2),
+        ((a, d), 3),
+        ((a, e), 2),
+        ((a, f), 3),
+        ((a, g), 4),
+        ((a, h), 5),
+        ((b, a), 3),
+        ((b, b), 0),
+        ((b, c), 1),
+        ((b, d), 2),
+        ((b, e), 1),
+        ((b, f), 2),
+        ((b, g), 3),
+        ((b, h), 4),
+        ((c, a), 2),
+        ((c, b), 3),
+        ((c, c), 0),
+        ((c, d), 1),
+        ((c, e), 4),
+        ((c, f), 5),
+        ((c, g), 6),
+        ((c, h), 7),
+        ((d, a), 1),
+        ((d, b), 2),
+        ((d, c), 3),
+        ((d, d), 0),
+        ((d, e), 3),
+        ((d, f), 4),
+        ((d, g), 5),
+        ((d, h), 6),
+        ((e, a), inf),
+        ((e, b), inf),
+        ((e, c), inf),
+        ((e, d), inf),
+        ((e, e), 0),
+        ((e, f), 1),
+        ((e, g), 2),
+        ((e, h), 3),
+        ((f, a), inf),
+        ((f, b), inf),
+        ((f, c), inf),
+        ((f, d), inf),
+        ((f, e), 3),
+        ((f, f), 0),
+        ((f, g), 1),
+        ((f, h), 2),
+        ((g, a), inf),
+        ((g, b), inf),
+        ((g, c), inf),
+        ((g, d), inf),
+        ((g, e), 2),
+        ((g, f), 3),
+        ((g, g), 0),
+        ((g, h), 1),
+        ((h, a), inf),
+        ((h, b), inf),
+        ((h, c), inf),
+        ((h, d), inf),
+        ((h, e), 1),
+        ((h, f), 2),
+        ((h, g), 3),
+        ((h, h), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    for source in graph.node_indices() {
+        let s = graph.to_index(source);
+        let res = spfa(&graph, source, |_| 1_i32).unwrap();
+
+        let nodes = [a, b, c, d, e, f, g, h];
+
+        for node in &nodes {
+            let n = graph.to_index(*node);
+            let dist = res.distances[n];
+            let expected_dist = *expected_res.get(&(source, *node)).unwrap();
+            assert_eq!(dist, expected_dist, "The distance between source '{s}' and target '{n}' is {dist}, but {expected_dist} is expected");
+        }
+    }
+}
+
+#[test]
+fn spfa_weighted() {
+    let mut graph: Graph<(), i32, Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+
+    graph.extend_with_edges([
+        (a, b, 1),
+        (a, c, 4),
+        (a, d, 10),
+        (b, c, 2),
+        (b, d, 2),
+        (c, d, 2),
+    ]);
+
+    let inf = i32::MAX;
+    let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+        ((a, a), 0),
+        ((a, b), 1),
+        ((a, c), 3),
+        ((a, d), 3),
+        ((b, a), inf),
+        ((b, b), 0),
+        ((b, c), 2),
+        ((b, d), 2),
+        ((c, a), inf),
+        ((c, b), inf),
+        ((c, c), 0),
+        ((c, d), 2),
+        ((d, a), inf),
+        ((d, b), inf),
+        ((d, c), inf),
+        ((d, d), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    for source in graph.node_indices() {
+        let s = graph.to_index(source);
+        let res = spfa(&graph, source, |edge| *edge.weight()).unwrap();
+
+        let nodes = [a, b, c, d];
+
+        for node in &nodes {
+            let n = graph.to_index(*node);
+            let dist = res.distances[n];
+            let expected_dist = *expected_res.get(&(source, *node)).unwrap();
+            assert_eq!(dist, expected_dist, "The distance between source '{s}' and target '{n}' is {dist}, but {expected_dist} is expected");
+        }
+    }
+}
+
+#[test]
+fn spfa_weighted_undirected() {
+    let mut graph: Graph<(), i32, Undirected> = Graph::new_undirected();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+
+    graph.extend_with_edges([
+        (a, b, 1),
+        (a, c, 4),
+        (a, d, 10),
+        (b, d, 2),
+        (c, b, 2),
+        (c, d, 2),
+    ]);
+
+    let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+        ((a, a), 0),
+        ((a, b), 1),
+        ((a, c), 3),
+        ((a, d), 3),
+        ((b, a), 1),
+        ((b, b), 0),
+        ((b, c), 2),
+        ((b, d), 2),
+        ((c, a), 3),
+        ((c, b), 2),
+        ((c, c), 0),
+        ((c, d), 2),
+        ((d, a), 3),
+        ((d, b), 2),
+        ((d, c), 2),
+        ((d, d), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    for source in graph.node_indices() {
+        let s = graph.to_index(source);
+        let res = spfa(&graph, source, |edge| *edge.weight()).unwrap();
+
+        let nodes = [a, b, c, d];
+
+        for node in &nodes {
+            let n = graph.to_index(*node);
+            let dist = res.distances[n];
+            let expected_dist = *expected_res.get(&(source, *node)).unwrap();
+            assert_eq!(dist, expected_dist, "The distance between source '{s}' and target '{n}' is {dist}, but {expected_dist} is expected");
+        }
+    }
+}
+
+#[test]
+fn spfa_negative_cycle() {
+    let mut graph: Graph<(), i32, Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+
+    graph.extend_with_edges([(a, b, 1), (b, c, -3), (c, a, 1)]);
+
+    for source in graph.node_indices() {
+        let res = spfa(&graph, source, |edge| *edge.weight());
+        assert!(res.is_err());
+    }
+}
+
+#[test]
+fn spfa_multiple_edges() {
+    let mut graph: Graph<(), i32, Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+
+    graph.extend_with_edges([
+        (a, b, 10),
+        (a, b, 1),
+        (a, c, 4),
+        (a, d, 10),
+        (b, c, 2),
+        (b, d, 2),
+        (c, d, 2),
+        (a, d, 100),
+        (c, d, 20),
+        (a, a, 5),
+    ]);
+
+    let inf = i32::MAX;
+    let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+        ((a, a), 0),
+        ((a, b), 1),
+        ((a, c), 3),
+        ((a, d), 3),
+        ((b, a), inf),
+        ((b, b), 0),
+        ((b, c), 2),
+        ((b, d), 2),
+        ((c, a), inf),
+        ((c, b), inf),
+        ((c, c), 0),
+        ((c, d), 2),
+        ((d, a), inf),
+        ((d, b), inf),
+        ((d, c), inf),
+        ((d, d), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    for source in graph.node_indices() {
+        let s = graph.to_index(source);
+        let res = spfa(&graph, source, |edge| *edge.weight()).unwrap();
+
+        let nodes = [a, b, c, d];
+        for node in &nodes {
+            let n = graph.to_index(*node);
+            let dist = res.distances[n];
+            let expected_dist = *expected_res.get(&(source, *node)).unwrap();
+            assert_eq!(dist, expected_dist, "The distance between source '{s}' and target '{n}' is {dist}, but {expected_dist} is expected");
+        }
+    }
+}


### PR DESCRIPTION
SPFA (Shortest Path Faster Algorithm) is the improved variation of Bellman-Ford.

### Time Complexity: 
- Average Time Complexity: `O(|E|) `, but this bound has not been approved yet.
- Worstcase Time Complexity: `O(|V|*|E|)`

### Space complexity
- Space complexity: `O(V)`

### [Wikipedia](https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm#CITEREFMoore1959) says:
A variation of the Bellman–Ford algorithm described by [Moore (1959)](https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm#CITEREFMoore1959), reduces the number of relaxation steps that need to be performed within each iteration of the algorithm. If a vertex v has a distance value that has not changed since the last time the edges out of v were relaxed, then there is no need to relax the edges out of v a second time. In this way, as the number of vertices with correct distance values grows, the number whose outgoing edges that need to be relaxed in each iteration shrinks, leading to a constant-factor savings in time for [dense graphs](https://en.wikipedia.org/wiki/Dense_graph). This variation can be implemented by keeping a collection of vertices whose outgoing edges need to be relaxed, removing a vertex from this collection when its edges are relaxed, and adding to the collection any vertex whose distance value is changed by a relaxation step. In China, this algorithm was popularized by Fanding Duan, who rediscovered it in 1994, as the "shortest path faster algorithm".[[6]](https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm#cite_note-6)

### About implementation
I used a stack instead of a queue to improve performance. In this regard, there is a slight discrepancy with the classic description of the "SPFA" algorithm, but this option was also tested on random tests against Bellman-Ford [here](https://github.com/starovoid/graphalgs/blob/main/src/shortest_path/spfa.rs).