### PR TITLE
Make UndirectedAdaptor & inner G pub

### DIFF
--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -64,6 +64,7 @@
 // so that they can use the trait template macros
 pub use self::filter::*;
 pub use self::reversed::*;
+pub use self::undirected_adaptor::*;
 
 #[macro_use]
 mod macros;

--- a/src/visit/undirected_adaptor.rs
+++ b/src/visit/undirected_adaptor.rs
@@ -7,7 +7,7 @@ use crate::Direction;
 
 /// An edge direction removing graph adaptor.
 #[derive(Copy, Clone, Debug)]
-pub struct UndirectedAdaptor<G>(G);
+pub struct UndirectedAdaptor<G>(pub G);
 
 impl<G: GraphRef> GraphRef for UndirectedAdaptor<G> {}
 


### PR DESCRIPTION
Fix the omission mentioned in [comment](https://github.com/petgraph/petgraph/pull/318#issuecomment-2569189542), and also made the internal `G` public by analogy with the `Reversed` adapter.