### PR TITLE
feat: Add methods with recoverable errors for `Graph` and `StableGraph`

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -276,7 +276,7 @@ impl<E, Ix: IndexType> Edge<E, Ix> {
     }
 }
 
-/// The error type for fallible `Graph` operations.
+/// The error type for fallible `Graph` & `StableGraph` operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GraphError {
     /// The Graph is at the maximum number of nodes for its index.
@@ -285,8 +285,8 @@ pub enum GraphError {
     /// The Graph is at the maximum number of edges for its index.
     EdgeIxLimit,
 
-    /// The specified node is missing from the graph.
-    NodeMissed,
+    /// The node with the specified index is missing from the graph.
+    NodeMissed(usize),
 
     /// Node indices out of bounds.
     NodeOutBounds,
@@ -303,7 +303,9 @@ impl fmt::Display for GraphError {
                 f,
                 "The Graph is at the maximum number of edges for its index."
             ),
-            GraphError::NodeMissed => write!(f, "The specified node is missing from the graph."),
+            GraphError::NodeMissed(i) => {
+                write!(f, "The node with index {i} is missing from the graph.")
+            }
             GraphError::NodeOutBounds => write!(f, "Node indices out of bounds."),
         }
     }

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -679,6 +679,7 @@ where
     /// connected to `a` (and `b`, if the graph edges are undirected).
     ///
     /// **Panics** if any of the nodes doesn't exist.
+    /// or the graph is at the maximum number of edges for its index (when adding new edge)
     pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
         self.try_update_edge(a, b, weight).unwrap()
     }

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -292,7 +292,11 @@ pub enum GraphError {
     NodeOutBounds,
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GraphError {}
+
+#[cfg(not(feature = "std"))]
+impl core::error::Error for GraphError {}
 
 impl fmt::Display for GraphError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -680,13 +680,34 @@ where
     ///
     /// **Panics** if any of the nodes doesn't exist.
     pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
+        self.try_update_edge(a, b, weight).unwrap()
+    }
+
+    /// Try to add or update an edge from `a` to `b`.
+    /// If the edge already exists, its weight is updated.
+    ///
+    /// Return the index of the affected edge.
+    ///
+    /// Computes in **O(e')** time, where **e'** is the number of edges
+    /// connected to `a` (and `b`, if the graph edges are undirected).
+    ///
+    /// Possible errors:
+    /// - [`GraphError::NodeOutBounds`] - if any of the nodes don't exist.<br>
+    /// - [`GraphError::EdgeIxLimit`] if the Graph is at the maximum number of edges for its index
+    ///     type (N/A if usize).
+    pub fn try_update_edge(
+        &mut self,
+        a: NodeIndex<Ix>,
+        b: NodeIndex<Ix>,
+        weight: E,
+    ) -> Result<EdgeIndex<Ix>, GraphError> {
         if let Some(ix) = self.find_edge(a, b) {
             if let Some(ed) = self.edge_weight_mut(ix) {
                 *ed = weight;
-                return ix;
+                return Ok(ix);
             }
         }
-        self.add_edge(a, b, weight)
+        self.try_add_edge(a, b, weight)
     }
 
     /// Access the weight for edge `e`.

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -292,6 +292,8 @@ pub enum GraphError {
     NodeOutBounds,
 }
 
+impl std::error::Error for GraphError {}
+
 impl fmt::Display for GraphError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -557,7 +557,7 @@ where
     ///
     /// Return the index of the new node.
     ///
-    /// **Panics** if the Graph is at the maximum number of nodes for its index
+    /// **Panics** if the `Graph` is at the maximum number of nodes for its index
     /// type (N/A if usize).
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
         self.try_add_node(weight).unwrap()
@@ -569,7 +569,7 @@ where
     ///
     /// Return the index of the new node.
     ///
-    /// Returns `Err` if the Graph is at the maximum number of nodes for its index.
+    /// Return [`GraphError::NodeIxLimit`] if the `Graph` is at the maximum number of nodes for its index.
     pub fn try_add_node(&mut self, weight: N) -> Result<NodeIndex<Ix>, GraphError> {
         let node = Node {
             weight,
@@ -609,7 +609,7 @@ where
     /// Computes in **O(1)** time.
     ///
     /// **Panics** if any of the nodes don't exist.<br>
-    /// **Panics** if the Graph is at the maximum number of edges for its index
+    /// **Panics** if the `Graph` is at the maximum number of edges for its index
     /// type (N/A if usize).
     ///
     /// **Note:** `Graph` allows adding parallel (“duplicate”) edges. If you want
@@ -631,7 +631,7 @@ where
     ///
     /// Possible errors:
     /// - [`GraphError::NodeOutBounds`] - if any of the nodes don't exist.<br>
-    /// - [`GraphError::EdgeIxLimit`] if the Graph is at the maximum number of edges for its index
+    /// - [`GraphError::EdgeIxLimit`] if the `Graph` is at the maximum number of edges for its index
     ///     type (N/A if usize).
     ///
     /// Note: Graph allows adding parallel (“duplicate”) edges. If you want
@@ -694,7 +694,7 @@ where
     ///
     /// Possible errors:
     /// - [`GraphError::NodeOutBounds`] - if any of the nodes don't exist.<br>
-    /// - [`GraphError::EdgeIxLimit`] if the Graph is at the maximum number of edges for its index
+    /// - [`GraphError::EdgeIxLimit`] if the `Graph` is at the maximum number of edges for its index
     ///     type (N/A if usize).
     pub fn try_update_edge(
         &mut self,

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -269,7 +269,7 @@ where
     ///
     /// Return the index of the new node.
     ///
-    /// Returns `Err` if the `StableGraph` is at the maximum number of nodes for its index.
+    /// Return [`GraphError::NodeIxLimit`] if the `StableGraph` is at the maximum number of nodes for its index.
     pub fn try_add_node(&mut self, weight: N) -> Result<NodeIndex<Ix>, GraphError> {
         if self.free_node != NodeIndex::end() {
             let node_idx = self.free_node;
@@ -368,7 +368,7 @@ where
         res.unwrap()
     }
 
-    /// Add an edge from `a` to `b` to the graph, with its associated
+    /// Try to add an edge from `a` to `b` to the graph, with its associated
     /// data `weight`.
     ///
     /// Return the index of the new edge.

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -471,13 +471,35 @@ where
     /// Computes in **O(e')** time, where **e'** is the number of edges
     /// connected to `a` (and `b`, if the graph edges are undirected).
     ///
-    /// **Panics** if any of the nodes don't exist.
+    /// **Panics** if any of the nodes don't exist
+    /// or the stable graph is at the maximum number of edges for its index (when adding new edge).
     pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
+        self.try_update_edge(a, b, weight).unwrap()
+    }
+
+    /// Try to add or update an edge from `a` to `b`.
+    /// If the edge already exists, its weight is updated.
+    ///
+    /// Return the index of the affected edge.
+    ///
+    /// Computes in **O(e')** time, where **e'** is the number of edges
+    /// connected to `a` (and `b`, if the graph edges are undirected).
+    ///
+    /// Possible errors:
+    /// - [`GraphError::NodeMissed`] - if any of the nodes don't exist.<br>
+    /// - [`GraphError::EdgeIxLimit`] if the `StableGraph` is at the maximum number of edges for its index
+    ///     type (N/A if usize).
+    pub fn try_update_edge(
+        &mut self,
+        a: NodeIndex<Ix>,
+        b: NodeIndex<Ix>,
+        weight: E,
+    ) -> Result<EdgeIndex<Ix>, GraphError> {
         if let Some(ix) = self.find_edge(a, b) {
             self[ix] = weight;
-            return ix;
+            return Ok(ix);
         }
-        self.add_edge(a, b, weight)
+        self.try_add_edge(a, b, weight)
     }
 
     /// Remove an edge and return its edge weight, or `None` if it didn't exist.

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -359,11 +359,10 @@ where
     /// **Note:** `StableGraph` allows adding parallel (“duplicate”) edges.
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
         let res = self.try_add_edge(a, b, weight);
-        if res == Err(GraphError::NodeMissed) {
+        if let Err(GraphError::NodeMissed(i)) = res {
             panic!(
                 "StableGraph::add_edge: node index {} is not a node in the graph",
-                //i
-                0 // Temporary stub
+                i
             );
         }
         res.unwrap()
@@ -439,8 +438,8 @@ where
                     }
                 }
             };
-            if wrong_index.is_some() {
-                return Err(GraphError::NodeMissed);
+            if let Some(i) = wrong_index {
+                return Err(GraphError::NodeMissed(i));
             }
             self.edge_count += 1;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ pub mod graph {
     pub use crate::graph_impl::{
         edge_index, node_index, DefaultIx, DiGraph, Edge, EdgeIndex, EdgeIndices, EdgeReference,
         EdgeReferences, EdgeWeightsMut, Edges, EdgesConnecting, Externals, Frozen, Graph,
-        GraphIndex, IndexType, Neighbors, Node, NodeIndex, NodeIndices, NodeReferences,
+        GraphError, GraphIndex, IndexType, Neighbors, Node, NodeIndex, NodeIndices, NodeReferences,
         NodeWeightsMut, UnGraph, WalkNeighbors,
     };
 }

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -397,6 +397,32 @@ fn update_edge() {
 }
 
 #[test]
+fn try_update_edge() {
+    {
+        let mut gr = Graph::new();
+        let a = gr.add_node("a");
+        let b = gr.add_node("b");
+        let e = gr.try_update_edge(a, b, 1).unwrap();
+        let f = gr.try_update_edge(a, b, 2).unwrap();
+        let _ = gr.try_update_edge(b, a, 3).unwrap();
+        assert_eq!(gr.edge_count(), 2);
+        assert_eq!(e, f);
+        assert_eq!(*gr.edge_weight(f).unwrap(), 2);
+    }
+
+    {
+        let mut gr = Graph::new_undirected();
+        let a = gr.add_node("a");
+        let b = gr.add_node("b");
+        let e = gr.try_update_edge(a, b, 1).unwrap();
+        let f = gr.try_update_edge(b, a, 2).unwrap();
+        assert_eq!(gr.edge_count(), 1);
+        assert_eq!(e, f);
+        assert_eq!(*gr.edge_weight(f).unwrap(), 2);
+    }
+}
+
+#[test]
 fn dijk() {
     let mut g = Graph::new_undirected();
     let a = g.add_node("A");

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -2468,3 +2468,19 @@ fn test_try_add_node() {
     }
     assert_eq!(graph.try_add_node(()), Err(GraphError::NodeIxLimit));
 }
+
+#[test]
+fn test_try_add_edge() {
+    let mut graph = Graph::<(), (), Directed, u8>::with_capacity(1, 512);
+    let a = graph.try_add_node(()).unwrap();
+
+    assert_eq!(
+        graph.try_add_edge(a.into(), 10.into(), ()),
+        Err(GraphError::NodeOutBounds)
+    );
+    for i in 0..255 {
+        assert_eq!(graph.try_add_edge(a, a, ()), Ok(i.into()));
+    }
+
+    assert_eq!(graph.try_add_edge(a, a, ()), Err(GraphError::EdgeIxLimit));
+}

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -2501,7 +2501,7 @@ fn test_try_add_edge() {
     let a = graph.try_add_node(()).unwrap();
 
     assert_eq!(
-        graph.try_add_edge(a.into(), 10.into(), ()),
+        graph.try_add_edge(a, 10.into(), ()),
         Err(GraphError::NodeOutBounds)
     );
     for i in 0..255 {

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -14,7 +14,7 @@ use petgraph::algo::{
 };
 
 use petgraph::graph::node_index as n;
-use petgraph::graph::IndexType;
+use petgraph::graph::{GraphError, IndexType};
 
 use petgraph::algo::{astar, dijkstra, DfsSpace};
 use petgraph::visit::{
@@ -2458,4 +2458,13 @@ fn test_dominators_simple_fast() {
         None,
         "nodes that aren't reachable from the root do not have an idom"
     );
+}
+
+#[test]
+fn test_try_add_node() {
+    let mut graph = Graph::<(), (), Directed, u8>::with_capacity(256, 0);
+    for i in 0..255 {
+        assert_eq!(graph.try_add_node(()), Ok(i.into()));
+    }
+    assert_eq!(graph.try_add_node(()), Err(GraphError::NodeIxLimit));
 }


### PR DESCRIPTION
## Methods with recoverable errors
This PR provides `try_add_node`, `try_add_edge` and `try_update_edge` for `Graph` and `StableGraph`.

The `GraphError` type has been added to represent possible errors:
```rust
/// The error type for fallible `Graph` & `StableGraph` operations.
#[derive(Debug, Clone, Copy, PartialEq, Eq)]
pub enum GraphError {
    /// The Graph is at the maximum number of nodes for its index.
    NodeIxLimit,

    /// The Graph is at the maximum number of edges for its index.
    EdgeIxLimit,

    /// The node with the specified index is missing from the graph.
    NodeMissed(usize),

    /// Node indices out of bounds.
    NodeOutBounds,
}
```
To represent potential errors in `MatrixGraph` and other storages some other Errors will be needed due to the significant differences in provided APIs.

## Rewrite fallible methods with its `try` counterparts
To avoid code duplication, I rewrote `add_node`, `add_edge` and `update_edge` for both `Graph` and `StableGraph` using `try` counterparts. 
This changed the set of possible panics, but I tried to keep the custom panic messages:
```rust
panic!(
    "StableGraph::add_edge: node index {} is not a node in the graph",
    i
);

panic!("Graph::add_edge: node indices out of bounds")
```