### PR TITLE
Bugfix: Allow use of 2.7.0 Indexmap for people running newer versions of rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - name: Downgrade dependencies
+        if: matrix.rust == '1.64.0'
+        run: |
+          cargo generate-lockfile
+          cargo update -p hashbrown --precise 0.15.0
       - name: Build
         run: |
           cargo build --verbose --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ debug = true
 
 [dependencies]
 fixedbitset = { version = "0.5.7", default-features = false }
-indexmap = "~2.5.0"
+indexmap = "2.5.0"
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }


### PR DESCRIPTION
This lets indexmap V2.7 work with people running newer versions of rust. I didn't bump the MSRV but instead added a lockfile-change to make 1.64 work, let me know if you would rather bump msrv.

Talked to the maintainer of indexmap here: https://github.com/indexmap-rs/indexmap/issues/366 and this seems to be a good way to support both old and new version users.