### PR TITLE
Add Maximum Bipartite Matching Algorithm

### DIFF
--- a/benches/matching.rs
+++ b/benches/matching.rs
@@ -3,13 +3,14 @@
 extern crate petgraph;
 extern crate test;
 
+use petgraph::visit::NodeIndexable;
 use test::Bencher;
 
 #[allow(dead_code)]
 mod common;
 use common::*;
 
-use petgraph::algo::{greedy_matching, maximum_matching};
+use petgraph::algo::{greedy_matching, maximum_bipartite_matching, maximum_matching};
 use petgraph::graph::UnGraph;
 
 fn huge() -> UnGraph<(), ()> {
@@ -27,6 +28,30 @@ fn huge() -> UnGraph<(), ()> {
 
     // 999 nodes, 83500 edges
     UnGraph::from_edges(&edges)
+}
+
+fn generate_bipartite(node_count: u32) -> (UnGraph<(), ()>, Vec<u32>, Vec<u32>) {
+    let mut edges = Vec::new();
+
+    let mut partition_1 = Vec::new();
+    let mut partition_2 = Vec::new();
+    for i in 0..node_count {
+        for j in i..node_count {
+            if i % 6 == 0 && j % 2 == 1 {
+                edges.push((i, j));
+            }
+        }
+    }
+
+    for i in (0..node_count).step_by(6) {
+        partition_1.push(i);
+    }
+
+    for i in (1..node_count).step_by(2) {
+        partition_2.push(i);
+    }
+
+    (UnGraph::from_edges(&edges), partition_1, partition_2)
 }
 
 #[bench]
@@ -75,4 +100,32 @@ fn maximum_matching_bigger(bench: &mut Bencher) {
 fn maximum_matching_huge(bench: &mut Bencher) {
     let g = huge();
     bench.iter(|| maximum_matching(&g));
+}
+
+#[bench]
+fn maximum_bipartite_matching_100(bench: &mut Bencher) {
+    let (g, partition_1, partition_2) = generate_bipartite(100);
+    let partition_1_ids = partition_1
+        .iter()
+        .map(|&id| NodeIndexable::from_index(&g, id as usize))
+        .collect();
+    let partition_2_ids = partition_2
+        .iter()
+        .map(|&id| NodeIndexable::from_index(&g, id as usize))
+        .collect();
+    bench.iter(|| maximum_bipartite_matching(&g, &partition_1_ids, &partition_2_ids));
+}
+
+#[bench]
+fn maximum_bipartite_matching_1000(bench: &mut Bencher) {
+    let (g, partition_1, partition_2) = generate_bipartite(1_000);
+    let partition_1_ids = partition_1
+        .iter()
+        .map(|&id| NodeIndexable::from_index(&g, id as usize))
+        .collect();
+    let partition_2_ids = partition_2
+        .iter()
+        .map(|&id| NodeIndexable::from_index(&g, id as usize))
+        .collect();
+    bench.iter(|| maximum_bipartite_matching(&g, &partition_1_ids, &partition_2_ids));
 }

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -2,9 +2,11 @@ use std::collections::VecDeque;
 use std::hash::Hash;
 
 use crate::visit::{
-    EdgeRef, GraphBase, IntoEdges, IntoNeighbors, IntoNodeIdentifiers, NodeCount, NodeIndexable,
-    VisitMap, Visitable,
+    EdgeCount, EdgeIndexable, EdgeRef, GraphBase, IntoEdges, IntoNeighbors, IntoNodeIdentifiers,
+    IntoNodeReferences, NodeCount, NodeIndexable, VisitMap, Visitable,
 };
+
+use crate::{algo::ford_fulkerson, graph::NodeIndex, Directed, Graph};
 
 /// Computed
 /// [*matching*](https://en.wikipedia.org/wiki/Matching_(graph_theory)#Definitions)
@@ -590,5 +592,109 @@ fn augment_path<G>(
         augment_path(graph, target, source, mate, label);
     } else {
         panic!("Unexpected label when augmenting path");
+    }
+}
+
+/// Compute the [*maximum matching*][1]
+/// for a bipartite graph by reducing it to a [maximum flow][2] problem,
+/// and then using Ford Fulkerson method to solve maximum flow problem.
+///
+/// [1]: https://en.wikipedia.org/wiki/Matching_(graph_theory)
+/// [2]: https://en.wikipedia.org/wiki/Maximum_flow_problem
+///
+/// The input graph is treated as if undirected.
+pub fn maximum_bipartite_matching<G>(
+    graph: G,
+    partition_a: &Vec<G::NodeId>,
+    partition_b: &Vec<G::NodeId>,
+) -> Matching<G>
+where
+    G: NodeIndexable + EdgeIndexable + NodeCount + EdgeCount + IntoNodeReferences + IntoEdges,
+{
+    let (network, source, sink) =
+        maximum_bipartite_matching_instance(&graph, partition_a, partition_b);
+
+    let (_, flow) = ford_fulkerson(&network, source, sink);
+    let mut mate = vec![None; graph.node_count()];
+    let mut n_edges = 0;
+
+    for edge in graph.edge_references() {
+        if flow[EdgeIndexable::to_index(&graph, edge.id())] == 1 {
+            let (source, target) =
+                source_and_target_from_partitions::<G>(edge, partition_a, partition_b);
+            mate[NodeIndexable::to_index(&graph, source)] = Some(target);
+            mate[NodeIndexable::to_index(&graph, target)] = Some(source);
+            n_edges += 1;
+        }
+    }
+
+    Matching::new(graph, mate, n_edges)
+}
+
+/// Create a network from given graph.
+/// Created Nodes and Edges indices are compatible
+/// with the ones from original graph.
+fn maximum_bipartite_matching_instance<G>(
+    graph: &G,
+    partition_a: &Vec<G::NodeId>,
+    partition_b: &Vec<G::NodeId>,
+) -> (Graph<(), usize, Directed>, NodeIndex, NodeIndex)
+where
+    G: NodeIndexable + EdgeIndexable + NodeCount + EdgeCount + IntoNodeReferences + IntoEdges,
+{
+    let mut network = Graph::with_capacity(
+        graph.node_count() + 2,
+        graph.edge_count() + partition_a.len() + partition_b.len(),
+    );
+
+    // Add nodes from original graph
+    for _ in 0..graph.node_count() {
+        network.add_node(());
+    }
+
+    // Add edges from original graph, directed from partition_a to partition_b
+    for edge in graph.edge_references() {
+        let (source, target) =
+            source_and_target_from_partitions::<G>(edge, partition_a, partition_b);
+        let source_index = NodeIndexable::to_index(&graph, source);
+        let target_index = NodeIndexable::to_index(&graph, target);
+        network.add_edge(
+            NodeIndexable::from_index(&network, source_index),
+            NodeIndexable::from_index(&network, target_index),
+            1,
+        );
+    }
+
+    // Add source node
+    let source = network.add_node(());
+    for &node in partition_a {
+        let node_index = NodeIndexable::to_index(&graph, node);
+        network.add_edge(source, NodeIndex::new(node_index), 1);
+    }
+
+    // Add sink node
+    let sink = network.add_node(());
+    for &node in partition_b {
+        let node_index = NodeIndexable::to_index(&graph, node);
+        network.add_edge(NodeIndex::new(node_index), sink, 1);
+    }
+
+    (network, source, sink)
+}
+
+fn source_and_target_from_partitions<G>(
+    edge: G::EdgeRef,
+    partition_a: &Vec<G::NodeId>,
+    partition_b: &Vec<G::NodeId>,
+) -> (G::NodeId, G::NodeId)
+where
+    G: IntoEdges,
+{
+    if partition_a.contains(&edge.source()) {
+        (edge.source(), edge.target())
+    } else if partition_b.contains(&edge.source()) {
+        (edge.target(), edge.source())
+    } else {
+        panic!("Partitions are inconsistent.");
     }
 }

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -46,7 +46,7 @@ pub use isomorphism::{
     subgraph_isomorphisms_iter,
 };
 pub use k_shortest_path::k_shortest_path;
-pub use matching::{greedy_matching, maximum_matching, Matching};
+pub use matching::{greedy_matching, maximum_bipartite_matching, maximum_matching, Matching};
 pub use min_spanning_tree::{min_spanning_tree, min_spanning_tree_prim};
 pub use page_rank::page_rank;
 pub use simple_paths::all_simple_paths;

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 
-use petgraph::algo::{greedy_matching, maximum_matching};
+use petgraph::algo::{greedy_matching, maximum_bipartite_matching, maximum_matching};
 use petgraph::prelude::*;
+use petgraph::visit::EdgeIndexable;
 
 macro_rules! assert_one_of {
     ($actual:expr, [$($expected:expr),+]) => {
@@ -138,4 +139,75 @@ fn is_perfect_in_stable_graph() {
     let m = maximum_matching(&g);
     assert_eq!(m.len(), 1);
     assert!(m.is_perfect());
+}
+
+#[test]
+fn maximum_bipartite_empty() {
+    let g: UnGraph<(), ()> = UnGraph::default();
+    let m = maximum_bipartite_matching(&g, &Vec::new(), &Vec::new());
+    assert_eq!(collect(m.edges()), set![]);
+    assert_eq!(collect(m.nodes()), set![]);
+}
+
+#[test]
+fn maximum_bipartite_k2() {
+    let mut g = UnGraph::new_undirected();
+    let _0 = g.add_node(());
+    let _1 = g.add_node(());
+    g.add_edge(_0, _1, ());
+
+    let m = maximum_bipartite_matching(&g, &vec![_0], &vec![_1]);
+    assert_eq!(collect(m.edges()), set![(0, 1)]);
+    assert_eq!(collect(m.nodes()), set![0, 1]);
+}
+
+#[test]
+fn maximum_bipartite_test() {
+    let mut g: Graph<(), (), Undirected> = UnGraph::new_undirected();
+
+    // Partition 1
+    let _1_1 = g.add_node(());
+    let _1_2 = g.add_node(());
+    let _1_3 = g.add_node(());
+    let _1_4 = g.add_node(());
+    let _1_5 = g.add_node(());
+    let _1_6 = g.add_node(());
+    let partition_1 = vec![_1_1, _1_2, _1_3, _1_4, _1_5, _1_6];
+
+    // Partition 2
+    let _2_1 = g.add_node(());
+    let _2_2 = g.add_node(());
+    let _2_3 = g.add_node(());
+    let _2_4 = g.add_node(());
+    let _2_5 = g.add_node(());
+    let _2_6 = g.add_node(());
+    let partition_2 = vec![_2_1, _2_2, _2_3, _2_4, _2_5, _2_6];
+
+    // Edges
+    g.extend_with_edges(vec![
+        (_1_1, _2_2),
+        (_1_1, _2_3),
+        (_1_3, _2_1),
+        (_1_3, _2_4),
+        (_1_4, _2_3),
+        (_1_5, _2_3),
+        (_1_5, _2_4),
+        (_1_6, _2_6),
+    ]);
+
+    let m = maximum_bipartite_matching(&g, &partition_1, &partition_2);
+    assert_eq!(
+        collect(m.edges()),
+        set![
+            (_1_1, _2_2),
+            (_1_3, _2_1),
+            (_1_4, _2_3),
+            (_1_5, _2_4),
+            (_1_6, _2_6)
+        ]
+    );
+    assert_eq!(
+        collect(m.nodes()),
+        set![_1_1, _1_3, _1_4, _1_5, _1_6, _2_1, _2_2, _2_3, _2_4, _2_6]
+    );
 }

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -3,7 +3,6 @@ use std::hash::Hash;
 
 use petgraph::algo::{greedy_matching, maximum_bipartite_matching, maximum_matching};
 use petgraph::prelude::*;
-use petgraph::visit::EdgeIndexable;
 
 macro_rules! assert_one_of {
     ($actual:expr, [$($expected:expr),+]) => {


### PR DESCRIPTION
# Add Maximum Bipartite Matching Algorithm

Solves the Maximum Matching Problem for a Bipartite graph by reducing it to a Maximum Flow problem and using existent algorithm for Maximum Flow.

References:
* https://en.wikipedia.org/wiki/Matching_(graph_theory)
* https://en.wikipedia.org/wiki/Maximum_flow_problem

## Creating the Max Flow Instance
In the algorithm I manually copy all nodes and edges from original graph to create a network flow instance. 
I believe there are faster ways to do this and optimize the algorithm, but I don't know how to do so, so I'm accepting some help on this.

## Further Optimization
This algorithm can be further optimized when [Dinic's Algorithm PR](https://github.com/petgraph/petgraph/pull/739) is accepted, because Dinic's is much faster than Ford Fulkerson method for [finding maximum flows in unit networks](https://cp-algorithms.com/graph/dinic.html#unit-networks).

I executed the bench tests with Ford Fulkerson and with the Dinic's algorithm, and this were the results:
```
using ford_fulkerson to find max flow:
    test maximum_bipartite_matching_100  ... bench:      32,223.41 ns/iter (+/- 5,470.65)
    test maximum_bipartite_matching_1000 ... bench:  27,260,136.10 ns/iter (+/- 5,475,181.00)

using dinics to find max flow:
    test maximum_bipartite_matching_100  ... bench:      14,483.79 ns/iter (+/- 512.79)
    test maximum_bipartite_matching_1000 ... bench:   1,867,409.90 ns/iter (+/- 105,994.25)
```