### PR TITLE
feat: Add Johnson's algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ahash = "0.7.2"
 fxhash = "0.2.1"
 
 [features]
-rayon = ["std", "dep:rayon", "indexmap/rayon"]
+rayon = ["std", "dep:rayon", "indexmap/rayon", "hashbrown/rayon"]
 dot_parser = ["std", "dep:dot-parser", "dep:dot-parser-macros"]
 
 # feature flags for testing use only

--- a/benches/common/factories.rs
+++ b/benches/common/factories.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use petgraph::data::Build;
 use petgraph::prelude::*;
@@ -330,4 +330,28 @@ pub fn directed_fan(n: usize) -> DiGraph<(), ()> {
     }
 
     g
+}
+
+#[allow(clippy::needless_range_loop)]
+pub fn build_graph(node_count: usize, dense: bool) -> Graph<usize, i32, Undirected> {
+    use core::cmp::{max, min};
+
+    let mut graph = Graph::new_undirected();
+    let nodes: Vec<NodeIndex<_>> = (0..node_count).map(|i| graph.add_node(i)).collect();
+    for i in 0..node_count {
+        let n1 = nodes[i];
+        let neighbour_count = if dense {
+            i % (node_count / 3) + 3
+        } else {
+            i % 8 + 3
+        };
+        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
+        let j_to = min(node_count, j_from + neighbour_count);
+        for j in j_from..j_to {
+            let n2 = nodes[j];
+            let distance = (i + 3) % 10;
+            graph.add_edge(n1, n2, distance as i32);
+        }
+    }
+    graph
 }

--- a/benches/floyd_warshall.rs
+++ b/benches/floyd_warshall.rs
@@ -3,32 +3,29 @@
 extern crate petgraph;
 extern crate test;
 
-use petgraph::prelude::*;
-use std::cmp::{max, min};
+#[allow(dead_code)]
+mod common;
+use common::*;
+
 use test::Bencher;
 
 use petgraph::algo::floyd_warshall;
 
 #[bench]
-#[allow(clippy::needless_range_loop)]
-fn floyd_warshall_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 100;
-    let mut g = Graph::new_undirected();
-    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).map(|i| g.add_node(i)).collect();
-    for i in 0..NODE_COUNT {
-        let n1 = nodes[i];
-        let neighbour_count = i % 8 + 3;
-        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
-        let j_to = min(NODE_COUNT, j_from + neighbour_count);
-        for j in j_from..j_to {
-            let n2 = nodes[j];
-            let distance = (i + 3) % 10;
-            g.add_edge(n1, n2, distance);
-        }
-    }
+fn floyd_warshall_sparse_100_nodes(bench: &mut Bencher) {
+    let graph = build_graph(100, false);
 
     bench.iter(|| {
-        let _scores = floyd_warshall(&g, |e| *e.weight());
+        let _scores = floyd_warshall(&graph, |e| *e.weight());
+    });
+}
+
+#[bench]
+fn floyd_warshall_dense_100_nodes(bench: &mut Bencher) {
+    let graph = build_graph(100, true);
+
+    bench.iter(|| {
+        let _scores = floyd_warshall(&graph, |e| *e.weight());
     });
 }
 
@@ -48,26 +45,4 @@ fn floyd_warshall_dense_1000_nodes(bench: &mut Bencher) {
     bench.iter(|| {
         let _scores = floyd_warshall(&graph, |e| *e.weight());
     });
-}
-
-#[allow(clippy::needless_range_loop)]
-fn build_graph(node_count: usize, dense: bool) -> Graph<usize, i32, Undirected> {
-    let mut graph = Graph::new_undirected();
-    let nodes: Vec<NodeIndex<_>> = (0..node_count).map(|i| graph.add_node(i)).collect();
-    for i in 0..node_count {
-        let n1 = nodes[i];
-        let neighbour_count = if dense {
-            i % (node_count / 3) + 3
-        } else {
-            i % 8 + 3
-        };
-        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
-        let j_to = min(node_count, j_from + neighbour_count);
-        for j in j_from..j_to {
-            let n2 = nodes[j];
-            let distance = (i + 3) % 10;
-            graph.add_edge(n1, n2, distance as i32);
-        }
-    }
-    graph
 }

--- a/benches/johnson.rs
+++ b/benches/johnson.rs
@@ -9,6 +9,9 @@ use test::Bencher;
 
 use petgraph::algo::johnson;
 
+#[cfg(feature = "rayon")]
+use petgraph::algo::parallel_johnson;
+
 #[bench]
 #[allow(clippy::needless_range_loop)]
 fn johnson_bench(bench: &mut Bencher) {
@@ -33,6 +36,16 @@ fn johnson_bench(bench: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(feature = "rayon")]
+fn parallel_johnson_bench(bench: &mut Bencher) {
+    let graph = build_graph(100, false);
+
+    bench.iter(|| {
+        let _scores = parallel_johnson(&graph, |e| *e.weight());
+    });
+}
+
+#[bench]
 fn johnson_sparse_1000_nodes(bench: &mut Bencher) {
     let graph = build_graph(1000, false);
 
@@ -47,6 +60,26 @@ fn johnson_dense_1000_nodes(bench: &mut Bencher) {
 
     bench.iter(|| {
         let _scores = johnson(&graph, |e| *e.weight());
+    });
+}
+
+#[bench]
+#[cfg(feature = "rayon")]
+fn parallel_johnson_sparse_1000_nodes(bench: &mut Bencher) {
+    let graph = build_graph(1000, false);
+
+    bench.iter(|| {
+        let _scores = parallel_johnson(&graph, |e| *e.weight());
+    });
+}
+
+#[bench]
+#[cfg(feature = "rayon")]
+fn parallel_johnson_dense_1000_nodes(bench: &mut Bencher) {
+    let graph = build_graph(1000, true);
+
+    bench.iter(|| {
+        let _scores = parallel_johnson(&graph, |e| *e.weight());
     });
 }
 

--- a/benches/johnson.rs
+++ b/benches/johnson.rs
@@ -7,11 +7,11 @@ use petgraph::prelude::*;
 use std::cmp::{max, min};
 use test::Bencher;
 
-use petgraph::algo::floyd_warshall;
+use petgraph::algo::johnson;
 
 #[bench]
 #[allow(clippy::needless_range_loop)]
-fn floyd_warshall_bench(bench: &mut Bencher) {
+fn johnson_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 100;
     let mut g = Graph::new_undirected();
     let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).map(|i| g.add_node(i)).collect();
@@ -28,25 +28,25 @@ fn floyd_warshall_bench(bench: &mut Bencher) {
     }
 
     bench.iter(|| {
-        let _scores = floyd_warshall(&g, |e| *e.weight());
+        let _scores = johnson(&g, |e| *e.weight());
     });
 }
 
 #[bench]
-fn floyd_warshall_sparse_1000_nodes(bench: &mut Bencher) {
+fn johnson_sparse_1000_nodes(bench: &mut Bencher) {
     let graph = build_graph(1000, false);
 
     bench.iter(|| {
-        let _scores = floyd_warshall(&graph, |e| *e.weight());
+        let _scores = johnson(&graph, |e| *e.weight());
     });
 }
 
 #[bench]
-fn floyd_warshall_dense_1000_nodes(bench: &mut Bencher) {
+fn johnson_dense_1000_nodes(bench: &mut Bencher) {
     let graph = build_graph(1000, true);
 
     bench.iter(|| {
-        let _scores = floyd_warshall(&graph, |e| *e.weight());
+        let _scores = johnson(&graph, |e| *e.weight());
     });
 }
 

--- a/benches/johnson.rs
+++ b/benches/johnson.rs
@@ -3,41 +3,45 @@
 extern crate petgraph;
 extern crate test;
 
-use petgraph::prelude::*;
-use std::cmp::{max, min};
-use test::Bencher;
+#[allow(dead_code)]
+mod common;
+use common::*;
 
 use petgraph::algo::johnson;
+use test::Bencher;
 
 #[cfg(feature = "rayon")]
 use petgraph::algo::parallel_johnson;
 
 #[bench]
-#[allow(clippy::needless_range_loop)]
-fn johnson_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 100;
-    let mut g = Graph::new_undirected();
-    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).map(|i| g.add_node(i)).collect();
-    for i in 0..NODE_COUNT {
-        let n1 = nodes[i];
-        let neighbour_count = i % 8 + 3;
-        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
-        let j_to = min(NODE_COUNT, j_from + neighbour_count);
-        for j in j_from..j_to {
-            let n2 = nodes[j];
-            let distance = (i + 3) % 10;
-            g.add_edge(n1, n2, distance);
-        }
-    }
-
+fn johnson_sparse_100_nodes(bench: &mut Bencher) {
+    let graph = build_graph(100, false);
     bench.iter(|| {
-        let _scores = johnson(&g, |e| *e.weight());
+        let _scores = johnson(&graph, |e| *e.weight());
+    });
+}
+
+#[bench]
+fn johnson_dense_100_nodes(bench: &mut Bencher) {
+    let graph = build_graph(100, true);
+    bench.iter(|| {
+        let _scores = johnson(&graph, |e| *e.weight());
     });
 }
 
 #[bench]
 #[cfg(feature = "rayon")]
-fn parallel_johnson_bench(bench: &mut Bencher) {
+fn parallel_johnson_sparse_100_nodes(bench: &mut Bencher) {
+    let graph = build_graph(100, false);
+
+    bench.iter(|| {
+        let _scores = parallel_johnson(&graph, |e| *e.weight());
+    });
+}
+
+#[bench]
+#[cfg(feature = "rayon")]
+fn parallel_johnson_dense_100_nodes(bench: &mut Bencher) {
     let graph = build_graph(100, false);
 
     bench.iter(|| {
@@ -81,26 +85,4 @@ fn parallel_johnson_dense_1000_nodes(bench: &mut Bencher) {
     bench.iter(|| {
         let _scores = parallel_johnson(&graph, |e| *e.weight());
     });
-}
-
-#[allow(clippy::needless_range_loop)]
-fn build_graph(node_count: usize, dense: bool) -> Graph<usize, i32, Undirected> {
-    let mut graph = Graph::new_undirected();
-    let nodes: Vec<NodeIndex<_>> = (0..node_count).map(|i| graph.add_node(i)).collect();
-    for i in 0..node_count {
-        let n1 = nodes[i];
-        let neighbour_count = if dense {
-            i % (node_count / 3) + 3
-        } else {
-            i % 8 + 3
-        };
-        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
-        let j_to = min(node_count, j_from + neighbour_count);
-        for j in j_from..j_to {
-            let n2 = nodes[j];
-            let distance = (i + 3) % 10;
-            graph.add_edge(n1, n2, distance as i32);
-        }
-    }
-    graph
 }

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -21,6 +21,9 @@ use crate::visit::{
 /// * `Ok`: (if graph contains no negative cycle) a hashmap containing all pairs shortest paths
 /// * `Err`: if graph contains negative cycle.
 ///
+/// **Note**: If the graph is sparse (the number of edges is quite small),
+/// consider using the [`johnson`](fn@crate::algo::johnson), which is likely to show better performance.
+///
 /// # Examples
 /// ```rust
 /// use petgraph::{prelude::*, Graph, Directed};

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -1,7 +1,9 @@
 //! Johnson's algorithm implementation.
-use std::collections::HashMap;
-use std::hash::Hash;
-use std::ops::Sub;
+use alloc::{vec, vec::Vec};
+use core::hash::Hash;
+use core::ops::Sub;
+
+use hashbrown::HashMap;
 
 use super::{dijkstra, spfa::spfa_loop};
 pub use super::{BoundedMeasure, NegativeCycle};

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -20,6 +20,9 @@ use core::marker::{Send, Sync};
 /// The time complexity of this implementation is O(VElog(V) + V^2*log(V)),
 /// which is faster than [`floyd_warshall`](fn@crate::algo::floyd_warshall) on sparse graphs and slower on dense ones.
 ///
+/// If you are working with a sparse graph that is guaranteed to have no negative weights,
+/// it's preferable to run [`dijkstra`](fn@crate::algo::dijkstra) several times.
+///
 /// There is also a parallel implementation `parallel_johnson`, available under the `rayon` feature.
 ///
 /// ## Arguments
@@ -123,10 +126,13 @@ where
 
 /// \[Generic\] [Johnson algorithm][johnson]
 /// implementation for all pairs shortest path problem,
-/// parallelizing the `dijkstra` algorithm calls with `rayon`.
+/// parallelizing the [`dijkstra`](fn@crate::algo::dijkstra) calls with `rayon`.
 ///
 /// Сompute the lengths of shortest paths in a weighted graph with
 /// positive or negative edge weights, but no negative cycles.
+///
+/// If you are working with a sparse graph that is guaranteed to have no negative weights,
+/// it's preferable to run [`dijkstra`](fn@crate::algo::dijkstra) several times in parallel.
 ///
 /// ## Arguments
 /// * `graph`: weighted graph.

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -10,7 +10,7 @@ pub use super::{BoundedMeasure, NegativeCycle};
 use crate::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeIndexable, Visitable};
 
 #[cfg(feature = "rayon")]
-use std::marker::{Send, Sync};
+use core::marker::{Send, Sync};
 
 /// \[Generic\] [Johnson algorithm][johnson] for all pairs shortest path problem.
 ///

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -116,7 +116,7 @@ where
 
 /// [Johnson algorithm][johnson]
 /// implementation for all pairs shortest path problem,
-/// parallelizing the [`dijkstra`] algorithm calls.
+/// parallelizing the `dijkstra` algorithm calls with `rayon`.
 ///
 /// Сompute the lengths of shortest paths in a weighted graph with
 /// positive or negative edge weights, but no negative cycles.

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -10,10 +10,15 @@ use crate::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeIndexable, Visit
 #[cfg(feature = "rayon")]
 use std::marker::{Send, Sync};
 
-/// [Johnson algorithm][johnson] for all pairs shortest path problem.
+/// \[Generic\] [Johnson algorithm][johnson] for all pairs shortest path problem.
 ///
 /// Сompute the lengths of shortest paths in a weighted graph with
 /// positive or negative edge weights, but no negative cycles.
+///
+/// The time complexity of this implementation is O(VElog(V) + V^2*log(V)),
+/// which is faster than [`floyd_warshall`](fn@crate::algo::floyd_warshall) on sparse graphs and slower on dense ones.
+///
+/// There is also a parallel implementation `parallel_johnson`, available under the `rayon` feature.
 ///
 /// ## Arguments
 /// * `graph`: weighted graph.
@@ -114,7 +119,7 @@ where
     Ok(distance_map)
 }
 
-/// [Johnson algorithm][johnson]
+/// \[Generic\] [Johnson algorithm][johnson]
 /// implementation for all pairs shortest path problem,
 /// parallelizing the `dijkstra` algorithm calls with `rayon`.
 ///

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -1,0 +1,125 @@
+//! Johnson's algorithm implementation.
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::ops::Sub;
+
+use super::{dijkstra, spfa::spfa_loop};
+pub use super::{BoundedMeasure, NegativeCycle};
+use crate::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeIndexable, Visitable};
+
+/// [Johnson algorithm][johnson] for all pairs shortest path problem.
+///
+/// Сompute the lengths of shortest paths in a weighted graph with
+/// positive or negative edge weights, but no negative cycles.
+///
+/// ## Arguments
+/// * `graph`: weighted graph.
+/// * `edge_cost`: closure that returns cost of a particular edge.
+///
+/// ## Returns
+/// * `Err`: if graph contains negative cycle.
+/// * `Ok`: `HashMap` of shortest distances.
+///
+/// [johnson]: https://en.wikipedia.org/wiki/Johnson%27s_algorithm
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::{prelude::*, Graph, Directed};
+/// use petgraph::algo::johnson;
+/// use std::collections::HashMap;
+///
+/// let mut graph: Graph<(), i32, Directed> = Graph::new();
+/// let a = graph.add_node(());
+/// let b = graph.add_node(());
+/// let c = graph.add_node(());
+/// let d = graph.add_node(());
+///
+/// graph.extend_with_edges(&[
+///    (a, b, 1),
+///    (a, c, 4),
+///    (a, d, 10),
+///    (b, c, 2),
+///    (b, d, 2),
+///    (c, d, 2)
+/// ]);
+///
+/// //     ----- b --------
+/// //    |      ^         | 2
+/// //    |    1 |    4    v
+/// //  2 |      a ------> c
+/// //    |   10 |         | 2
+/// //    |      v         v
+/// //     --->  d <-------
+///
+/// let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+///    ((a, a), 0), ((a, b), 1), ((a, c), 3), ((a, d), 3),
+///    ((b, b), 0), ((b, c), 2), ((b, d), 2),
+///    ((c, c), 0), ((c, d), 2),
+///    ((d, d), 0),
+/// ].iter().cloned().collect();
+///
+///
+/// let res = johnson(&graph, |edge| {
+///     *edge.weight()
+/// }).unwrap();
+///
+/// let nodes = [a, b, c, d];
+/// for node1 in &nodes {
+///     for node2 in &nodes {
+///         assert_eq!(res.get(&(*node1, *node2)), expected_res.get(&(*node1, *node2)));
+///     }
+/// }
+/// ```
+#[allow(clippy::type_complexity)]
+pub fn johnson<G, F, K>(
+    graph: G,
+    mut edge_cost: F,
+) -> Result<HashMap<(G::NodeId, G::NodeId), K>, NegativeCycle>
+where
+    G: IntoEdges + IntoNodeIdentifiers + NodeIndexable + Visitable,
+    G::NodeId: Eq + Hash,
+    F: FnMut(G::EdgeRef) -> K,
+    K: BoundedMeasure + Copy + Sub<K, Output = K>,
+{
+    // Add a virtual node to the graph with oriented edges with zero weight
+    // to all other vertices, and then run SPFA from it.
+    // The found distances will be used to change the edge weights in Dijkstra's
+    // algorithm to make them non-negative.
+
+    let ix = |i| graph.to_index(i);
+    let node_bound = graph.node_bound();
+
+    let reweight = vec![K::default(); node_bound];
+
+    // Queue of vertices capable of relaxation of the found shortest distances.
+    let mut queue: Vec<G::NodeId> = Vec::with_capacity(node_bound);
+
+    // Adding all vertices to the queue is the same as starting the algorithm from a virtual node.
+    queue.extend(graph.node_identifiers());
+    let in_queue = vec![true; node_bound];
+
+    let (reweight, _) = spfa_loop(graph, reweight, None, queue, in_queue, &mut edge_cost)?;
+
+    let mut distance_map: HashMap<(G::NodeId, G::NodeId), K> =
+        HashMap::with_capacity(node_bound * node_bound);
+
+    // Reweight edges.
+    let mut new_cost = |edge: G::EdgeRef| {
+        let (sum, _overflow) = edge_cost(edge).overflowing_add(reweight[ix(edge.source())]);
+        debug_assert!(!_overflow);
+        sum - reweight[ix(edge.target())]
+    };
+
+    // Run Dijkstra's algorithm from each node.
+    for source in graph.node_identifiers() {
+        for (target, dist) in dijkstra(graph, source, None, &mut new_cost) {
+            distance_map.insert(
+                (source, target),
+                dist + reweight[ix(target)] - reweight[ix(source)],
+            );
+        }
+    }
+
+    Ok(distance_map)
+}

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -7,6 +7,9 @@ use super::{dijkstra, spfa::spfa_loop};
 pub use super::{BoundedMeasure, NegativeCycle};
 use crate::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeIndexable, Visitable};
 
+#[cfg(feature = "rayon")]
+use std::marker::{Send, Sync};
+
 /// [Johnson algorithm][johnson] for all pairs shortest path problem.
 ///
 /// Сompute the lengths of shortest paths in a weighted graph with
@@ -82,24 +85,11 @@ where
     F: FnMut(G::EdgeRef) -> K,
     K: BoundedMeasure + Copy + Sub<K, Output = K>,
 {
-    // Add a virtual node to the graph with oriented edges with zero weight
-    // to all other vertices, and then run SPFA from it.
-    // The found distances will be used to change the edge weights in Dijkstra's
-    // algorithm to make them non-negative.
+    let reweight = johnson_reweight(graph, &mut edge_cost)?;
+    let reweight = reweight.as_slice();
 
-    let ix = |i| graph.to_index(i);
     let node_bound = graph.node_bound();
-
-    let reweight = vec![K::default(); node_bound];
-
-    // Queue of vertices capable of relaxation of the found shortest distances.
-    let mut queue: Vec<G::NodeId> = Vec::with_capacity(node_bound);
-
-    // Adding all vertices to the queue is the same as starting the algorithm from a virtual node.
-    queue.extend(graph.node_identifiers());
-    let in_queue = vec![true; node_bound];
-
-    let (reweight, _) = spfa_loop(graph, reweight, None, queue, in_queue, &mut edge_cost)?;
+    let ix = |i| graph.to_index(i);
 
     let mut distance_map: HashMap<(G::NodeId, G::NodeId), K> =
         HashMap::with_capacity(node_bound * node_bound);
@@ -122,4 +112,142 @@ where
     }
 
     Ok(distance_map)
+}
+
+/// [Johnson algorithm][johnson]
+/// implementation for all pairs shortest path problem,
+/// parallelizing the [`dijkstra`] algorithm calls.
+///
+/// Сompute the lengths of shortest paths in a weighted graph with
+/// positive or negative edge weights, but no negative cycles.
+///
+/// ## Arguments
+/// * `graph`: weighted graph.
+/// * `edge_cost`: closure that returns cost of a particular edge.
+///
+/// ## Returns
+/// * `Err`: if graph contains negative cycle.
+/// * `Ok`: `HashMap` of shortest distances.
+///
+/// [johnson]: https://en.wikipedia.org/wiki/Johnson%27s_algorithm
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::{prelude::*, Graph, Directed};
+/// use petgraph::algo::parallel_johnson;
+/// use std::collections::HashMap;
+///
+/// let mut graph: Graph<(), i32, Directed> = Graph::new();
+/// let a = graph.add_node(());
+/// let b = graph.add_node(());
+/// let c = graph.add_node(());
+/// let d = graph.add_node(());
+///
+/// graph.extend_with_edges(&[
+///    (a, b, 1),
+///    (a, c, 4),
+///    (a, d, 10),
+///    (b, c, 2),
+///    (b, d, 2),
+///    (c, d, 2)
+/// ]);
+///
+/// //     ----- b --------
+/// //    |      ^         | 2
+/// //    |    1 |    4    v
+/// //  2 |      a ------> c
+/// //    |   10 |         | 2
+/// //    |      v         v
+/// //     --->  d <-------
+///
+/// let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+///    ((a, a), 0), ((a, b), 1), ((a, c), 3), ((a, d), 3),
+///    ((b, b), 0), ((b, c), 2), ((b, d), 2),
+///    ((c, c), 0), ((c, d), 2),
+///    ((d, d), 0),
+/// ].iter().cloned().collect();
+///
+///
+/// let res = parallel_johnson(&graph, |edge| {
+///     *edge.weight()
+/// }).unwrap();
+///
+/// let nodes = [a, b, c, d];
+/// for node1 in &nodes {
+///     for node2 in &nodes {
+///         assert_eq!(res.get(&(*node1, *node2)), expected_res.get(&(*node1, *node2)));
+///     }
+/// }
+/// ```
+#[cfg(feature = "rayon")]
+#[allow(clippy::type_complexity)]
+pub fn parallel_johnson<G, F, K>(
+    graph: G,
+    mut edge_cost: F,
+) -> Result<HashMap<(G::NodeId, G::NodeId), K>, NegativeCycle>
+where
+    G: IntoEdges + IntoNodeIdentifiers + NodeIndexable + Visitable + Sync,
+    G::NodeId: Eq + Hash + Send,
+    F: Fn(G::EdgeRef) -> K + Sync,
+    K: BoundedMeasure + Copy + Sub<K, Output = K> + Send + Sync,
+{
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+    let reweight = johnson_reweight(graph, &mut edge_cost)?;
+    let reweight = reweight.as_slice();
+
+    let node_bound = graph.node_bound();
+    let ix = |i| graph.to_index(i);
+
+    // Reweight edges.
+    let new_cost = |edge: G::EdgeRef| {
+        let (sum, _overflow) = edge_cost(edge).overflowing_add(reweight[ix(edge.source())]);
+        debug_assert!(!_overflow);
+        sum - reweight[ix(edge.target())]
+    };
+
+    // Run Dijkstra's algorithm from each node.
+    let distance_map = (0..node_bound)
+        .into_par_iter()
+        .flat_map_iter(|s| {
+            let source = graph.from_index(s);
+
+            dijkstra(graph, source, None, new_cost)
+                .into_iter()
+                .map(move |(target, dist)| {
+                    (
+                        (source, target),
+                        dist + reweight[ix(target)] - reweight[ix(source)],
+                    )
+                })
+        })
+        .collect::<HashMap<(G::NodeId, G::NodeId), K>>();
+
+    Ok(distance_map)
+}
+
+/// Add a virtual node to the graph with oriented edges with zero weight
+/// to all other vertices, and then run SPFA from it.
+/// The found distances will be used to change the edge weights in Dijkstra's
+/// algorithm to make them non-negative.
+fn johnson_reweight<G, F, K>(graph: G, mut edge_cost: F) -> Result<Vec<K>, NegativeCycle>
+where
+    G: IntoEdges + IntoNodeIdentifiers + NodeIndexable + Visitable,
+    G::NodeId: Eq + Hash,
+    F: FnMut(G::EdgeRef) -> K,
+    K: BoundedMeasure + Copy + Sub<K, Output = K>,
+{
+    let node_bound = graph.node_bound();
+
+    let reweight = vec![K::default(); node_bound];
+
+    // Queue of vertices capable of relaxation of the found shortest distances.
+    let mut queue: Vec<G::NodeId> = Vec::with_capacity(node_bound);
+
+    // Adding all vertices to the queue is the same as starting the algorithm from a virtual node.
+    queue.extend(graph.node_identifiers());
+    let in_queue = vec![true; node_bound];
+
+    spfa_loop(graph, reweight, None, queue, in_queue, &mut edge_cost).map(|(dists, _)| dists)
 }

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -14,7 +14,7 @@ pub mod feedback_arc_set;
 pub mod floyd_warshall;
 pub mod ford_fulkerson;
 pub mod isomorphism;
-mod johnson;
+pub mod johnson;
 pub mod k_shortest_path;
 pub mod matching;
 pub mod maximal_cliques;
@@ -61,6 +61,9 @@ pub use simple_paths::all_simple_paths;
 pub use spfa::spfa;
 #[cfg(feature = "stable_graph")]
 pub use steiner_tree::steiner_tree;
+
+#[cfg(feature = "rayon")]
+pub use johnson::parallel_johnson;
 
 /// \[Generic\] Return the number of connected components of the graph.
 ///

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -14,6 +14,7 @@ pub mod feedback_arc_set;
 pub mod floyd_warshall;
 pub mod ford_fulkerson;
 pub mod isomorphism;
+mod johnson;
 pub mod k_shortest_path;
 pub mod matching;
 pub mod maximal_cliques;
@@ -50,6 +51,7 @@ pub use isomorphism::{
     is_isomorphic, is_isomorphic_matching, is_isomorphic_subgraph, is_isomorphic_subgraph_matching,
     subgraph_isomorphisms_iter,
 };
+pub use johnson::johnson;
 pub use k_shortest_path::k_shortest_path;
 pub use matching::{greedy_matching, maximum_matching, Matching};
 pub use maximal_cliques::maximal_cliques;

--- a/tests/johnson.rs
+++ b/tests/johnson.rs
@@ -1,9 +1,9 @@
+use core::fmt::Debug;
+use core::hash::Hash;
+use hashbrown::HashMap;
 use petgraph::algo::johnson;
 use petgraph::visit::GraphBase;
 use petgraph::{prelude::*, Directed, Graph, Undirected};
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
 
 #[cfg(feature = "rayon")]
 use petgraph::algo::parallel_johnson;

--- a/tests/johnson.rs
+++ b/tests/johnson.rs
@@ -1,0 +1,259 @@
+use petgraph::algo::johnson;
+use petgraph::{prelude::*, Directed, Graph, Undirected};
+use std::collections::HashMap;
+
+#[test]
+fn johnson_uniform_weight() {
+    let mut graph: Graph<(), (), Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+    let e = graph.add_node(());
+    let f = graph.add_node(());
+    let g = graph.add_node(());
+    let h = graph.add_node(());
+
+    graph.extend_with_edges([
+        (a, b),
+        (b, c),
+        (c, d),
+        (d, a),
+        (e, f),
+        (b, e),
+        (f, g),
+        (g, h),
+        (h, e),
+    ]);
+    // a ----> b ----> e ----> f
+    // ^       |       ^       |
+    // |       v       |       v
+    // d <---- c       h <---- g
+
+    let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+        ((a, a), 0),
+        ((a, b), 1),
+        ((a, c), 2),
+        ((a, d), 3),
+        ((a, e), 2),
+        ((a, f), 3),
+        ((a, g), 4),
+        ((a, h), 5),
+        ((b, a), 3),
+        ((b, b), 0),
+        ((b, c), 1),
+        ((b, d), 2),
+        ((b, e), 1),
+        ((b, f), 2),
+        ((b, g), 3),
+        ((b, h), 4),
+        ((c, a), 2),
+        ((c, b), 3),
+        ((c, c), 0),
+        ((c, d), 1),
+        ((c, e), 4),
+        ((c, f), 5),
+        ((c, g), 6),
+        ((c, h), 7),
+        ((d, a), 1),
+        ((d, b), 2),
+        ((d, c), 3),
+        ((d, d), 0),
+        ((d, e), 3),
+        ((d, f), 4),
+        ((d, g), 5),
+        ((d, h), 6),
+        ((e, e), 0),
+        ((e, f), 1),
+        ((e, g), 2),
+        ((e, h), 3),
+        ((f, e), 3),
+        ((f, f), 0),
+        ((f, g), 1),
+        ((f, h), 2),
+        ((g, e), 2),
+        ((g, f), 3),
+        ((g, g), 0),
+        ((g, h), 1),
+        ((h, e), 1),
+        ((h, f), 2),
+        ((h, g), 3),
+        ((h, h), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+    let res = johnson(&graph, |_| 1_i32).unwrap();
+
+    let nodes = [a, b, c, d, e, f, g, h];
+    for node1 in &nodes {
+        for node2 in &nodes {
+            assert_eq!(
+                res.get(&(*node1, *node2)),
+                expected_res.get(&(*node1, *node2))
+            );
+        }
+    }
+}
+
+#[test]
+fn johnson_weighted() {
+    let mut graph: Graph<(), i32, Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+
+    graph.extend_with_edges([
+        (a, b, 1),
+        (a, c, 4),
+        (a, d, 10),
+        (b, c, 2),
+        (b, d, 2),
+        (c, d, 2),
+    ]);
+
+    let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+        ((a, a), 0),
+        ((a, b), 1),
+        ((a, c), 3),
+        ((a, d), 3),
+        ((b, b), 0),
+        ((b, c), 2),
+        ((b, d), 2),
+        ((c, c), 0),
+        ((c, d), 2),
+        ((d, d), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    let res = johnson(&graph, |edge| *edge.weight()).unwrap();
+
+    let nodes = [a, b, c, d];
+    for node1 in &nodes {
+        for node2 in &nodes {
+            assert_eq!(
+                res.get(&(*node1, *node2)),
+                expected_res.get(&(*node1, *node2))
+            );
+        }
+    }
+}
+
+#[test]
+fn johnson_weighted_undirected() {
+    let mut graph: Graph<(), i32, Undirected> = Graph::new_undirected();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+
+    graph.extend_with_edges([
+        (a, b, 1),
+        (a, c, 4),
+        (a, d, 10),
+        (b, d, 2),
+        (c, b, 2),
+        (c, d, 2),
+    ]);
+
+    let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+        ((a, a), 0),
+        ((a, b), 1),
+        ((a, c), 3),
+        ((a, d), 3),
+        ((b, a), 1),
+        ((b, b), 0),
+        ((b, c), 2),
+        ((b, d), 2),
+        ((c, a), 3),
+        ((c, b), 2),
+        ((c, c), 0),
+        ((c, d), 2),
+        ((d, a), 3),
+        ((d, b), 2),
+        ((d, c), 2),
+        ((d, d), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    let res = johnson(&graph, |edge| *edge.weight()).unwrap();
+
+    let nodes = [a, b, c, d];
+    for node1 in &nodes {
+        for node2 in &nodes {
+            assert_eq!(
+                res.get(&(*node1, *node2)),
+                expected_res.get(&(*node1, *node2))
+            );
+        }
+    }
+}
+
+#[test]
+fn johnson_negative_cycle() {
+    let mut graph: Graph<(), f32, Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+
+    graph.extend_with_edges([(a, b, 1.0), (b, c, -3.0), (c, a, 1.0)]);
+
+    let res = johnson(&graph, |edge| *edge.weight());
+
+    assert!(res.is_err());
+}
+
+#[test]
+fn johnson_multiple_edges() {
+    let mut graph: Graph<(), i32, Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+    let d = graph.add_node(());
+
+    graph.extend_with_edges([
+        (a, b, 10),
+        (a, b, 1),
+        (a, c, 4),
+        (a, d, 10),
+        (b, c, 2),
+        (b, d, 2),
+        (c, d, 2),
+        (a, d, 100),
+        (c, d, 20),
+        (a, a, 5),
+    ]);
+
+    let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
+        ((a, a), 0),
+        ((a, b), 1),
+        ((a, c), 3),
+        ((a, d), 3),
+        ((b, b), 0),
+        ((b, c), 2),
+        ((b, d), 2),
+        ((c, c), 0),
+        ((c, d), 2),
+        ((d, d), 0),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    let res = johnson(&graph, |edge| *edge.weight()).unwrap();
+
+    let nodes = [a, b, c, d];
+    for node1 in &nodes {
+        for node2 in &nodes {
+            assert_eq!(
+                res.get(&(*node1, *node2)),
+                expected_res.get(&(*node1, *node2))
+            );
+        }
+    }
+}

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -34,7 +34,7 @@ use petgraph::algo::{
     find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
     is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching, johnson,
     k_shortest_path, kosaraju_scc, maximal_cliques as maximal_cliques_algo, maximum_matching,
-    min_spanning_tree, page_rank, parallel_johnson, spfa, tarjan_scc, toposort, Matching,
+    min_spanning_tree, page_rank, spfa, tarjan_scc, toposort, Matching,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -47,6 +47,9 @@ use petgraph::visit::{
     IntoNodeReferences, NodeCount, NodeIndexable, Reversed, Topo, VisitMap, Visitable,
 };
 use petgraph::EdgeType;
+
+#[cfg(feature = "rayon")]
+use petgraph::algo::parallel_johnson;
 
 fn mst_graph<N, E, Ty, Ix>(g: &Graph<N, E, Ty, Ix>) -> Graph<N, E, Undirected, Ix>
 where

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -32,7 +32,7 @@ use petgraph::algo::steiner_tree;
 use petgraph::algo::{
     bellman_ford, condensation, connected_components, dijkstra, dsatur_coloring,
     find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
-    is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching,
+    is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching, johnson,
     k_shortest_path, kosaraju_scc, maximal_cliques as maximal_cliques_algo, maximum_matching,
     min_spanning_tree, page_rank, spfa, tarjan_scc, toposort, Matching,
 };
@@ -1554,6 +1554,30 @@ quickcheck! {
             if i >= 10 { break; } // testing all is too slow
             spfa(&gr, start, |edge| *edge.weight()).unwrap();
         }
+        true
+    }
+}
+
+quickcheck! {
+    // checks johnson against dijkstra results
+    fn johnson_(g: Graph<u32, u32>) -> bool {
+        if g.node_count() == 0 {
+            return true;
+        }
+
+        let johnson_res = johnson(&g, |e| *e.weight()).unwrap();
+
+        for node1 in g.node_identifiers() {
+            let dijkstra_res = dijkstra(&g, node1, None, |e| *e.weight());
+
+            for node2 in g.node_identifiers() {
+                // The results must be same
+                if johnson_res.get(&(node1, node2)) != dijkstra_res.get(&node2) {
+                    return false;
+                }
+            }
+        }
+
         true
     }
 }


### PR DESCRIPTION
## Brief
Add [Johnson algorithm][johnson] for all pairs shortest path problem.

```rust
pub fn johnson<G, F, K>(
    graph: G,
    mut edge_cost: F,
) -> Result<HashMap<(G::NodeId, G::NodeId), K>, NegativeCycle>
where
    G: IntoEdges + IntoNodeIdentifiers + NodeIndexable + Visitable,
    G::NodeId: Eq + Hash,
    F: FnMut(G::EdgeRef) -> K,
    K: BoundedMeasure + Copy + Sub<K, Output = K>,
```

## About algorithm & implementation
Johnson's algorithm is based on Dijkstra's algorithm, calling it for each vertex after some preparation using SPFA.
In this way we can find all pair shortest paths in O(VD + VE) time (D is the Dijksta's time complexity).

In the current implementation, we have a time complexity O(VE*log(V) + V^2*log(V)), which is preferable for non-dense graphs, compared to the Floyd-Warshall algorithm.

Instead of SPFA, it would also be possible to use the existing `bellman_ford` implementation, but SPFA usage additionally speeds up the algorithm on sparse graphs, and there is an unconfirmed estimate that SPFA works on average in O(E) time.

## Becnhmarks
I have conducted small comparative tests that confirm the statement that Johnson's algorithm is preferable on sparse graphs (almost five times faster than `floyd_warshall`), but it also naturally loses on dense graphs.

```
test johnson_dense_1000_nodes  ... bench: 1,169,255,997.40 ns/iter (+/- 7,208,144.98)
test johnson_dense_100_nodes   ... bench:   1,777,834.38 ns/iter (+/- 24,188.31)
test johnson_sparse_1000_nodes ... bench:  86,516,820.50 ns/iter (+/- 1,082,174.18)
test johnson_sparse_100_nodes  ... bench:     778,894.19 ns/iter (+/- 14,603.94)
```

```
test floyd_warshall_dense_1000_nodes  ... bench: 544,423,954.20 ns/iter (+/- 7,272,191.85)
test floyd_warshall_dense_100_nodes   ... bench:     568,021.70 ns/iter (+/- 12,867.89)
test floyd_warshall_sparse_1000_nodes ... bench: 495,226,815.90 ns/iter (+/- 8,736,234.74)
test floyd_warshall_sparse_100_nodes  ... bench:     529,623.65 ns/iter (+/- 14,083.83)

```
The benchmark code has also been added to this PR in order to be able to compare the performance of certain algorithms in the future.


## `parallel_johnson`
A version of the algorithm that parallels `dijkstra` calls is available under the `rayon` feature.

```rust
pub fn parallel_johnson<G, F, K>(
    graph: G,
    mut edge_cost: F,
) -> Result<HashMap<(G::NodeId, G::NodeId), K>, NegativeCycle>
where
    G: IntoEdges + IntoNodeIdentifiers + NodeIndexable + Visitable + Sync,
    G::NodeId: Eq + Hash + Send,
    F: Fn(G::EdgeRef) -> K + Sync,
    K: BoundedMeasure + Copy + Sub<K, Output = K> + Send + Sync,
```

The benchmarks show the following performance on PC with Ryzen 9 7950X:
```
test johnson_dense_1000_nodes           ... bench: 1,177,432,008.20 ns/iter (+/- 11,077,709.38)
test johnson_dense_100_nodes            ... bench:   1,714,581.45 ns/iter (+/- 31,400.66)
test johnson_sparse_1000_nodes          ... bench:  78,071,539.40 ns/iter (+/- 2,063,005.61)
test johnson_sparse_100_nodes           ... bench:     660,780.69 ns/iter (+/- 15,389.23)
test parallel_johnson_dense_1000_nodes  ... bench:  68,611,940.20 ns/iter (+/- 1,782,308.55)
test parallel_johnson_dense_100_nodes   ... bench:     258,762.17 ns/iter (+/- 16,887.11)
test parallel_johnson_sparse_1000_nodes ... bench:  14,309,925.60 ns/iter (+/- 1,388,024.20)
test parallel_johnson_sparse_100_nodes  ... bench:     259,247.53 ns/iter (+/- 15,763.51)
```

and
```
test johnson_dense_1000_nodes           ... bench: 1,931,386,001.60 ns/iter (+/- 30,692,353.78)
test johnson_sparse_1000_nodes          ... bench: 155,685,943.60 ns/iter (+/- 104,165,471.95)
test parallel_johnson_dense_1000_nodes  ... bench: 246,817,415.40 ns/iter (+/- 7,077,236.51)
test parallel_johnson_sparse_1000_nodes ... bench:  34,137,779.80 ns/iter (+/- 4,018,118.69)
```
on laptop with 12th Intel(R) i7-12700H

[johnson]: https://en.wikipedia.org/wiki/Johnson%27s_algorithm
