### PR TITLE
feat!: Add `from_f32/64` methods for `Float`, `Unit`, and `Bounded` measures

### DIFF
--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -734,6 +734,8 @@ impl<M> Measure for M where M: Debug + PartialOrd + Add<M, Output = M> + Default
 pub trait FloatMeasure: Measure + Copy {
     fn zero() -> Self;
     fn infinite() -> Self;
+    fn from_f32(val: f32) -> Self;
+    fn from_f64(val: f64) -> Self;
 }
 
 impl FloatMeasure for f32 {
@@ -743,6 +745,12 @@ impl FloatMeasure for f32 {
     fn infinite() -> Self {
         1. / 0.
     }
+    fn from_f32(val: f32) -> Self {
+        val
+    }
+    fn from_f64(val: f64) -> Self {
+        val as f32
+    }
 }
 
 impl FloatMeasure for f64 {
@@ -751,6 +759,12 @@ impl FloatMeasure for f64 {
     }
     fn infinite() -> Self {
         1. / 0.
+    }
+    fn from_f32(val: f32) -> Self {
+        val as f64
+    }
+    fn from_f64(val: f64) -> Self {
+        val
     }
 }
 

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -837,6 +837,8 @@ pub trait UnitMeasure:
     fn one() -> Self;
     fn from_usize(nb: usize) -> Self;
     fn default_tol() -> Self;
+    fn from_f32(val: f32) -> Self;
+    fn from_f64(val: f64) -> Self;
 }
 
 macro_rules! impl_unit_measure(
@@ -858,6 +860,13 @@ macro_rules! impl_unit_measure(
                     1e-6 as $t
                 }
 
+                fn from_f32(val: f32) -> Self {
+                    val as $t
+                }
+
+                fn from_f64(val: f64) -> Self {
+                    val as $t
+                }
             }
 
         )*

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -772,6 +772,8 @@ pub trait BoundedMeasure: Measure + core::ops::Sub<Self, Output = Self> {
     fn min() -> Self;
     fn max() -> Self;
     fn overflowing_add(self, rhs: Self) -> (Self, bool);
+    fn from_f32(val: f32) -> Self;
+    fn from_f64(val: f64) -> Self;
 }
 
 macro_rules! impl_bounded_measure_integer(
@@ -788,6 +790,14 @@ macro_rules! impl_bounded_measure_integer(
 
                 fn overflowing_add(self, rhs: Self) -> (Self, bool) {
                     self.overflowing_add(rhs)
+                }
+
+                fn from_f32(val: f32) -> Self {
+                    val as $t
+                }
+
+                fn from_f64(val: f64) -> Self {
+                    val as $t
                 }
             }
         )*
@@ -816,6 +826,14 @@ macro_rules! impl_bounded_measure_float(
                     let underflow = !overflow && self < Self::default() && rhs < Self::default() && self < $t::MIN - rhs;
 
                     (self + rhs, overflow || underflow)
+                }
+
+                fn from_f32(val: f32) -> Self {
+                    val as $t
+                }
+
+                fn from_f64(val: f64) -> Self {
+                    val as $t
                 }
             }
         )*


### PR DESCRIPTION
Add two required methods for `FloatMeasure`, `BoundedMeasure` and `UnitMeasure` traits:
```rust
/// A floating-point measure.
pub trait FloatMeasure: Measure + Copy {
    fn zero() -> Self;
    fn infinite() -> Self;

    // NEW:
    fn from_f32(val: f32) -> Self;
    fn from_f64(val: f64) -> Self;
}
```

### Motivation
This will add flexibility in programming operations with edge weights and make possible the behavior requested in issue #723.


---
BREAKING CHANGE:

This PR adds new required methods to the public trait