### PR TITLE
Release `0.7.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "petgraph"
-version = "0.6.6"
+version = "0.7.0"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 authors = ["bluss", "mitchmindtree"]

--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,5 +1,10 @@
-Version 0.6.6 (2024-12-31)
+Version 0.7.0 (2024-12-31)
 ==========================
+
+- Re-released version 0.6.6 with the correct version number, as it included a major update to an exposed crate (`#664`_).
+
+Version 0.6.6 (2024-12-31 - yanked)
+===================================
 
 - Add graph6 format encoder and decoder (`#658`_)
 - Dynamic Topological Sort algorithm support (`#675`_)


### PR DESCRIPTION
`0.6.6` has been yanked as it contained a major bump of an exposed crate.

closes #712 