### PR TITLE
ci: downgrade hashbrown rather than limiting indexmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - name: MSRV downgrade
+        if: matrix.rust == '1.64.0'
+        run: |
+          cargo generate-lockfile
+          cargo update -p hashbrown --precise 0.15.0
       - name: Build
         run: |
           cargo build --verbose --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ debug = true
 
 [dependencies]
 fixedbitset = { version = "0.5.7", default-features = false }
-indexmap = "~2.5.0"
+indexmap = "2.5.0"
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }


### PR DESCRIPTION
Pinning `indexmap = "~2.5.0"` for MSRV prevents users with more current compilers from using the latest petgraph and indexmap together, even though they would otherwise work fine. Instead, dependencies can just be downgraded as needed for CI testing, and users who need the older compiler support can also manage this in their own lock files.