### PR TITLE
ci: Use the pr's branch on semver-checks `pull_request_target` workflow

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           path: PR_BRANCH
       - name: Checkout baseline
         uses: actions/checkout@v4
@@ -39,6 +40,13 @@ jobs:
       - uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-semver-checks
         run: cargo binstall -y cargo-semver-checks
+
+      # Abort if the crate has build errors, without posting/deleting the comment.
+      - name: Check for build errors
+        id: build
+        run: |
+            cd PR_BRANCH
+            cargo check
 
       # Run cargo-semver-checks against the PR's target branch.
       - name: Check for public API changes
@@ -61,6 +69,9 @@ jobs:
             echo
             echo EOF
           } >> $GITHUB_OUTPUT
+
+          echo "semver-checks diagnostic:\n"
+          cat diagnostic.txt
       
       # Check if the PR title contains a breaking change flag in its title,
       # according to the conventional commits specification.


### PR DESCRIPTION
The `semver-checks` workflow from #692 uses `pull_request_target` as a workflow trigger.
When using `_target` instead of `pull_request` events, `actions/checkout` fetches the _base_ branch of the PR by default.

See in this workflow, both the base and "head" checkouts use the same sha.
https://github.com/petgraph/petgraph/actions/runs/12163228521/job/33921923785?pr=675#step:2:72

This fix sets an explicit parameter when fetching the head.

drive-by: Check if the PR has build errors and skip posting comments if so.