### PR TITLE
Almost satisfy clippy

### DIFF
--- a/benches/acyclic.rs
+++ b/benches/acyclic.rs
@@ -11,6 +11,7 @@ use test::Bencher;
 
 /// Dynamic toposort using Acyclic<G>
 #[bench]
+#[allow(clippy::needless_range_loop)]
 fn acyclic_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 100;
     let mut g = Acyclic::<DiGraph<usize, ()>>::new();
@@ -33,6 +34,7 @@ fn acyclic_bench(bench: &mut Bencher) {
 
 /// As a baseline: build the graph and toposort it every time a new edge is added
 #[bench]
+#[allow(clippy::needless_range_loop)]
 fn toposort_baseline_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 100;
     let mut g = DiGraph::<usize, ()>::new();

--- a/benches/bellman_ford.rs
+++ b/benches/bellman_ford.rs
@@ -10,6 +10,7 @@ use test::Bencher;
 use petgraph::algo::{bellman_ford, find_negative_cycle};
 
 #[bench]
+#[allow(clippy::needless_range_loop)]
 fn bellman_ford_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 100;
     let mut g = Graph::new();
@@ -35,6 +36,7 @@ fn bellman_ford_bench(bench: &mut Bencher) {
 }
 
 #[bench]
+#[allow(clippy::needless_range_loop)]
 fn find_negative_cycle_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 100;
     let mut g = Graph::new();

--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -10,6 +10,7 @@ use test::Bencher;
 use petgraph::algo::dijkstra;
 
 #[bench]
+#[allow(clippy::needless_range_loop)]
 fn dijkstra_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 10_000;
     let mut g = Graph::new_undirected();

--- a/benches/floyd_warshall.rs
+++ b/benches/floyd_warshall.rs
@@ -10,6 +10,7 @@ use test::Bencher;
 use petgraph::algo::floyd_warshall;
 
 #[bench]
+#[allow(clippy::needless_range_loop)]
 fn floyd_warshall_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 100;
     let mut g = Graph::new_undirected();

--- a/benches/k_shortest_path.rs
+++ b/benches/k_shortest_path.rs
@@ -10,6 +10,7 @@ use test::Bencher;
 use petgraph::algo::k_shortest_path;
 
 #[bench]
+#[allow(clippy::needless_range_loop)]
 fn k_shortest_path_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 10_000;
     let mut g = Graph::new_undirected();

--- a/src/acyclic.rs
+++ b/src/acyclic.rs
@@ -274,6 +274,7 @@ where
     ///
     /// If `return_result` is false, then the cones are not constructed and the
     /// method only checks for disjointness.
+    #[allow(clippy::type_complexity)]
     fn causal_cones(
         &self,
         min_node: G::NodeId,
@@ -555,41 +556,41 @@ impl<G: Visitable + Data> Data for Acyclic<G> {
 }
 
 impl<G: Visitable + DataMap> DataMap for Acyclic<G> {
-    fn node_weight(self: &Self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
+    fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
         self.inner().node_weight(id)
     }
 
-    fn edge_weight(self: &Self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
+    fn edge_weight(&self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
         self.inner().edge_weight(id)
     }
 }
 
 impl<G: Visitable + DataMapMut> DataMapMut for Acyclic<G> {
-    fn node_weight_mut(self: &mut Self, id: Self::NodeId) -> Option<&mut Self::NodeWeight> {
+    fn node_weight_mut(&mut self, id: Self::NodeId) -> Option<&mut Self::NodeWeight> {
         self.inner_mut().node_weight_mut(id)
     }
 
-    fn edge_weight_mut(self: &mut Self, id: Self::EdgeId) -> Option<&mut Self::EdgeWeight> {
+    fn edge_weight_mut(&mut self, id: Self::EdgeId) -> Option<&mut Self::EdgeWeight> {
         self.inner_mut().edge_weight_mut(id)
     }
 }
 
 impl<G: Visitable + EdgeCount> EdgeCount for Acyclic<G> {
-    fn edge_count(self: &Self) -> usize {
+    fn edge_count(&self) -> usize {
         self.inner().edge_count()
     }
 }
 
 impl<G: Visitable + EdgeIndexable> EdgeIndexable for Acyclic<G> {
-    fn edge_bound(self: &Self) -> usize {
+    fn edge_bound(&self) -> usize {
         self.inner().edge_bound()
     }
 
-    fn to_index(self: &Self, a: Self::EdgeId) -> usize {
+    fn to_index(&self, a: Self::EdgeId) -> usize {
         self.inner().to_index(a)
     }
 
-    fn from_index(self: &Self, i: usize) -> Self::EdgeId {
+    fn from_index(&self, i: usize) -> Self::EdgeId {
         self.inner().from_index(i)
     }
 }
@@ -597,16 +598,11 @@ impl<G: Visitable + EdgeIndexable> EdgeIndexable for Acyclic<G> {
 impl<G: Visitable + GetAdjacencyMatrix> GetAdjacencyMatrix for Acyclic<G> {
     type AdjMatrix = G::AdjMatrix;
 
-    fn adjacency_matrix(self: &Self) -> Self::AdjMatrix {
+    fn adjacency_matrix(&self) -> Self::AdjMatrix {
         self.inner().adjacency_matrix()
     }
 
-    fn is_adjacent(
-        self: &Self,
-        matrix: &Self::AdjMatrix,
-        a: Self::NodeId,
-        b: Self::NodeId,
-    ) -> bool {
+    fn is_adjacent(&self, matrix: &Self::AdjMatrix, a: Self::NodeId, b: Self::NodeId) -> bool {
         self.inner().is_adjacent(matrix, a, b)
     }
 }
@@ -618,21 +614,21 @@ impl<G: Visitable + GraphProp> GraphProp for Acyclic<G> {
 impl<G: Visitable + NodeCompactIndexable> NodeCompactIndexable for Acyclic<G> {}
 
 impl<G: Visitable + NodeCount> NodeCount for Acyclic<G> {
-    fn node_count(self: &Self) -> usize {
+    fn node_count(&self) -> usize {
         self.inner().node_count()
     }
 }
 
 impl<G: Visitable + NodeIndexable> NodeIndexable for Acyclic<G> {
-    fn node_bound(self: &Self) -> usize {
+    fn node_bound(&self) -> usize {
         self.inner().node_bound()
     }
 
-    fn to_index(self: &Self, a: Self::NodeId) -> usize {
+    fn to_index(&self, a: Self::NodeId) -> usize {
         self.inner().to_index(a)
     }
 
-    fn from_index(self: &Self, i: usize) -> Self::NodeId {
+    fn from_index(&self, i: usize) -> Self::NodeId {
         self.inner().from_index(i)
     }
 }
@@ -640,11 +636,11 @@ impl<G: Visitable + NodeIndexable> NodeIndexable for Acyclic<G> {
 impl<G: Visitable> Visitable for Acyclic<G> {
     type Map = G::Map;
 
-    fn visit_map(self: &Self) -> Self::Map {
+    fn visit_map(&self) -> Self::Map {
         self.inner().visit_map()
     }
 
-    fn reset_map(self: &Self, map: &mut Self::Map) {
+    fn reset_map(&self, map: &mut Self::Map) {
         self.inner().reset_map(map)
     }
 }

--- a/src/adj.rs
+++ b/src/adj.rs
@@ -68,14 +68,14 @@ pub struct EdgeReference<'a, E, Ix: IndexType> {
     edge: &'a WSuc<E, Ix>,
 }
 
-impl<'a, E, Ix: IndexType> Copy for EdgeReference<'a, E, Ix> {}
-impl<'a, E, Ix: IndexType> Clone for EdgeReference<'a, E, Ix> {
+impl<E, Ix: IndexType> Copy for EdgeReference<'_, E, Ix> {}
+impl<E, Ix: IndexType> Clone for EdgeReference<'_, E, Ix> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, E, Ix: IndexType> visit::EdgeRef for EdgeReference<'a, E, Ix> {
+impl<E, Ix: IndexType> visit::EdgeRef for EdgeReference<'_, E, Ix> {
     type NodeId = NodeIndex<Ix>;
     type EdgeId = EdgeIndex<Ix>;
     type Weight = E;
@@ -101,7 +101,7 @@ pub struct EdgeIndices<'a, E, Ix: IndexType> {
     cur: usize,
 }
 
-impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
+impl<E, Ix: IndexType> Iterator for EdgeIndices<'_, E, Ix> {
     type Item = EdgeIndex<Ix>;
     fn next(&mut self) -> Option<EdgeIndex<Ix>> {
         loop {
@@ -371,7 +371,7 @@ impl<E, Ix: IndexType> Build for List<E, Ix> {
     }
 }
 
-impl<'a, E, Ix> fmt::Debug for EdgeReferences<'a, E, Ix>
+impl<E, Ix> fmt::Debug for EdgeReferences<'_, E, Ix>
 where
     E: fmt::Debug,
     Ix: IndexType,
@@ -431,7 +431,7 @@ where
     }
 }
 
-impl<'a, E, Ix: IndexType> visit::IntoNodeIdentifiers for &'a List<E, Ix> {
+impl<E, Ix: IndexType> visit::IntoNodeIdentifiers for &List<E, Ix> {
     type NodeIdentifiers = NodeIndices<Ix>;
     fn node_identifiers(self) -> NodeIndices<Ix> {
         self.node_indices()
@@ -449,7 +449,7 @@ impl<Ix: IndexType> visit::NodeRef for NodeIndex<Ix> {
     }
 }
 
-impl<'a, Ix: IndexType, E> visit::IntoNodeReferences for &'a List<E, Ix> {
+impl<Ix: IndexType, E> visit::IntoNodeReferences for &List<E, Ix> {
     type NodeRef = NodeIndex<Ix>;
     type NodeReferences = NodeIndices<Ix>;
     fn node_references(self) -> Self::NodeReferences {
@@ -496,7 +496,7 @@ iter: std::iter::FlatMap<
 >,
 }
 
-impl<'a, E, Ix: IndexType> Clone for EdgeReferences<'a, E, Ix> {
+impl<E, Ix: IndexType> Clone for EdgeReferences<'_, E, Ix> {
     fn clone(&self) -> Self {
         EdgeReferences {
             iter: self.iter.clone(),

--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -731,7 +731,7 @@ mod matching {
         }
     }
 
-    impl<'a, 'b, 'c, G0, G1, NM, EM> Iterator for GraphMatcher<'a, 'b, 'c, G0, G1, NM, EM>
+    impl<G0, G1, NM, EM> Iterator for GraphMatcher<'_, '_, '_, G0, G1, NM, EM>
     where
         G0: NodeCompactIndexable
             + EdgeCount

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -105,7 +105,6 @@ where
 
 trait WithDummy: NodeIndexable {
     fn dummy_idx(&self) -> usize;
-    fn node_bound_with_dummy(&self) -> usize;
     /// Convert `i` to a node index, returns None for the dummy node
     fn try_from_index(&self, i: usize) -> Option<Self::NodeId>;
 }
@@ -116,10 +115,6 @@ impl<G: NodeIndexable> WithDummy for G {
         // vertex. Our vertex indices are zero-based and so we use the node
         // bound as the dummy node.
         self.node_bound()
-    }
-
-    fn node_bound_with_dummy(&self) -> usize {
-        self.node_bound() + 1
     }
 
     fn try_from_index(&self, i: usize) -> Option<Self::NodeId> {

--- a/src/algo/page_rank.rs
+++ b/src/algo/page_rank.rs
@@ -146,7 +146,7 @@ where
     let nb = D::from_usize(node_count);
     let mut ranks: Vec<D> = (0..node_count)
         .into_par_iter()
-        .map(|i| D::one() / nb)
+        .map(|_| D::one() / nb)
         .collect();
     for _ in 0..nb_iter {
         let pi = (0..node_count)

--- a/src/algo/tred.rs
+++ b/src/algo/tred.rs
@@ -94,6 +94,7 @@ where
 /// list such that:
 /// * Node indices are a toposort, and
 /// * The neighbors of all nodes are stored in topological order.
+///
 /// To get such a representation, use the function [`dag_to_toposorted_adjacency_list`].
 ///
 /// [`dag_to_toposorted_adjacency_list`]: ./fn.dag_to_toposorted_adjacency_list.html

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -411,13 +411,13 @@ pub struct EdgeReference<'a, E: 'a, Ty, Ix: 'a = DefaultIx> {
     ty: PhantomData<Ty>,
 }
 
-impl<'a, E, Ty, Ix: Copy> Clone for EdgeReference<'a, E, Ty, Ix> {
+impl<E, Ty, Ix: Copy> Clone for EdgeReference<'_, E, Ty, Ix> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, E, Ty, Ix: Copy> Copy for EdgeReference<'a, E, Ty, Ix> {}
+impl<E, Ty, Ix: Copy> Copy for EdgeReference<'_, E, Ty, Ix> {}
 
 impl<'a, Ty, E, Ix> EdgeReference<'a, E, Ty, Ix>
 where
@@ -432,7 +432,7 @@ where
     }
 }
 
-impl<'a, E, Ty, Ix> EdgeRef for EdgeReference<'a, E, Ty, Ix>
+impl<E, Ty, Ix> EdgeRef for EdgeReference<'_, E, Ty, Ix>
 where
     Ty: EdgeType,
     Ix: IndexType,
@@ -594,7 +594,7 @@ pub struct Neighbors<'a, Ix: 'a = DefaultIx> {
     iter: SliceIter<'a, NodeIndex<Ix>>,
 }
 
-impl<'a, Ix> Iterator for Neighbors<'a, Ix>
+impl<Ix> Iterator for Neighbors<'_, Ix>
 where
     Ix: IndexType,
 {
@@ -696,7 +696,7 @@ where
     }
 }
 
-impl<'a, N, E, Ty, Ix> IntoNodeIdentifiers for &'a Csr<N, E, Ty, Ix>
+impl<N, E, Ty, Ix> IntoNodeIdentifiers for &Csr<N, E, Ty, Ix>
 where
     Ty: EdgeType,
     Ix: IndexType,
@@ -776,7 +776,7 @@ where
     }
 }
 
-impl<'a, N, Ix> DoubleEndedIterator for NodeReferences<'a, N, Ix>
+impl<N, Ix> DoubleEndedIterator for NodeReferences<'_, N, Ix>
 where
     Ix: IndexType,
 {
@@ -787,11 +787,11 @@ where
     }
 }
 
-impl<'a, N, Ix> ExactSizeIterator for NodeReferences<'a, N, Ix> where Ix: IndexType {}
+impl<N, Ix> ExactSizeIterator for NodeReferences<'_, N, Ix> where Ix: IndexType {}
 
 /// The adjacency matrix for **Csr** is a bitmap that's computed by
 /// `.adjacency_matrix()`.
-impl<'a, N, E, Ty, Ix> GetAdjacencyMatrix for &'a Csr<N, E, Ty, Ix>
+impl<N, E, Ty, Ix> GetAdjacencyMatrix for &Csr<N, E, Ty, Ix>
 where
     Ix: IndexType,
     Ty: EdgeType,
@@ -926,7 +926,7 @@ mod tests {
         .unwrap();
         println!("{:?}", m);
         let mut dfs = Dfs::new(&m, 0);
-        while let Some(_) = dfs.next(&m) {}
+        while dfs.next(&m).is_some() {}
         for i in 0..m.node_count() - 2 {
             assert!(dfs.discovered.is_visited(&i), "visited {}", i)
         }
@@ -938,7 +938,7 @@ mod tests {
 
         dfs.reset(&m);
         dfs.move_to(0);
-        while let Some(_) = dfs.next(&m) {}
+        while dfs.next(&m).is_some() {}
 
         for i in 0..m.node_count() {
             assert!(dfs.discovered[i], "visited {}", i)

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -131,6 +131,7 @@ where
 /// Csr creation error: edges were not in sorted order.
 #[derive(Clone, Debug)]
 pub struct EdgesNotSorted {
+    #[allow(unused)]
     first_error: (usize, usize),
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -415,10 +415,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            let mut elt = match self.iter.next() {
-                None => return None,
-                Some(elt) => elt,
-            };
+            let mut elt = self.iter.next()?;
             let keep = (self.f)(match elt {
                 Element::Node { ref mut weight } => Element::Node { weight },
                 Element::Edge {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -144,7 +144,7 @@ make_config_struct!(
     GraphContentOnly,
 );
 
-impl<'a, G> Dot<'a, G>
+impl<G> Dot<'_, G>
 where
     G: IntoNodeReferences + IntoEdgeReferences + NodeIndexable + GraphProp,
 {
@@ -201,7 +201,7 @@ where
     }
 }
 
-impl<'a, G> fmt::Display for Dot<'a, G>
+impl<G> fmt::Display for Dot<'_, G>
 where
     G: IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,
     G::EdgeWeight: fmt::Display,
@@ -212,7 +212,7 @@ where
     }
 }
 
-impl<'a, G> fmt::LowerHex for Dot<'a, G>
+impl<G> fmt::LowerHex for Dot<'_, G>
 where
     G: IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,
     G::EdgeWeight: fmt::LowerHex,
@@ -223,7 +223,7 @@ where
     }
 }
 
-impl<'a, G> fmt::UpperHex for Dot<'a, G>
+impl<G> fmt::UpperHex for Dot<'_, G>
 where
     G: IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,
     G::EdgeWeight: fmt::UpperHex,
@@ -234,7 +234,7 @@ where
     }
 }
 
-impl<'a, G> fmt::Debug for Dot<'a, G>
+impl<G> fmt::Debug for Dot<'_, G>
 where
     G: IntoEdgeReferences + IntoNodeReferences + NodeIndexable + GraphProp,
     G::EdgeWeight: fmt::Debug,

--- a/src/graph6/graph6_encoder.rs
+++ b/src/graph6/graph6_encoder.rs
@@ -23,7 +23,7 @@ const N: usize = 63;
 
 /// A graph that can be converted to graph6 format string.
 pub trait ToGraph6 {
-    fn graph6_string(self: &Self) -> String;
+    fn graph6_string(&self) -> String;
 }
 
 /// Converts a graph that implements GetAdjacencyMatrix and IntoNodeIdentifers
@@ -50,13 +50,13 @@ fn get_adj_matrix_upper_diagonal_as_bits<G>(graph: G) -> (usize, Vec<usize>)
 where
     G: GetAdjacencyMatrix + IntoNodeIdentifiers,
 {
-    let mut node_ids_iter = graph.node_identifiers();
+    let node_ids_iter = graph.node_identifiers();
     let mut node_ids_vec = vec![];
 
     let adj_matrix = graph.adjacency_matrix();
     let mut bits = vec![];
     let mut n = 0;
-    while let Some(node_id) = node_ids_iter.next() {
+    for node_id in node_ids_iter {
         node_ids_vec.push(node_id);
 
         for i in 1..=n {
@@ -68,7 +68,7 @@ where
         n += 1;
     }
 
-    return (n, bits);
+    (n, bits)
 }
 
 // Converts graph order to a bits vector.
@@ -116,21 +116,21 @@ fn bits_to_ascii(mut bits: Vec<usize>) -> String {
 }
 
 impl<N, E, Ix: IndexType> ToGraph6 for Graph<N, E, Undirected, Ix> {
-    fn graph6_string(self: &Self) -> String {
+    fn graph6_string(&self) -> String {
         get_graph6_representation(self)
     }
 }
 
 #[cfg(feature = "stable_graph")]
 impl<N, E, Ix: IndexType> ToGraph6 for StableGraph<N, E, Undirected, Ix> {
-    fn graph6_string(self: &Self) -> String {
+    fn graph6_string(&self) -> String {
         get_graph6_representation(self)
     }
 }
 
 #[cfg(feature = "graphmap")]
 impl<N: NodeTrait, E, S: BuildHasher> ToGraph6 for GraphMap<N, E, Undirected, S> {
-    fn graph6_string(self: &Self) -> String {
+    fn graph6_string(&self) -> String {
         get_graph6_representation(self)
     }
 }
@@ -142,13 +142,13 @@ where
     Null: Nullable<Wrapped = E>,
     Ix: IndexType,
 {
-    fn graph6_string(self: &Self) -> String {
+    fn graph6_string(&self) -> String {
         get_graph6_representation(self)
     }
 }
 
 impl<N, E, Ix: IndexType> ToGraph6 for Csr<N, E, Undirected, Ix> {
-    fn graph6_string(self: &Self) -> String {
+    fn graph6_string(&self) -> String {
         get_graph6_representation(self)
     }
 }

--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -21,14 +21,14 @@ impl<'a, G> Frozen<'a, G> {
 
 /// Deref allows transparent access to all shared reference (read-only)
 /// functionality in the underlying graph.
-impl<'a, G> Deref for Frozen<'a, G> {
+impl<G> Deref for Frozen<'_, G> {
     type Target = G;
     fn deref(&self) -> &G {
         self.0
     }
 }
 
-impl<'a, G, I> Index<I> for Frozen<'a, G>
+impl<G, I> Index<I> for Frozen<'_, G>
 where
     G: Index<I>,
 {
@@ -38,7 +38,7 @@ where
     }
 }
 
-impl<'a, G, I> IndexMut<I> for Frozen<'a, G>
+impl<G, I> IndexMut<I> for Frozen<'_, G>
 where
     G: IndexMut<I>,
 {
@@ -47,7 +47,7 @@ where
     }
 }
 
-impl<'a, N, E, Ty, Ix> Frozen<'a, Graph<N, E, Ty, Ix>>
+impl<N, E, Ty, Ix> Frozen<'_, Graph<N, E, Ty, Ix>>
 where
     Ty: EdgeType,
     Ix: IndexType,
@@ -80,7 +80,7 @@ macro_rules! access0 {
     };
 }
 
-impl<'a, G> GraphBase for Frozen<'a, G>
+impl<G> GraphBase for Frozen<'_, G>
 where
     G: GraphBase,
 {

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -323,24 +323,24 @@ impl<E, Ix: IndexType> Edge<E, Ix> {
 /// but these are only stable across certain operations:
 ///
 /// * **Removing nodes or edges may shift other indices.** Removing a node will
-/// force the last node to shift its index to take its place. Similarly,
-/// removing an edge shifts the index of the last edge.
+///     force the last node to shift its index to take its place. Similarly,
+///     removing an edge shifts the index of the last edge.
 /// * Adding nodes or edges keeps indices stable.
 ///
 /// The `Ix` parameter is `u32` by default. The goal is that you can ignore this parameter
 /// completely unless you need a very big graph -- then you can use `usize`.
 ///
 /// * The fact that the node and edge indices in the graph each are numbered in compact
-/// intervals (from 0 to *n* - 1 for *n* nodes) simplifies some graph algorithms.
+///     intervals (from 0 to *n* - 1 for *n* nodes) simplifies some graph algorithms.
 ///
 /// * You can select graph index integer type after the size of the graph. A smaller
-/// size may have better performance.
+///     size may have better performance.
 ///
 /// * Using indices allows mutation while traversing the graph, see `Dfs`,
-/// and `.neighbors(a).detach()`.
+///     and `.neighbors(a).detach()`.
 ///
 /// * You can create several graphs using the equal node indices but with
-/// differing weights or differing edges.
+///     differing weights or differing edges.
 ///
 /// * Indices don't allow as much compile time checking as references.
 ///

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1517,7 +1517,7 @@ pub struct Neighbors<'a, E: 'a, Ix: 'a = DefaultIx> {
     next: [EdgeIndex<Ix>; 2],
 }
 
-impl<'a, E, Ix> Iterator for Neighbors<'a, E, Ix>
+impl<E, Ix> Iterator for Neighbors<'_, E, Ix>
 where
     Ix: IndexType,
 {
@@ -1546,14 +1546,14 @@ where
     }
 }
 
-impl<'a, E, Ix> Clone for Neighbors<'a, E, Ix>
+impl<E, Ix> Clone for Neighbors<'_, E, Ix>
 where
     Ix: IndexType,
 {
     clone_fields!(Neighbors, skip_start, edges, next,);
 }
 
-impl<'a, E, Ix> Neighbors<'a, E, Ix>
+impl<E, Ix> Neighbors<'_, E, Ix>
 where
     Ix: IndexType,
 {
@@ -1587,7 +1587,7 @@ where
     EdgesWalkerMut { edges, next, dir }
 }
 
-impl<'a, E, Ix> EdgesWalkerMut<'a, E, Ix>
+impl<E, Ix> EdgesWalkerMut<'_, E, Ix>
 where
     Ix: IndexType,
 {
@@ -1751,7 +1751,7 @@ fn swap_pair<T>(mut x: [T; 2]) -> [T; 2] {
     x
 }
 
-impl<'a, E, Ty, Ix> Clone for Edges<'a, E, Ty, Ix>
+impl<E, Ty, Ix> Clone for Edges<'_, E, Ty, Ix>
 where
     Ix: IndexType,
     Ty: EdgeType,
@@ -2109,15 +2109,15 @@ pub struct EdgeReference<'a, E: 'a, Ix = DefaultIx> {
     weight: &'a E,
 }
 
-impl<'a, E, Ix: IndexType> Clone for EdgeReference<'a, E, Ix> {
+impl<E, Ix: IndexType> Clone for EdgeReference<'_, E, Ix> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, E, Ix: IndexType> Copy for EdgeReference<'a, E, Ix> {}
+impl<E, Ix: IndexType> Copy for EdgeReference<'_, E, Ix> {}
 
-impl<'a, E, Ix: IndexType> PartialEq for EdgeReference<'a, E, Ix>
+impl<E, Ix: IndexType> PartialEq for EdgeReference<'_, E, Ix>
 where
     E: PartialEq,
 {
@@ -2287,7 +2287,7 @@ where
     }
 }
 
-impl<'a, N, Ix> DoubleEndedIterator for NodeReferences<'a, N, Ix>
+impl<N, Ix> DoubleEndedIterator for NodeReferences<'_, N, Ix>
 where
     Ix: IndexType,
 {
@@ -2298,7 +2298,7 @@ where
     }
 }
 
-impl<'a, N, Ix> ExactSizeIterator for NodeReferences<'a, N, Ix> where Ix: IndexType {}
+impl<N, Ix> ExactSizeIterator for NodeReferences<'_, N, Ix> where Ix: IndexType {}
 
 impl<'a, Ix, E> EdgeReference<'a, E, Ix>
 where
@@ -2313,7 +2313,7 @@ where
     }
 }
 
-impl<'a, Ix, E> visit::EdgeRef for EdgeReference<'a, E, Ix>
+impl<Ix, E> visit::EdgeRef for EdgeReference<'_, E, Ix>
 where
     Ix: IndexType,
 {
@@ -2360,7 +2360,7 @@ where
     }
 }
 
-impl<'a, E, Ix> DoubleEndedIterator for EdgeReferences<'a, E, Ix>
+impl<E, Ix> DoubleEndedIterator for EdgeReferences<'_, E, Ix>
 where
     Ix: IndexType,
 {
@@ -2373,7 +2373,7 @@ where
     }
 }
 
-impl<'a, E, Ix> ExactSizeIterator for EdgeReferences<'a, E, Ix> where Ix: IndexType {}
+impl<E, Ix> ExactSizeIterator for EdgeReferences<'_, E, Ix> where Ix: IndexType {}
 
 impl<N, E, Ty, Ix> visit::EdgeIndexable for Graph<N, E, Ty, Ix>
 where

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -55,16 +55,16 @@ mod serialization;
 /// is some local measure of edge count.
 ///
 /// - Nodes and edges are each numbered in an interval from *0* to some number
-/// *m*, but *not all* indices in the range are valid, since gaps are formed
-/// by deletions.
+///     *m*, but *not all* indices in the range are valid, since gaps are formed
+///     by deletions.
 ///
 /// - You can select graph index integer type after the size of the graph. A smaller
-/// size may have better performance.
+///     size may have better performance.
 ///
 /// - Using indices allows mutation while traversing the graph, see `Dfs`.
 ///
 /// - The `StableGraph` is a regular rust collection and is `Send` and `Sync`
-/// (as long as associated data `N` and `E` are).
+///     (as long as associated data `N` and `E` are).
 ///
 /// - Indices don't allow as much compile time checking as references.
 ///

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -1318,7 +1318,7 @@ where
     }
 }
 
-impl<'a, N, Ix> DoubleEndedIterator for NodeReferences<'a, N, Ix>
+impl<N, Ix> DoubleEndedIterator for NodeReferences<'_, N, Ix>
 where
     Ix: IndexType,
 {
@@ -1336,15 +1336,15 @@ pub struct EdgeReference<'a, E: 'a, Ix = DefaultIx> {
     weight: &'a E,
 }
 
-impl<'a, E, Ix: IndexType> Clone for EdgeReference<'a, E, Ix> {
+impl<E, Ix: IndexType> Clone for EdgeReference<'_, E, Ix> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, E, Ix: IndexType> Copy for EdgeReference<'a, E, Ix> {}
+impl<E, Ix: IndexType> Copy for EdgeReference<'_, E, Ix> {}
 
-impl<'a, E, Ix: IndexType> PartialEq for EdgeReference<'a, E, Ix>
+impl<E, Ix: IndexType> PartialEq for EdgeReference<'_, E, Ix>
 where
     E: PartialEq,
 {
@@ -1516,7 +1516,7 @@ where
     }
 }
 
-impl<'a, E, Ix> DoubleEndedIterator for EdgeReferences<'a, E, Ix>
+impl<E, Ix> DoubleEndedIterator for EdgeReferences<'_, E, Ix>
 where
     Ix: IndexType,
 {
@@ -1580,7 +1580,7 @@ pub struct Neighbors<'a, E: 'a, Ix: 'a = DefaultIx> {
     next: [EdgeIndex<Ix>; 2],
 }
 
-impl<'a, E, Ix> Neighbors<'a, E, Ix>
+impl<E, Ix> Neighbors<'_, E, Ix>
 where
     Ix: IndexType,
 {
@@ -1599,7 +1599,7 @@ where
     }
 }
 
-impl<'a, E, Ix> Iterator for Neighbors<'a, E, Ix>
+impl<E, Ix> Iterator for Neighbors<'_, E, Ix>
 where
     Ix: IndexType,
 {
@@ -1709,7 +1709,7 @@ pub struct NodeIndices<'a, N: 'a, Ix: 'a = DefaultIx> {
     iter: iter::Enumerate<slice::Iter<'a, Node<Option<N>, Ix>>>,
 }
 
-impl<'a, N, Ix: IndexType> Iterator for NodeIndices<'a, N, Ix> {
+impl<N, Ix: IndexType> Iterator for NodeIndices<'_, N, Ix> {
     type Item = NodeIndex<Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1727,7 +1727,7 @@ impl<'a, N, Ix: IndexType> Iterator for NodeIndices<'a, N, Ix> {
     }
 }
 
-impl<'a, N, Ix: IndexType> DoubleEndedIterator for NodeIndices<'a, N, Ix> {
+impl<N, Ix: IndexType> DoubleEndedIterator for NodeIndices<'_, N, Ix> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.ex_rfind_map(|(i, node)| {
             if node.weight.is_some() {
@@ -1745,7 +1745,7 @@ pub struct EdgeIndices<'a, E: 'a, Ix: 'a = DefaultIx> {
     iter: iter::Enumerate<slice::Iter<'a, Edge<Option<E>, Ix>>>,
 }
 
-impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
+impl<E, Ix: IndexType> Iterator for EdgeIndices<'_, E, Ix> {
     type Item = EdgeIndex<Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1763,7 +1763,7 @@ impl<'a, E, Ix: IndexType> Iterator for EdgeIndices<'a, E, Ix> {
     }
 }
 
-impl<'a, E, Ix: IndexType> DoubleEndedIterator for EdgeIndices<'a, E, Ix> {
+impl<E, Ix: IndexType> DoubleEndedIterator for EdgeIndices<'_, E, Ix> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.ex_rfind_map(|(i, node)| {
             if node.weight.is_some() {
@@ -1900,7 +1900,7 @@ where
     }
 }
 
-impl<'a, Ix, E> visit::EdgeRef for EdgeReference<'a, E, Ix>
+impl<Ix, E> visit::EdgeRef for EdgeReference<'_, E, Ix>
 where
     Ix: IndexType,
 {

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -50,13 +50,13 @@ pub type DiGraphMap<N, E> = GraphMap<N, E, Directed>;
 ///
 /// - Associated data `N` for nodes and `E` for edges, called *weights*.
 /// - The node weight `N` must implement `Copy` and will be used as node
-/// identifier, duplicated into several places in the data structure.
-/// It must be suitable as a hash table key (implementing `Eq + Hash`).
-/// The node type must also implement `Ord` so that the implementation can
-/// order the pair (`a`, `b`) for an edge connecting any two nodes `a` and `b`.
+///     identifier, duplicated into several places in the data structure.
+///     It must be suitable as a hash table key (implementing `Eq + Hash`).
+///     The node type must also implement `Ord` so that the implementation can
+///     order the pair (`a`, `b`) for an edge connecting any two nodes `a` and `b`.
 /// - `E` can be of arbitrary type.
 /// - Edge type `Ty` that determines whether the graph edges are directed or
-/// undirected.
+///     undirected.
 ///
 /// You can use the type aliases `UnGraphMap` and `DiGraphMap` for convenience.
 ///

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -697,7 +697,7 @@ where
     ty: PhantomData<Ty>,
 }
 
-impl<'a, N, Ty> Iterator for Neighbors<'a, N, Ty>
+impl<N, Ty> Iterator for Neighbors<'_, N, Ty>
 where
     N: NodeTrait,
     Ty: EdgeType,
@@ -734,7 +734,7 @@ where
     ty: PhantomData<Ty>,
 }
 
-impl<'a, N, Ty> Iterator for NeighborsDirected<'a, N, Ty>
+impl<N, Ty> Iterator for NeighborsDirected<'_, N, Ty>
 where
     N: NodeTrait,
     Ty: EdgeType,
@@ -997,8 +997,8 @@ where
 /// with the `Cell<T>` being `TypedArena` allocated.
 pub struct Ptr<'b, T: 'b>(pub &'b T);
 
-impl<'b, T> Copy for Ptr<'b, T> {}
-impl<'b, T> Clone for Ptr<'b, T> {
+impl<T> Copy for Ptr<'_, T> {}
+impl<T> Clone for Ptr<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
@@ -1030,23 +1030,23 @@ impl<'b, T> Ord for Ptr<'b, T> {
     }
 }
 
-impl<'b, T> Deref for Ptr<'b, T> {
+impl<T> Deref for Ptr<'_, T> {
     type Target = T;
     fn deref(&self) -> &T {
         self.0
     }
 }
 
-impl<'b, T> Eq for Ptr<'b, T> {}
+impl<T> Eq for Ptr<'_, T> {}
 
-impl<'b, T> Hash for Ptr<'b, T> {
+impl<T> Hash for Ptr<'_, T> {
     fn hash<H: hash::Hasher>(&self, st: &mut H) {
         let ptr = (self.0) as *const T;
         ptr.hash(st)
     }
 }
 
-impl<'b, T: fmt::Debug> fmt::Debug for Ptr<'b, T> {
+impl<T: fmt::Debug> fmt::Debug for Ptr<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }

--- a/src/iter_format.rs
+++ b/src/iter_format.rs
@@ -58,7 +58,7 @@ pub trait IterFormatExt: Iterator {
 
 impl<I> IterFormatExt for I where I: Iterator {}
 
-impl<'a, I> Format<'a, I>
+impl<I> Format<'_, I>
 where
     I: Iterator,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ impl<Ix, E> IntoWeightedEdge<E> for (Ix, Ix, E) {
     }
 }
 
-impl<'a, Ix, E> IntoWeightedEdge<E> for (Ix, Ix, &'a E)
+impl<Ix, E> IntoWeightedEdge<E> for (Ix, Ix, &E)
 where
     E: Clone,
 {
@@ -281,7 +281,7 @@ where
     }
 }
 
-impl<'a, Ix, E> IntoWeightedEdge<E> for &'a (Ix, Ix)
+impl<Ix, E> IntoWeightedEdge<E> for &(Ix, Ix)
 where
     Ix: Copy,
     E: Default,
@@ -293,7 +293,7 @@ where
     }
 }
 
-impl<'a, Ix, E> IntoWeightedEdge<E> for &'a (Ix, Ix, E)
+impl<Ix, E> IntoWeightedEdge<E> for &(Ix, Ix, E)
 where
     Ix: Copy,
     E: Clone,

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -587,7 +587,7 @@ impl<'a, Ix: IndexType> NodeIdentifiers<'a, Ix> {
     }
 }
 
-impl<'a, Ix: IndexType> Iterator for NodeIdentifiers<'a, Ix> {
+impl<Ix: IndexType> Iterator for NodeIdentifiers<'_, Ix> {
     type Item = NodeIndex<Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -709,7 +709,7 @@ impl<'a, Ty: EdgeType, Null: Nullable, Ix: IndexType> Iterator
 #[derive(Debug, Clone)]
 pub struct Neighbors<'a, Ty: EdgeType, Null: 'a + Nullable, Ix>(Edges<'a, Ty, Null, Ix>);
 
-impl<'a, Ty: EdgeType, Null: Nullable, Ix: IndexType> Iterator for Neighbors<'a, Ty, Null, Ix> {
+impl<Ty: EdgeType, Null: Nullable, Ix: IndexType> Iterator for Neighbors<'_, Ty, Null, Ix> {
     type Item = NodeIndex<Ix>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -983,7 +983,7 @@ struct IdIterator<'a> {
     current: Option<usize>,
 }
 
-impl<'a> Iterator for IdIterator<'a> {
+impl Iterator for IdIterator<'_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1381,8 +1381,8 @@ mod tests {
         let c = g.add_node('c');
         g.add_edge(a, b, true);
         g.add_edge(b, c, false);
-        assert_eq!(*g.edge_weight(a, b), true);
-        assert_eq!(*g.edge_weight(b, c), false);
+        assert!(*g.edge_weight(a, b));
+        assert!(!*g.edge_weight(b, c));
     }
 
     #[test]

--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -113,7 +113,7 @@ pub struct NodeFilteredNeighbors<'a, I, F: 'a> {
     f: &'a F,
 }
 
-impl<'a, I, F> Iterator for NodeFilteredNeighbors<'a, I, F>
+impl<I, F> Iterator for NodeFilteredNeighbors<'_, I, F>
 where
     I: Iterator,
     I::Item: Copy,
@@ -188,7 +188,7 @@ pub struct NodeFilteredNodes<'a, I, F: 'a> {
     f: &'a F,
 }
 
-impl<'a, I, F> Iterator for NodeFilteredNodes<'a, I, F>
+impl<I, F> Iterator for NodeFilteredNodes<'_, I, F>
 where
     I: Iterator,
     I::Item: Copy + NodeRef,
@@ -233,7 +233,7 @@ pub struct NodeFilteredEdgeReferences<'a, G, I, F: 'a> {
     f: &'a F,
 }
 
-impl<'a, G, I, F> Iterator for NodeFilteredEdgeReferences<'a, G, I, F>
+impl<G, I, F> Iterator for NodeFilteredEdgeReferences<'_, G, I, F>
 where
     F: FilterNode<G::NodeId>,
     G: IntoEdgeReferences,
@@ -295,7 +295,7 @@ pub struct NodeFilteredEdges<'a, G, I, F: 'a> {
     dir: Direction,
 }
 
-impl<'a, G, I, F> Iterator for NodeFilteredEdges<'a, G, I, F>
+impl<G, I, F> Iterator for NodeFilteredEdges<'_, G, I, F>
 where
     F: FilterNode<G::NodeId>,
     G: IntoEdges,
@@ -436,7 +436,7 @@ where
     f: &'a F,
 }
 
-impl<'a, G, F> Iterator for EdgeFilteredNeighbors<'a, G, F>
+impl<G, F> Iterator for EdgeFilteredNeighbors<'_, G, F>
 where
     F: FilterEdge<G::EdgeRef>,
     G: IntoEdges,
@@ -515,7 +515,7 @@ pub struct EdgeFilteredEdges<'a, G, I, F: 'a> {
     f: &'a F,
 }
 
-impl<'a, G, I, F> Iterator for EdgeFilteredEdges<'a, G, I, F>
+impl<G, I, F> Iterator for EdgeFilteredEdges<'_, G, I, F>
 where
     F: FilterEdge<G::EdgeRef>,
     G: IntoEdgeReferences,
@@ -543,7 +543,7 @@ where
     from: G::NodeId,
 }
 
-impl<'a, G, F> Iterator for EdgeFilteredNeighborsDirected<'a, G, F>
+impl<G, F> Iterator for EdgeFilteredNeighborsDirected<'_, G, F>
 where
     F: FilterEdge<G::EdgeRef>,
     G: IntoEdgesDirected,

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -103,7 +103,7 @@ GraphBase! {delegate_impl [['a, G], G, &'a mut G, deref]}
 /// A copyable reference to a graph.
 pub trait GraphRef: Copy + GraphBase {}
 
-impl<'a, G> GraphRef for &'a G where G: GraphBase {}
+impl<G> GraphRef for &G where G: GraphBase {}
 
 trait_template! {
 /// Access to the neighbors of each node
@@ -232,7 +232,7 @@ pub trait EdgeRef: Copy {
     fn id(&self) -> Self::EdgeId;
 }
 
-impl<'a, N, E> EdgeRef for (N, N, &'a E)
+impl<N, E> EdgeRef for (N, N, &E)
 where
     N: Copy,
 {
@@ -290,7 +290,7 @@ where
     }
 }
 
-impl<'a, Id, W> NodeRef for (Id, &'a W)
+impl<Id, W> NodeRef for (Id, &W)
 where
     Id: Copy,
 {

--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -485,7 +485,7 @@ where
     }
 }
 
-impl<'a, C, W: ?Sized> Walker<C> for &'a mut W
+impl<C, W: ?Sized> Walker<C> for &mut W
 where
     W: Walker<C>,
 {

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1044,6 +1044,7 @@ fn oob_index() {
     let a = gr.add_node(0);
     let b = gr.add_node(1);
     gr.remove_node(a);
+    #[allow(clippy::no_effect)]
     gr[b];
 }
 
@@ -1760,7 +1761,7 @@ fn neighbors_selfloops() {
     assert_eq!(&seen_undir, &undir_edges);
 }
 
-fn degree<'a, G>(g: G, node: G::NodeId) -> usize
+fn degree<G>(g: G, node: G::NodeId) -> usize
 where
     G: IntoNeighbors,
     G::NodeId: PartialEq,

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1841,6 +1841,7 @@ fn neighbor_order() {
 fn dot() {
     // test alternate formatting
     #[derive(Debug)]
+    #[allow(unused)]
     struct Record {
         a: i32,
         b: &'static str,

--- a/tests/graph6.rs
+++ b/tests/graph6.rs
@@ -224,6 +224,7 @@ fn test_graph6_for_csr(graph6_str: &str, order: usize, edges: Vec<(u16, u16)>) {
 }
 
 // Test cases format: (graph order, expected ghaph6 representation, graph edges)
+#[allow(clippy::type_complexity)]
 #[rustfmt::skip]
 const TEST_CASES: [(usize, &str, &[(u16, u16)]); 20] = [
     // Empty Graphs

--- a/tests/stable_graph.rs
+++ b/tests/stable_graph.rs
@@ -456,8 +456,8 @@ fn from_min_spanning_tree() {
     for &(a, b) in es.iter() {
         g.add_edge(NodeIndex::new(a), NodeIndex::new(b), ());
     }
-    for i in 0..3 {
-        let _ = g.remove_node(nodes[i]);
+    for &node in nodes.iter().take(3) {
+        let _ = g.remove_node(node);
     }
     let _ = StableGraph::<(), (), Undirected, usize>::from_elements(min_spanning_tree(&g));
 }


### PR DESCRIPTION
This PR satisfies almost all the warnings from Clippy.

In some places, Clippy warnings were indeed fixed, in others `#[allow(...)]` were used.

## A more detailed description:
#### 1. Fix dead code warnings
1. Remove unused method of private trait `WithDummy`
2. Allow unused fields in some structs that implement `Debug` (it may be breaking to just remove these fields).

#### 2. Remove unecessary lifetime annotations
Most cases looks like:

```rust
// Before:
impl<'a, E, Ix: IndexType> visit::EdgeRef for EdgeReference<'a, E, Ix> 

// After
impl<E, Ix: IndexType> visit::EdgeRef for EdgeReference<'_, E, Ix>
```

#### 3. Various minor refactorings that are difficult to categorize

#### 4.  Satisfy Clippy in docs lints

#### 5. Process warnings in tests 

#### 6. Allow clippy::needless_range_loop in benches