### PR TITLE
`MatrixGraph` methods with recoverable errors

### DIFF
--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -494,6 +494,13 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         &self.nodes[a.index()]
     }
 
+    /// Try to access the weight for node `a`.
+    ///
+    /// Return `None` if the node doesn't exist.
+    pub fn get_node_weight(&self, a: NodeIndex<Ix>) -> Option<&N> {
+        self.nodes.elements.get(a.index())?.as_ref()
+    }
+
     /// Access the weight for node `a`, mutably.
     ///
     /// Also available with indexing syntax: `&mut graph[a]`.
@@ -501,6 +508,13 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     /// **Panics** if the node doesn't exist.
     pub fn node_weight_mut(&mut self, a: NodeIndex<Ix>) -> &mut N {
         &mut self.nodes[a.index()]
+    }
+
+    /// Try to access the weight for node `a`, mutably.
+    ///
+    /// Return `None` if the node doesn't exist.
+    pub fn get_node_weight_mut(&mut self, a: NodeIndex<Ix>) -> Option<&mut N> {
+        self.nodes.elements.get_mut(a.index())?.as_mut()
     }
 
     /// Access the weight for edge `e`.

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -387,12 +387,16 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         old_weight.unwrap()
     }
 
-    /// Return true if there is an edge between `a` and `b`.
+    /// Return `true` if there is an edge between `a` and `b`.
     ///
-    /// **Panics** if any of the nodes don't exist.
+    /// If any of the nodes don't exist - returns `false`.
     pub fn has_edge(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
         if let Some(p) = self.to_edge_position(a, b) {
-            return !self.node_adjacencies[p].is_null();
+            return self
+                .node_adjacencies
+                .get(p)
+                .map(|e| !e.is_null())
+                .unwrap_or(false);
         }
         false
     }
@@ -1353,6 +1357,20 @@ mod tests {
         assert!(g.has_edge(n2, n1));
         assert!(g.has_edge(n2, n3));
         assert!(g.has_edge(n2, n4));
+    }
+
+    #[test]
+    fn test_has_edge() {
+        let mut g = MatrixGraph::new();
+        let a = g.add_node('a');
+        let b = g.add_node('b');
+        let c = g.add_node('c');
+        g.add_edge(a, b, ());
+        g.add_edge(b, c, ());
+        assert!(g.has_edge(a, b));
+        assert!(g.has_edge(b, c));
+        assert!(!g.has_edge(a, c));
+        assert!(!g.has_edge(10.into(), 100.into())); // Non-existent nodes.
     }
 
     #[test]

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 
 use std::cmp;
+use std::fmt;
 use std::mem;
 
 use indexmap::IndexSet;
@@ -185,6 +186,37 @@ pub fn node_index(ax: usize) -> NodeIndex {
     NodeIndex::new(ax)
 }
 
+/// The error type for fallible `MatrixGraph` operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatrixError {
+    /// The `MatrixGraph` is at the maximum number of nodes for its index.
+    NodeIxLimit,
+
+    /// The node with the specified index is missing from the graph.
+    NodeMissed(usize),
+
+    /// Edge between nodes with specified indices already exist in `MatrixGraph`.
+    EdgeAlreadyExist(usize, usize),
+}
+
+impl fmt::Display for MatrixError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MatrixError::NodeIxLimit => write!(
+                f,
+                "The MatrixGraph is at the maximum number of nodes for its index"
+            ),
+
+            MatrixError::NodeMissed(i) => {
+                write!(f, "The node with index {i} is missing from the graph.")
+            }
+            MatrixError::EdgeAlreadyExist(a, b) => {
+                write!(f, "The edge between nodes {a} and {b} already exists.")
+            }
+        }
+    }
+}
+
 /// `MatrixGraph<N, E, Ty, Null>` is a graph datastructure using an adjacency matrix
 /// representation.
 ///
@@ -357,6 +389,25 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         old_weight.into()
     }
 
+    /// try to update the edge from `a` to `b`, with its associated data `weight`.
+    ///
+    /// Return the previous data, if any.
+    ///
+    /// Computes in **O(1)** time, best case.
+    /// Computes in **O(|V|^2)** time, worst case (matrix needs to be re-allocated).
+    ///
+    /// Possible errors:
+    /// - [`MatrixError::NodeMissed`] if any of the nodes don't exist.
+    pub fn try_update_edge(
+        &mut self,
+        a: NodeIndex<Ix>,
+        b: NodeIndex<Ix>,
+        weight: E,
+    ) -> Result<Option<E>, MatrixError> {
+        self.assert_node_bounds(a, b)?;
+        Ok(self.update_edge(a, b, weight))
+    }
+
     /// Add an edge from `a` to `b` to the graph, with its associated
     /// data `weight`.
     ///
@@ -524,6 +575,16 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
                 self.add_node(N::default());
             }
             self.add_edge(source, target, weight);
+        }
+    }
+
+    fn assert_node_bounds(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Result<(), MatrixError> {
+        if a.index() >= self.node_capacity {
+            Err(MatrixError::NodeMissed(a.index()))
+        } else if b.index() >= self.node_capacity {
+            Err(MatrixError::NodeMissed(b.index()))
+        } else {
+            Ok(())
         }
     }
 }
@@ -1827,6 +1888,24 @@ mod tests {
         assert_eq!(
             crate::algo::kosaraju_scc(&g),
             [[node_index(2)], [node_index(0)]]
+        );
+    }
+
+    #[test]
+    fn test_try_update_edge() {
+        let mut g = MatrixGraph::<char, u32>::new();
+        let a = g.add_node('a');
+        let b = g.add_node('b');
+        let c = g.add_node('c');
+        g.add_edge(a, b, 1);
+        g.add_edge(b, c, 2);
+        assert_eq!(g.try_update_edge(a, b, 10), Ok(Some(1)));
+        assert_eq!(g.try_update_edge(a, b, 100), Ok(Some(10)));
+        assert_eq!(g.try_update_edge(a, c, 33), Ok(None));
+        assert_eq!(g.try_update_edge(a, c, 66), Ok(Some(33)));
+        assert_eq!(
+            g.try_update_edge(10.into(), 20.into(), 5),
+            Err(MatrixError::NodeMissed(10))
         );
     }
 }

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -389,7 +389,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         old_weight.into()
     }
 
-    /// try to update the edge from `a` to `b`, with its associated data `weight`.
+    /// Try to update the edge from `a` to `b`, with its associated data `weight`.
     ///
     /// Return the previous data, if any.
     ///
@@ -422,6 +422,26 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) {
         let old_edge_id = self.update_edge(a, b, weight);
         assert!(old_edge_id.is_none());
+    }
+
+    /// Add or update edge from `a` to `b` to the graph, with its associated
+    /// data `weight`.
+    ///
+    /// Return the previous data, if any.
+    ///
+    /// Computes in **O(1)** time, best case.
+    /// Computes in **O(|V|^2)** time, worst case (matrix needs to be re-allocated).
+    ///
+    /// Possible errors:
+    /// - [`MatrixError::NodeMissed`] if any of the nodes don't exist.
+    pub fn add_or_update_edge(
+        &mut self,
+        a: NodeIndex<Ix>,
+        b: NodeIndex<Ix>,
+        weight: E,
+    ) -> Result<Option<E>, MatrixError> {
+        self.extend_capacity_for_edge(a, b);
+        self.try_update_edge(a, b, weight)
     }
 
     /// Remove the edge from `a` to `b` to the graph.
@@ -1907,5 +1927,20 @@ mod tests {
             g.try_update_edge(10.into(), 20.into(), 5),
             Err(MatrixError::NodeMissed(10))
         );
+    }
+
+    #[test]
+    fn test_add_or_update_edge() {
+        let mut g = MatrixGraph::<char, u32>::new();
+        let a = g.add_node('a');
+        let b = g.add_node('b');
+        let c = g.add_node('c');
+        assert_eq!(g.add_or_update_edge(a, b, 1), Ok(None));
+        assert_eq!(g.add_or_update_edge(b, c, 2), Ok(None));
+        assert_eq!(g.add_or_update_edge(a, b, 10), Ok(Some(1)));
+        assert_eq!(g.add_or_update_edge(a, c, 33), Ok(None));
+        assert_eq!(g.add_or_update_edge(10.into(), 20.into(), 5), Ok(None));
+        assert!(g.has_edge(10.into(), 20.into()));
+        assert!(g.node_capacity >= 20);
     }
 }

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -531,6 +531,14 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
             .expect("No edge found between the nodes.")
     }
 
+    /// Access the weight for edge from `a` to `b`.
+    ///
+    /// Return `None` if the edge doesn't exist.
+    pub fn get_edge_weight(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<&E> {
+        let p = self.to_edge_position(a, b)?;
+        self.node_adjacencies.get(p)?.as_ref()
+    }
+
     /// Access the weight for edge `e`, mutably.
     ///
     /// Also available with indexing syntax: `&mut graph[e]`.
@@ -543,6 +551,14 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         self.node_adjacencies[p]
             .as_mut()
             .expect("No edge found between the nodes.")
+    }
+
+    /// Access the weight for edge from `a` to `b`, mutably.
+    ///
+    /// Return `None` if the edge doesn't exist.
+    pub fn get_edge_weight_mut(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<&mut E> {
+        let p = self.to_edge_position(a, b)?;
+        self.node_adjacencies.get_mut(p)?.as_mut()
     }
 
     /// Return an iterator of all nodes with an edge starting from `a`.

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -194,9 +194,6 @@ pub enum MatrixError {
 
     /// The node with the specified index is missing from the graph.
     NodeMissed(usize),
-
-    /// Edge between nodes with specified indices already exist in `MatrixGraph`.
-    EdgeAlreadyExist(usize, usize),
 }
 
 impl fmt::Display for MatrixError {
@@ -209,9 +206,6 @@ impl fmt::Display for MatrixError {
 
             MatrixError::NodeMissed(i) => {
                 write!(f, "The node with index {i} is missing from the graph.")
-            }
-            MatrixError::EdgeAlreadyExist(a, b) => {
-                write!(f, "The edge between nodes {a} and {b} already exists.")
             }
         }
     }
@@ -328,6 +322,22 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
     /// **Panics** if the MatrixGraph is at the maximum number of nodes for its index type.
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
         NodeIndex::new(self.nodes.add(weight))
+    }
+
+    /// Try to add a node (also called vertex) with associated data `weight` to the graph.
+    ///
+    /// Computes in **O(1)** time.
+    ///
+    /// Return the index of the new node.
+    ///
+    /// Possible errors:
+    /// - [`MatrixError::NodeIxLimit`] if the `MatrixGraph` is at the maximum number of nodes for its index type.
+    pub fn try_add_node(&mut self, weight: N) -> Result<NodeIndex<Ix>, MatrixError> {
+        let node_idx = NodeIndex::<Ix>::new(self.nodes.len());
+        if !(<Ix as IndexType>::max().index() == !0 || NodeIndex::end() != node_idx) {
+            return Err(MatrixError::NodeIxLimit);
+        }
+        Ok(NodeIndex::new(self.nodes.add(weight)))
     }
 
     /// Remove `a` from the graph.
@@ -1404,6 +1414,7 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> Build
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use crate::{Incoming, Outgoing};
 
@@ -1998,5 +2009,14 @@ mod tests {
         assert_eq!(g.try_remove_edge(a, b), Some(1));
         assert_eq!(g.try_remove_edge(a, b), None);
         assert_eq!(g.try_remove_edge(a, c), None);
+    }
+
+    #[test]
+    fn test_try_add_node() {
+        let mut graph = MatrixGraph::<(), u32, Directed, Option<u32>, u8>::with_capacity(255);
+        for i in 0..255 {
+            assert_eq!(graph.try_add_node(()), Ok(i.into()));
+        }
+        assert_eq!(graph.try_add_node(()), Err(MatrixError::NodeIxLimit));
     }
 }

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -458,6 +458,19 @@ impl<N, E, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType>
         old_weight.unwrap()
     }
 
+    /// Try to remove the edge from `a` to `b`.
+    ///
+    /// Return old value if present.
+    pub fn try_remove_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<E> {
+        let p = self.to_edge_position(a, b)?;
+        if let Some(entry) = self.node_adjacencies.get_mut(p) {
+            let old_weight = mem::take(entry).into()?;
+            self.nb_edges -= 1;
+            return Some(old_weight);
+        }
+        None
+    }
+
     /// Return `true` if there is an edge between `a` and `b`.
     ///
     /// If any of the nodes don't exist - returns `false`.
@@ -1942,5 +1955,18 @@ mod tests {
         assert_eq!(g.add_or_update_edge(10.into(), 20.into(), 5), Ok(None));
         assert!(g.has_edge(10.into(), 20.into()));
         assert!(g.node_capacity >= 20);
+    }
+
+    #[test]
+    fn test_remove_edge() {
+        let mut g = MatrixGraph::<char, u32>::new();
+        let a = g.add_node('a');
+        let b = g.add_node('b');
+        let c = g.add_node('c');
+        g.add_edge(a, b, 1);
+        g.add_edge(b, c, 2);
+        assert_eq!(g.try_remove_edge(a, b), Some(1));
+        assert_eq!(g.try_remove_edge(a, b), None);
+        assert_eq!(g.try_remove_edge(a, c), None);
     }
 }


### PR DESCRIPTION
## Provide methods for checked work with `MatrixGraph`

PR adds the `MatrixGraph` methods described in the [comment](https://github.com/petgraph/petgraph/issues/654#issuecomment-2571224471).
The purpose of the proposed changes is to allow potential errors to be handled instead of receiving multiple panics.

To represent possible errors I add the `MatrixError` enum:
```rust
/// The error type for fallible `MatrixGraph` operations.
#[derive(Debug, Clone, Copy, PartialEq, Eq)]
pub enum MatrixError {
    /// The `MatrixGraph` is at the maximum number of nodes for its index.
    NodeIxLimit,

    /// The node with the specified index is missing from the graph.
    NodeMissed(usize),
}
```

- Some methods (where appropriate) return `Option` instead of `Result`.
- `MatrixGraph::has_edge` has been rewritten to avoid panic.

### Full list of added methods:
```rust
pub fn try_add_node(&mut self, weight: N) -> Result<NodeIndex<Ix>, MatrixError>

pub fn try_update_edge(
        &mut self,
        a: NodeIndex<Ix>,
        b: NodeIndex<Ix>,
        weight: E,
    ) -> Result<Option<E>, MatrixError>

pub fn try_remove_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<E>

pub fn add_or_update_edge(
        &mut self,
        a: NodeIndex<Ix>,
        b: NodeIndex<Ix>,
        weight: E,
    ) -> Result<Option<E>, MatrixError>

pub fn get_node_weight(&self, a: NodeIndex<Ix>) -> Option<&N>

pub fn get_node_weight_mut(&mut self, a: NodeIndex<Ix>) -> Option<&mut N>

pub fn get_edge_weight(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<&E>

pub fn get_edge_weight_mut(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> Option<&mut E>
```