### PR TITLE
Add LowerHex and UpperHex impls for Dot

### DIFF
--- a/src/dot.rs
+++ b/src/dot.rs
@@ -212,6 +212,28 @@ where
     }
 }
 
+impl<'a, G> fmt::LowerHex for Dot<'a, G>
+where
+    G: IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,
+    G::EdgeWeight: fmt::LowerHex,
+    G::NodeWeight: fmt::LowerHex,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.graph_fmt(f, fmt::LowerHex::fmt, fmt::LowerHex::fmt)
+    }
+}
+
+impl<'a, G> fmt::UpperHex for Dot<'a, G>
+where
+    G: IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,
+    G::EdgeWeight: fmt::UpperHex,
+    G::NodeWeight: fmt::UpperHex,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.graph_fmt(f, fmt::UpperHex::fmt, fmt::UpperHex::fmt)
+    }
+}
+
 impl<'a, G> fmt::Debug for Dot<'a, G>
 where
     G: IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,


### PR DESCRIPTION
Hello!

Thank you for this library, it's very nice!

I'm using `petgraph` to represent some data with numeric edge and node weights. I'm sometimes using the `Dot` struct to display these graphs, and would like to be able to use `{:x}` and `{:X}` formatting for node and edge labels.

This PR just implements `LowerHex` and `UpperHex` on `Dot` in the style of the existing `Display` and `Debug` implementations.