### PR TITLE
feat: Add `UnionFind` capacity management methods

### DIFF
--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,9 +1,8 @@
 //! `UnionFind<K>` is a disjoint-set data structure.
 
-use alloc::{vec, vec::Vec};
-use core::cmp::Ordering;
-
 use super::graph::IndexType;
+use alloc::{collections::TryReserveError, vec, vec::Vec};
+use core::cmp::Ordering;
 
 /// `UnionFind<K>` is a disjoint-set data structure. It tracks set membership of *n* elements
 /// indexed from *0* to *n - 1*. The scalar type is `K` which must be an unsigned integer type.
@@ -224,5 +223,191 @@ where
             }
         }
         self.parent
+    }
+}
+
+impl<K> UnionFind<K> {
+    /// Constructs a new, empty `UnionFind<K>` with at least the specified capacity.
+    ///
+    /// This acts similarly to [`Vec::with_capacity`].
+    pub fn with_capacity(capacity: usize) -> Self {
+        UnionFind {
+            parent: Vec::with_capacity(capacity),
+            rank: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Returns the total number of elements the `UnionFind` can hold without reallocating.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use petgraph::unionfind::UnionFind;
+    ///
+    /// let mut uf: UnionFind<u32> = UnionFind::with_capacity(10);
+    /// uf.new_set();
+    /// assert!(uf.capacity() >= 10);
+    /// ```
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.parent.capacity().min(self.rank.capacity())
+    }
+
+    /// Reserves capacity for at least `additional` more elements to be inserted
+    /// in the given `UnionFind<K>`. The collection may reserve more space to
+    /// speculatively avoid frequent reallocations. After calling `reserve`,
+    /// capacity will be greater than or equal to `self.len() + additional`.
+    /// Does nothing if capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` _bytes_.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use petgraph::unionfind::UnionFind;
+    ///
+    /// let mut uf: UnionFind<u32> = UnionFind::new(3);
+    /// uf.reserve(10);
+    /// assert!(uf.capacity() >= 13);
+    /// ```
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.parent.reserve(additional);
+        self.rank.reserve(additional);
+    }
+
+    /// Reserves the minimum capacity for at least `additional` more elements to
+    /// be inserted in the given `UnionFind<K>`. Unlike [`reserve`], this will not
+    /// deliberately over-allocate to speculatively avoid frequent allocations.
+    /// After calling `reserve_exact`, capacity will be greater than or equal to
+    /// `self.len() + additional`. Does nothing if the capacity is already
+    /// sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it
+    /// requests. Therefore, capacity can not be relied upon to be precisely
+    /// minimal. Prefer [`reserve`] if future insertions are expected.
+    ///
+    /// [`reserve`]: UnionFind::reserve
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` _bytes_.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use petgraph::unionfind::UnionFind;
+    ///
+    /// let mut uf: UnionFind<u32> =  UnionFind::new_empty();
+    /// uf.reserve_exact(10);
+    /// assert!(uf.capacity() >= 10);
+    /// ```
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.parent.reserve_exact(additional);
+        self.rank.reserve_exact(additional);
+    }
+
+    /// Tries to reserve capacity for at least `additional` more elements to be inserted
+    /// in the given `UnionFind<K>`. The collection may reserve more space to speculatively avoid
+    /// frequent reallocations. After calling `try_reserve`, capacity will be
+    /// greater than or equal to `self.len() + additional` if it returns
+    /// `Ok(())`. Does nothing if capacity is already sufficient. This method
+    /// preserves the contents even if an error occurs.
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// is returned.
+    #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.parent
+            .try_reserve(additional)
+            .and_then(|_| self.rank.try_reserve(additional))
+    }
+
+    /// Tries to reserve the minimum capacity for at least `additional`
+    /// elements to be inserted in the given `UnionFind<K>`. Unlike [`try_reserve`],
+    /// this will not deliberately over-allocate to speculatively avoid frequent
+    /// allocations. After calling `try_reserve_exact`, capacity will be greater
+    /// than or equal to `self.len() + additional` if it returns `Ok(())`.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it
+    /// requests. Therefore, capacity can not be relied upon to be precisely
+    /// minimal. Prefer [`try_reserve`] if future insertions are expected.
+    ///
+    /// [`try_reserve`]: UnionFind::try_reserve
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// is returned.
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.parent
+            .try_reserve_exact(additional)
+            .and_then(|_| self.rank.try_reserve_exact(additional))
+    }
+
+    /// Shrinks the capacity of the `UnionFind` as much as possible.
+    ///
+    /// The behavior of this method depends on the allocator, which may either shrink the
+    /// collection in-place or reallocate. The resulting `UnionFind` might still have some excess capacity, just as
+    /// is the case for [`with_capacity`]. See [`Vec::shrink_to_fit`] for more details, since the implementation is based on this method.
+    ///
+    /// [`with_capacity`]: UnionFind::with_capacity
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use petgraph::unionfind::UnionFind;
+    ///
+    /// let mut uf: UnionFind<u32> = UnionFind::with_capacity(10);
+    ///
+    /// for _ in 0..3 {
+    ///     uf.new_set();
+    /// }
+    ///
+    /// assert!(uf.capacity() >= 10);
+    /// uf.shrink_to_fit();
+    /// assert!(uf.capacity() >= 3);
+    /// ```
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.parent.shrink_to_fit();
+        self.rank.shrink_to_fit();
+    }
+
+    /// Shrinks the capacity of the `UnionFind` with a lower bound.
+    ///
+    /// The capacity will remain at least as large as both the length
+    /// and the supplied value.
+    ///
+    /// If the current capacity is less than the lower limit, this is a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use petgraph::unionfind::UnionFind;
+    ///
+    /// let mut uf: UnionFind<u32> = UnionFind::with_capacity(10);
+    ///
+    /// for _ in 0..3 {
+    ///     uf.new_set();
+    /// }
+    ///
+    /// assert!(uf.capacity() >= 10);
+    /// uf.shrink_to(4);
+    /// assert!(uf.capacity() >= 4);
+    /// uf.shrink_to(0);
+    /// assert!(uf.capacity() >= 3);
+    /// ```
+    #[inline]
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.parent.shrink_to(min_capacity);
+        self.rank.shrink_to(min_capacity);
     }
 }


### PR DESCRIPTION
PR provides `UnionFind` capacity management methods suggested in #731.

I adopted the doc-comments from the `Vec` documentation. I hope this doesn't seem unnecessary and verbose.