### PR TITLE
Dsatur

### DIFF
--- a/benches/coloring.rs
+++ b/benches/coloring.rs
@@ -1,0 +1,31 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use petgraph::prelude::*;
+use std::cmp::{max, min};
+use test::Bencher;
+
+use petgraph::algo::dsatur_coloring;
+
+#[bench]
+fn dsatur_coloring_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 10_000;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).into_iter().map(|i| g.add_node(i)).collect();
+    for i in 0..NODE_COUNT {
+        let n1 = nodes[i];
+        let neighbour_count = i % 8 + 3;
+        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
+        let j_to = min(NODE_COUNT, j_from + neighbour_count);
+        for j in j_from..j_to {
+            let n2 = nodes[j];
+            g.add_edge(n1, n2, ());
+        }
+    }
+
+    bench.iter(|| {
+        let _scores = dsatur_coloring(&g);
+    });
+}

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -1,25 +1,25 @@
-use std::collections::{HashMap, HashSet, BinaryHeap};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::hash::Hash;
 
-use crate::visit::{IntoEdges, IntoNodeIdentifiers, Visitable, VisitMap};
 use crate::scored::MaxScored;
+use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visitable};
 
 /// \[Generic\] DStatur algorithm to properly color a non weighted undirected graph.
 /// https://en.wikipedia.org/wiki/DSatur
 ///
 /// This is a heuristic. So, it does not necessarily return a minimum coloring.
-/// 
+///
 /// The graph must be undirected. It should not contain loops.
 /// It must implement `IntoEdges`, `IntoNodeIdentifiers` and `Visitable`
 /// Returns a tuple composed of a HashMap that associates to each `NodeId` its color and the number of used colors.
-/// 
+///
 /// Computes in **O((|V| + |E|)*log(|V|)** time
 ///
 /// # Example
 /// ```rust
 /// use petgraph::{Graph, Undirected};
 /// use petgraph::algo::dsatur_coloring;
-/// 
+///
 /// let mut graph: Graph<(), (), Undirected> = Graph::new_undirected();
 /// let a = graph.add_node(());
 /// let b = graph.add_node(());
@@ -40,7 +40,7 @@ use crate::scored::MaxScored;
 /// // a ----- b ----- c
 /// // |               |
 /// // |               |
-/// // |               | 
+/// // |               |
 /// // f ----- e------ d
 ///
 /// let (coloring, nb_colors) = dsatur_coloring(&graph);
@@ -50,21 +50,23 @@ use crate::scored::MaxScored;
 
 pub fn dsatur_coloring<G>(graph: G) -> (HashMap<G::NodeId, usize>, usize)
 where
-    G: IntoEdges + IntoNodeIdentifiers + Visitable,
+    G: IntoEdges + IntoNodeIdentifiers + Visitable + NodeIndexable,
     G::NodeId: Eq + Hash,
 {
-    let mut degree_map = HashMap::new();
-    let mut queue =  BinaryHeap::new();
-    let mut colored = HashMap::new();
-    let mut adj_color_map = HashMap::new();
+    let ix = |v| graph.to_index(v);
+    let n = graph.node_bound();
+
+    let mut degree_map = vec![0; n];
+    let mut queue = BinaryHeap::with_capacity(n);
+    let mut colored = HashMap::with_capacity(n);
+    let mut adj_color_map = vec![HashSet::new(); n];
     let mut seen = graph.visit_map();
     let mut max_color = 0;
 
     for node in graph.node_identifiers() {
         let degree = graph.edges(node).count();
         queue.push(MaxScored((0, degree), node));
-        adj_color_map.insert(node, HashSet::new());
-        degree_map.insert(node, degree);
+        degree_map[ix(node)] = degree;
     }
 
     while let Some(MaxScored(_, node)) = queue.pop() {
@@ -72,19 +74,23 @@ where
             continue;
         }
         seen.visit(node);
-        let adj_color = &adj_color_map[&node];
+
+        let adj_color = &adj_color_map[ix(node)];
         let mut color = 0;
         while adj_color.contains(&color) {
             color += 1;
         }
-        colored.insert(node,  color);
+
+        colored.insert(node, color);
         max_color = max_color.max(color);
+
         for nbor in graph.neighbors(node) {
-            let adj_color = adj_color_map.get_mut(&nbor).unwrap();
-            adj_color.insert(color);
-            queue.push(MaxScored((adj_color.len(), degree_map[&nbor]), nbor));
+            if let Some(adj_color) = adj_color_map.get_mut(ix(nbor)) {
+                adj_color.insert(color);
+                queue.push(MaxScored((adj_color.len(), degree_map[ix(nbor)]), nbor));
+            }
         }
     }
 
-    (colored, max_color+1)
+    (colored, max_color + 1)
 }

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -1,0 +1,90 @@
+use std::collections::{HashMap, HashSet, BinaryHeap};
+use std::hash::Hash;
+
+use crate::visit::{IntoEdges, IntoNodeIdentifiers, Visitable, VisitMap};
+use crate::scored::MaxScored;
+
+/// \[Generic\] DStatur algorithm to properly color a non weighted undirected graph.
+/// https://en.wikipedia.org/wiki/DSatur
+///
+/// This is a heuristic. So, it does not necessarily return a minimum coloring.
+/// 
+/// The graph must be undirected. It should not contain loops.
+/// It must implement `IntoEdges`, `IntoNodeIdentifiers` and `Visitable`
+/// Returns a tuple composed of a HashMap that associates to each `NodeId` its color and the number of used colors.
+/// 
+/// Computes in **O((|V| + |E|)*log(|V|)** time
+///
+/// # Example
+/// ```rust
+/// use petgraph::{Graph, Undirected};
+/// use petgraph::algo::dsatur_coloring;
+/// 
+/// let mut graph: Graph<(), (), Undirected> = Graph::new_undirected();
+/// let a = graph.add_node(());
+/// let b = graph.add_node(());
+/// let c = graph.add_node(());
+/// let d = graph.add_node(());
+/// let e = graph.add_node(());
+/// let f = graph.add_node(());
+///
+/// graph.extend_with_edges(&[
+///     (a, b),
+///     (b, c),
+///     (c, d),
+///     (d, e),
+///     (e, f),
+///     (f, a),
+/// ]);
+///
+/// // a ----- b ----- c
+/// // |               |
+/// // |               |
+/// // |               | 
+/// // f ----- e------ d
+///
+/// let (coloring, nb_colors) = dsatur_coloring(&graph);
+/// assert_eq!(nb_colors, 2);
+/// assert_ne!(coloring[&a], coloring[&b]);
+/// ```
+
+pub fn dsatur_coloring<G>(graph: G) -> (HashMap<G::NodeId, usize>, usize)
+where
+    G: IntoEdges + IntoNodeIdentifiers + Visitable,
+    G::NodeId: Eq + Hash,
+{
+    let mut degree_map = HashMap::new();
+    let mut queue =  BinaryHeap::new();
+    let mut colored = HashMap::new();
+    let mut adj_color_map = HashMap::new();
+    let mut seen = graph.visit_map();
+    let mut max_color = 0;
+
+    for node in graph.node_identifiers() {
+        let degree = graph.edges(node).count();
+        queue.push(MaxScored((0, degree), node));
+        adj_color_map.insert(node, HashSet::new());
+        degree_map.insert(node, degree);
+    }
+
+    while let Some(MaxScored(_, node)) = queue.pop() {
+        if seen.is_visited(&node) {
+            continue;
+        }
+        seen.visit(node);
+        let adj_color = &adj_color_map[&node];
+        let mut color = 0;
+        while adj_color.contains(&color) {
+            color += 1;
+        }
+        colored.insert(node,  color);
+        max_color = max_color.max(color);
+        for nbor in graph.neighbors(node) {
+            let adj_color = adj_color_map.get_mut(&nbor).unwrap();
+            adj_color.insert(color);
+            queue.push(MaxScored((adj_color.len(), degree_map[&nbor]), nbor));
+        }
+    }
+
+    (colored, max_color+1)
+}

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod astar;
 pub mod bellman_ford;
+pub mod coloring;
 pub mod dijkstra;
 pub mod dominators;
 pub mod feedback_arc_set;
@@ -34,6 +35,7 @@ use crate::visit::Walker;
 
 pub use astar::astar;
 pub use bellman_ford::{bellman_ford, find_negative_cycle};
+pub use coloring::dsatur_coloring;
 pub use dijkstra::dijkstra;
 pub use feedback_arc_set::greedy_feedback_arc_set;
 pub use floyd_warshall::floyd_warshall;

--- a/src/scored.rs
+++ b/src/scored.rs
@@ -50,3 +50,44 @@ impl<K: PartialOrd, T> Ord for MinScored<K, T> {
         }
     }
 }
+
+#[derive(Copy, Clone, Debug)]
+pub struct MaxScored<K, T>(pub K, pub T);
+
+impl<K: PartialOrd, T> PartialEq for MaxScored<K, T> {
+    #[inline]
+    fn eq(&self, other: &MaxScored<K, T>) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<K: PartialOrd, T> Eq for MaxScored<K, T> {}
+
+impl<K: PartialOrd, T> PartialOrd for MaxScored<K, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &MaxScored<K, T>) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K: PartialOrd, T> Ord for MaxScored<K, T> {
+    #[inline]
+    fn cmp(&self, other: &MaxScored<K, T>) -> Ordering {
+        let a = &self.0;
+        let b = &other.0;
+        if a == b {
+            Ordering::Equal
+        } else if a < b {
+            Ordering::Less
+        } else if a > b {
+            Ordering::Greater
+        } else if a.ne(a) && b.ne(b) {
+            // these are the NaN cases
+            Ordering::Equal
+        } else if a.ne(a) {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        }
+    }
+}

--- a/tests/coloring.rs
+++ b/tests/coloring.rs
@@ -1,0 +1,66 @@
+use petgraph::algo::dsatur_coloring;
+use petgraph::{Graph, Undirected};
+
+#[test]
+fn dsatur_coloring_cycle6() {
+    let mut graph: Graph<(), (), Undirected> = Graph::new_undirected();
+    let a = graph.add_node(());
+    let d = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let e = graph.add_node(());
+    let f = graph.add_node(());
+    graph.extend_with_edges(&[
+        (a, b),
+        (b, c),
+        (c, d),
+        (d, e),
+        (e, f),
+        (f, e),
+    ]);
+
+    let (coloring, nb_colors) = dsatur_coloring(&graph);
+    assert_eq!(nb_colors, 2);
+    assert_eq!(coloring.len(), 6);
+}
+
+#[test]
+fn dsatur_coloring_bipartite() {
+    let mut graph: Graph<(), (), Undirected> = Graph::new_undirected();
+    let a = graph.add_node(());
+    let d = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let e = graph.add_node(());
+    let f = graph.add_node(());
+    let g = graph.add_node(());
+    let h = graph.add_node(());
+    let i = graph.add_node(());
+    let j = graph.add_node(());
+    let k = graph.add_node(());
+    let l = graph.add_node(());
+    graph.extend_with_edges(&[
+        (a, b),
+        (a, g),
+        (a, l),
+        (b, d),
+        (b, h),
+        (b, k),
+        (c, d),
+        (c, k),
+        (d, l),
+        (e, f),
+        (e, j),
+        (f, i),
+        (f, l),
+        (g, h),
+        (g, j),
+        (g, k),
+        (h, i),
+        (i, j),
+        (i, k),
+    ]);
+
+    let (_, nb_colors) = dsatur_coloring(&graph);
+    assert_eq!(nb_colors, 2);
+}

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -14,8 +14,7 @@ mod utils;
 use utils::{Small, Tournament};
 
 use odds::prelude::*;
-use std::collections::BTreeSet;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::hash::Hash;
 
 use itertools::assert_equal;
@@ -24,10 +23,10 @@ use quickcheck::{Arbitrary, Gen};
 use rand::Rng;
 
 use petgraph::algo::{
-    bellman_ford, condensation, dijkstra, find_negative_cycle, floyd_warshall, ford_fulkerson,
-    greedy_feedback_arc_set, greedy_matching, is_cyclic_directed, is_cyclic_undirected,
-    is_isomorphic, is_isomorphic_matching, k_shortest_path, kosaraju_scc, maximum_matching,
-    min_spanning_tree, page_rank, tarjan_scc, toposort, Matching,
+    bellman_ford, condensation, dijkstra, dsatur_coloring, find_negative_cycle, floyd_warshall,
+    ford_fulkerson, greedy_feedback_arc_set, greedy_matching, is_cyclic_directed,
+    is_cyclic_undirected, is_isomorphic, is_isomorphic_matching, k_shortest_path, kosaraju_scc,
+    maximum_matching, min_spanning_tree, page_rank, tarjan_scc, toposort, Matching,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -1430,6 +1429,29 @@ quickcheck! {
                 new_g = new_g_backup;
             }
         }
+        true
+    }
+}
+
+fn is_proper_coloring<G>(g: G, coloring: &HashMap<G::NodeId, usize>) -> bool
+where
+    G: IntoNodeIdentifiers + IntoEdges,
+    G::NodeId: Eq + Hash,
+{
+    for node in g.node_identifiers() {
+        for nbor in g.neighbors(node) {
+            if node != nbor && coloring[&node] == coloring[&nbor] {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+quickcheck! {
+    fn dsatur_coloring_quickcheck(g: Graph<(), (), Undirected>) -> bool {
+        let (coloring, _) = dsatur_coloring(&g);
+        assert!(is_proper_coloring(&g, &coloring), "dsatur_coloring returned a non proper coloring");
         true
     }
 }


### PR DESCRIPTION
I implemented the changes I suggested in PR #608 and updated the branch.

After several simple optimizations, the performance on the existing benchmark has improved:
- Old: `test dsatur_coloring_bench ... bench: 13,808,991.80 ns/iter (+/- 294,797.19)`
- New: `test dsatur_coloring_bench ... bench: 9,900,469.20 ns/iter (+/- 289,755.02)`

But to make optimizations, we had to add the `NodeIndexable` trait requirement. But I think it's a small price to pay for improved performance, and it won't hurt at all.