### PR TITLE
ci: Require conventional commits tag in PR titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+  -- Thanks for contributing to `petgraph`! 
+  --
+  -- We require PR titles to follow the Conventional Commits specification,
+  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
+  -- changelogs and follow semantic versioning.
+  --
+  -- Start the PR title with one of the following:
+  --  * `feat:` for new features
+  --  * `fix:` for bug fixes
+  --  * `refactor:` for code refactors
+  --  * `docs:` for documentation changes
+  --  * `test:` for test changes
+  --  * `perf:` for performance improvements
+  --  * `revert:` for reverting changes
+  --  * `ci:` for CI/CD changes
+  --  * `chore:` for changes that don't fit in any of the above categories
+  -- The last two categories will not be included in the changelog.
+  --
+  -- If your PR includes a breaking change, please add a `!` after the type
+  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
+  -- the necessary changes for users to update their code.
+  --
+  -->

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,171 @@
+name: Check Conventional Commits format
+
+on:
+  # Re-check whenever the PR is modified
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+  # The action does not support running on merge_group events,
+  # but if the check succeeds in the PR there is no need to check it again.
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  main:
+    name: Validate Conventional Commit PR title
+    runs-on: ubuntu-latest
+    outputs:
+      # Whether the PR title indicates a breaking change.
+      breaking: ${{ steps.breaking.outputs.breaking }}
+      # Whether the PR body contains a "BREAKING CHANGE:" footer describing the breaking change.
+      has_breaking_footer: ${{ steps.breaking.outputs.has_breaking_footer }}
+    # The following steps are only run on pull_request_target events. We add the
+    # `if` statements to each individual step since we want the job to still
+    # succeed in merge queues.
+    steps:
+      - name: Validate the PR title format
+        uses: amannn/action-semantic-pull-request@v5
+        if: github.event_name == 'pull_request_target'
+        id: lint_pr_title
+        with:
+          # Configure which types are allowed (newline-delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            ci
+            chore
+            revert
+          # Configure which scopes are allowed (newline-delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
+          #scopes: |
+          #  .*
+          # Configure that a scope must always be provided.
+          requireScope: false
+
+      # `action-semantic-pull-request` does not parse the title, so it cannot
+      # detect if it is marked as a breaking change.
+      #
+      # Since at this point we know the PR title is a valid conventional commit,
+      # we can use a simple regex that looks for a '!:' sequence. It could be
+      # more complex, but we don't care about false positives.
+      - name: Check for breaking change flag
+        if: github.event_name == 'pull_request_target'
+        id: breaking
+        run: |
+          if [[ "${PR_TITLE}" =~ ^.*\!:.*$ ]]; then
+            echo "breaking=true" >> $GITHUB_OUTPUT
+          else
+            echo "breaking=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Check if the PR comment has a "BREAKING CHANGE:" footer describing
+          # the breaking change.
+          if [[ "${PR_BODY}" != *"BREAKING CHANGE:"* ]]; then
+            echo "has_breaking_footer=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_breaking_footer=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+
+      # Post a help comment if the PR title indicates a breaking change but does
+      # not contain a "BREAKING CHANGE:" footer.
+      - name: Require "BREAKING CHANGE:" footer for breaking changes
+        id: breaking-comment
+        if: ${{ github.event_name == 'pull_request_target' && steps.breaking.outputs.breaking == 'true' && steps.breaking.outputs.has_breaking_footer == 'false' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋
+
+            It looks like your proposed title indicates a breaking change. If that's the case,
+            please make sure to include a "BREAKING CHANGE:" footer in the body of the pull request
+            describing the breaking change and any migration instructions.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fail if the footer is required but missing
+        if: ${{ github.event_name == 'pull_request_target' && steps.breaking.outputs.breaking == 'true' && steps.breaking.outputs.has_breaking_footer == 'false' }}
+        run: exit 1
+
+      # PR titles marked as `rfc:` or `RFC:` are still errors, but we special case and print a different message,
+      # reminding the author to change the title before merging.
+      - name: Check for RFC tag
+        if: always()  && github.event_name == 'pull_request_target' && (steps.lint_pr_title.outputs.error_message != null)
+        id: rfc-tag
+        run: |
+          shopt -s nocasematch
+          if [[ "${PR_TITLE}" =~ ^rfc:.*$ ]]; then
+            echo "rfc=true" >> $GITHUB_OUTPUT
+          else
+            echo "rfc=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+      - name: Post comment if the PR is an RFC
+        id: rfc-tag-comment
+        if: ${{ github.event_name == 'pull_request_target' && steps.rfc-tag.outputs.rfc == 'true' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋
+
+            This PR is marked as an RFC. Please make sure to change the conventional commit type before merging.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Terminate the workflow after posting the RFC comment
+        if: ${{ github.event_name == 'pull_request_target' && steps.rfc-tag.outputs.rfc == 'true' }}
+        run: exit 1
+
+      - name: Post a comment if the PR badly formatted
+        uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && github.event_name == 'pull_request_target'  && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
+            and it looks like your proposed title needs to be adjusted.
+
+            Your title should look like this. The scope field is optional.
+            ```
+            <type>(<scope>): <description>
+            ```
+
+            If the PR includes a breaking change, mark it with an exclamation mark:
+            ```
+            <type>!: <description>
+            ```
+            and include a "BREAKING CHANGE:" footer in the body of the pull request.
+
+            Details:
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+      # Delete previous comments when the issues have been resolved
+      # This step doesn't run if any of the previous checks fails.
+      - name: Delete previous comments
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request_target'
+        with:
+          header: pr-title-lint-error
+          delete: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -40,7 +40,6 @@ jobs:
             feat
             fix
             docs
-            style
             refactor
             perf
             test
@@ -92,41 +91,10 @@ jobs:
           message: |
             Hey there and thank you for opening this pull request! 👋
 
-            It looks like your proposed title indicates a breaking change. If that's the case,
-            please make sure to include a "BREAKING CHANGE:" footer in the body of the pull request
-            describing the breaking change and any migration instructions.
+            It looks like your proposed title indicates a breaking change. If that's the case, please make sure to include a "BREAKING CHANGE:" footer in the body of the pull request describing the breaking change and any migration instructions.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Fail if the footer is required but missing
         if: ${{ github.event_name == 'pull_request_target' && steps.breaking.outputs.breaking == 'true' && steps.breaking.outputs.has_breaking_footer == 'false' }}
-        run: exit 1
-
-      # PR titles marked as `rfc:` or `RFC:` are still errors, but we special case and print a different message,
-      # reminding the author to change the title before merging.
-      - name: Check for RFC tag
-        if: always()  && github.event_name == 'pull_request_target' && (steps.lint_pr_title.outputs.error_message != null)
-        id: rfc-tag
-        run: |
-          shopt -s nocasematch
-          if [[ "${PR_TITLE}" =~ ^rfc:.*$ ]]; then
-            echo "rfc=true" >> $GITHUB_OUTPUT
-          else
-            echo "rfc=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-      - name: Post comment if the PR is an RFC
-        id: rfc-tag-comment
-        if: ${{ github.event_name == 'pull_request_target' && steps.rfc-tag.outputs.rfc == 'true' }}
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: pr-title-lint-error
-          message: |
-            Hey there and thank you for opening this pull request! 👋
-
-            This PR is marked as an RFC. Please make sure to change the conventional commit type before merging.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Terminate the workflow after posting the RFC comment
-        if: ${{ github.event_name == 'pull_request_target' && steps.rfc-tag.outputs.rfc == 'true' }}
         run: exit 1
 
       - name: Post a comment if the PR badly formatted
@@ -139,8 +107,7 @@ jobs:
           message: |
             Hey there and thank you for opening this pull request! 👋
 
-            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
-            and it looks like your proposed title needs to be adjusted.
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
 
             Your title should look like this. The scope field is optional.
             ```
@@ -153,10 +120,16 @@ jobs:
             ```
             and include a "BREAKING CHANGE:" footer in the body of the pull request.
 
-            Details:
-            ```
-            ${{ steps.lint_pr_title.outputs.error_message }}
-            ```
+            Available types:
+            - feat: A new feature
+            - fix: A bug fix
+            - docs: Documentation only changes
+            - refactor: A code change that neither fixes a bug nor adds a feature
+            - perf: A code change that improves performance
+            - test: Adding missing tests or correcting existing tests
+            - ci: Changes to the CI configuration files and scripts
+            - chore: Other changes that don't affect the published crate
+            - revert: Reverts a previous commit
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -122,9 +122,7 @@ jobs:
           header: rs-semver-checks
           message: |
             This PR contains breaking changes to the public Rust API.
-            Please deprecate the old API instead (if possible), or mark the PR with a `!`
-            following the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
-            format to indicate a breaking change.
+            Please deprecate the old API instead (if possible), or mark the PR with a `!` following the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format to indicate a breaking change.
 
             <details>
               <summary>cargo-semver-checks summary</summary>

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -56,7 +56,7 @@ jobs:
           set +e
 
           cd PR_BRANCH
-          cargo semver-checks --color never --baseline-root ../BASELINE_BRANCH > diagnostic.txt
+          cargo semver-checks --color never --baseline-root ../BASELINE_BRANCH --release-type minor > diagnostic.txt
           if [ "$?" -ne 0 ]; then
             echo "breaking=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
This is part of the CI improvements listed in #725.

Adds a check when a PR is opened or modified to ensure it's title contains a [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) tag, e.g.
```yml
# Some new features and bug fixes
feat: Add this algorithm
fix(component): Don't panic
# A PR that introduces a semver breaking change
fix!: Refactor all the traits
```
When a PR introduces breaking changes (that will require a breaking semver bump) we also require a `BREAKING CHANGE: ...` line in the PR body describing what the changes required in user code.

When the check fails, the bot posts a help message indicating what needs to be fixed.

The list of valid tags are: `feat, fix, docs, style, refactor, perf, test, ci, chore, revert`.
`rfc` is an invalid tag with a custom error message, useful when opening draft PRs.
I added a pull request template with these instructions.

The main goal of this requirement is to automate changelog generation with [release-plz](https://release-plz.dev/). The tags get grouped into categories in the changelog, and breaking changes are automatically picked when deciding the version bump.

This also integrates with the semver checks added in #692. The check fails on PRs with breaking changes unless they are marked as breaking in title.

---

The code here is based on the reusable workflow I implemented in [CQCL/hugrverse-actions](https://github.com/CQCL/hugrverse-actions?tab=readme-ov-file#pr-title).