### PR TITLE
feat!: Add `no_std` Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,21 @@ jobs:
         env:
           RUSTDOCFLAGS: "-Dwarnings"
 
+  check-no-std:
+    name: Check no_std
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mozilla-actions/sccache-action@v0.0.7
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32v1-none
+
+      - name: Check
+        run: cargo check --no-default-features -p petgraph --target wasm32v1-none --features graphmap,serde-1
+
   miri:
     name: Unsoundness check
     if: github.event_name != 'merge_group'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           targets: wasm32v1-none
 
       - name: Check
-        run: cargo check --no-default-features -p petgraph --target wasm32v1-none --features graphmap,serde-1
+        run: cargo check --no-default-features -p petgraph --target wasm32v1-none --features graphmap,serde-1,stable_graph,matrix_graph,generate,unstable
 
   miri:
     name: Unsoundness check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         include:
           - rust: 1.64.0  # MSRV
+            required_features: std
+          - rust: 1.81.0  # no_std MSRV
           - rust: stable
             features: unstable quickcheck rayon
             test_all: --all
@@ -51,14 +53,14 @@ jobs:
           cargo update -p once_cell --precise 1.20.3
 
       - name: Build with no features
-        run: cargo build --verbose --no-default-features
+        run: cargo build --verbose --no-default-features --features "${{ matrix.required_features }}"
       - name: Test with no features
-        run: cargo test --verbose --no-default-features
+        run: cargo test --verbose --no-default-features --features "${{ matrix.required_features }}"
 
       - name: Build with features "${{ matrix.features }}"
-        run: cargo build --verbose --features "${{ matrix.features }}"
+        run: cargo build --verbose --features "${{ matrix.features }}" --features "${{ matrix.required_features }}"
       - name: Test with features "${{ matrix.features }}"
-        run: cargo test ${{ matrix.test_all }} --verbose --features "${{ matrix.features }}"
+        run: cargo test ${{ matrix.test_all }} --verbose --features "${{ matrix.features }}" --features "${{ matrix.required_features }}"
 
       - name: Build benchmarks
         if: ${{ matrix.bench }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,11 @@ debug = true
 
 [dependencies]
 fixedbitset = { version = "0.5.7", default-features = false }
-indexmap = "2.5.0"
+indexmap = { version = "2.5.0", default-features = false }
+hashbrown = { version = "^0.15.0" }
 quickcheck = { optional = true, version = "0.8", default-features = false }
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
+serde_derive = { version = "1.0", default-features = false, optional = true }
 rayon = { version = "1.5.3", optional = true }
 
 [dev-dependencies]
@@ -58,7 +59,7 @@ ahash = "0.7.2"
 fxhash = "0.2.1"
 
 [features]
-rayon = ["dep:rayon", "indexmap/rayon"]
+rayon = ["std", "dep:rayon", "indexmap/rayon"]
 
 # feature flags for testing use only
 all = [
@@ -69,12 +70,19 @@ all = [
     "graphmap",
     "rayon",
 ]
-default = ["graphmap", "stable_graph", "matrix_graph"]
+default = ["std", "graphmap", "stable_graph", "matrix_graph"]
 
-generate = [] # For unstable features
+generate = ["std"] # For unstable features
 
 graphmap = []
-matrix_graph = []
+matrix_graph = ["std"] # TODO: could be `no_std` with refactor
 serde-1 = ["serde", "serde_derive"]
-stable_graph = []
+stable_graph = ["std"] # TODO: could be `no_std` with refactor
 unstable = ["generate"]
+
+std = []
+
+[lints.clippy]
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ serde-1 = ["serde", "serde_derive"]
 stable_graph = ["std"] # TODO: could be `no_std` with refactor
 unstable = ["generate"]
 
-std = []
+std = ["indexmap/std"]
 
 [lints.clippy]
 alloc_instead_of_core = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,12 +72,12 @@ all = [
 ]
 default = ["std", "graphmap", "stable_graph", "matrix_graph"]
 
-generate = ["std"] # For unstable features
+generate = [] # For unstable features
 
 graphmap = []
-matrix_graph = ["std"] # TODO: could be `no_std` with refactor
+matrix_graph = []
 serde-1 = ["serde", "serde_derive"]
-stable_graph = ["std"] # TODO: could be `no_std` with refactor
+stable_graph = ["serde?/alloc"]
 unstable = ["generate"]
 
 std = ["indexmap/std"]

--- a/benches/graphmap.rs
+++ b/benches/graphmap.rs
@@ -67,14 +67,17 @@ macro_rules! test_case_with_hasher {
     };
 }
 
-test_case_with_hasher!(graphmap_serial_bench, std::hash::RandomState);
+test_case_with_hasher!(
+    graphmap_serial_bench,
+    std::collections::hash_map::RandomState
+);
 test_case_with_hasher!(graphmap_serial_bench_fxhash, fxhash::FxBuildHasher);
 test_case_with_hasher!(graphmap_serial_bench_ahash, ahash::RandomState);
 
 #[bench]
 fn graphmap_parallel_bench(bench: &mut Bencher) {
     let data = test_nodes();
-    let gr = test_graph::<std::hash::RandomState>(&data);
+    let gr = test_graph::<std::collections::hash_map::RandomState>(&data);
     bench.iter(|| {
         let _sources: Vec<MyStruct> = gr
             .par_nodes()

--- a/benches/matrix_graph.rs
+++ b/benches/matrix_graph.rs
@@ -66,7 +66,7 @@ fn add_5_edges_for_each_of_100_nodes(b: &mut test::Bencher) {
 #[bench]
 fn add_edges_from_root(bench: &mut test::Bencher) {
     bench.iter(|| {
-        let mut gr = MatrixGraph::new();
+        let mut gr = MatrixGraph::<_, _>::new();
         let a = gr.add_node(());
 
         for _ in 0..100 {
@@ -79,7 +79,7 @@ fn add_edges_from_root(bench: &mut test::Bencher) {
 #[bench]
 fn add_adjacent_edges(bench: &mut test::Bencher) {
     bench.iter(|| {
-        let mut gr = MatrixGraph::new();
+        let mut gr = MatrixGraph::<_, _>::new();
         let mut prev = None;
         for _ in 0..100 {
             let b = gr.add_node(());
@@ -151,7 +151,7 @@ const BIGGER: &str = "
 ";
 
 /// Parse a text adjacency matrix format into a directed graph
-fn parse_matrix<Ty: EdgeType>(s: &str) -> MatrixGraph<(), (), Ty> {
+fn parse_matrix<Ty: EdgeType>(s: &str) -> MatrixGraph<(), (), std::hash::RandomState, Ty> {
     let mut gr = MatrixGraph::default();
     let s = s.trim();
     let lines = s.lines().filter(|l| !l.is_empty());

--- a/src/acyclic.rs
+++ b/src/acyclic.rs
@@ -759,11 +759,14 @@ impl_graph_traits!(StableDiGraph);
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::*;
     use crate::prelude::DiGraph;
+    use crate::visit::IntoNodeReferences;
+
     #[cfg(feature = "stable_graph")]
     use crate::prelude::StableDiGraph;
-    use crate::visit::IntoNodeReferences;
 
     #[test]
     fn test_acyclic_graph() {

--- a/src/acyclic.rs
+++ b/src/acyclic.rs
@@ -1,9 +1,9 @@
 //! A wrapper around graph types that enforces an acyclicity invariant.
 
-use std::{
+use alloc::collections::{BTreeMap, BTreeSet};
+use core::{
     cell::RefCell,
     cmp::Ordering,
-    collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
     ops::{Deref, RangeBounds},
 };
@@ -841,7 +841,7 @@ mod tests {
             + IntoNodeReferences
             + IntoNeighborsDirected
             + GraphBase<NodeId = G::NodeId>,
-        G::NodeId: std::fmt::Debug,
+        G::NodeId: core::fmt::Debug,
     {
         let ordered_nodes: Vec<_> = acyclic.nodes_iter().collect();
         assert_eq!(ordered_nodes.len(), acyclic.node_count());

--- a/src/acyclic/order_map.rs
+++ b/src/acyclic/order_map.rs
@@ -3,7 +3,9 @@
 //!
 //! This data structure is an implementation detail and is not exposed in the
 //! public API.
-use std::{collections::BTreeMap, fmt, ops::RangeBounds};
+use alloc::collections::BTreeMap;
+use alloc::{vec, vec::Vec};
+use core::{fmt, ops::RangeBounds};
 
 use crate::{
     algo::{toposort, Cycle},

--- a/src/acyclic/order_map.rs
+++ b/src/acyclic/order_map.rs
@@ -3,8 +3,7 @@
 //!
 //! This data structure is an implementation detail and is not exposed in the
 //! public API.
-use alloc::collections::BTreeMap;
-use alloc::{vec, vec::Vec};
+use alloc::{collections::BTreeMap, vec, vec::Vec};
 use core::{fmt, ops::RangeBounds};
 
 use crate::{

--- a/src/adj.rs
+++ b/src/adj.rs
@@ -1,7 +1,6 @@
 //! Simple adjacency list.
 use alloc::{boxed::Box, vec::Vec};
-use core::fmt;
-use core::ops::Range;
+use core::{fmt, ops::Range};
 
 use fixedbitset::FixedBitSet;
 

--- a/src/adj.rs
+++ b/src/adj.rs
@@ -1,12 +1,15 @@
 //! Simple adjacency list.
+use alloc::{boxed::Box, vec::Vec};
+use core::fmt;
+use core::ops::Range;
+
+use fixedbitset::FixedBitSet;
+
 use crate::data::{Build, DataMap, DataMapMut};
 use crate::iter_format::NoPretty;
 use crate::visit::{
     self, EdgeCount, EdgeRef, GetAdjacencyMatrix, IntoEdgeReferences, IntoNeighbors, NodeCount,
 };
-use fixedbitset::FixedBitSet;
-use std::fmt;
-use std::ops::Range;
 
 #[doc(no_inline)]
 pub use crate::graph::{DefaultIx, IndexType};
@@ -34,7 +37,7 @@ impl (Iterator) for
 #[derive(Debug, Clone)]
 struct OutgoingEdgeIndices <Ix> where { Ix: IndexType }
 item: EdgeIndex<Ix>,
-iter: std::iter::Map<std::iter::Zip<Range<usize>, std::iter::Repeat<NodeIndex<Ix>>>, fn((usize, NodeIndex<Ix>)) -> EdgeIndex<Ix>>,
+iter: core::iter::Map<core::iter::Zip<Range<usize>, core::iter::Repeat<NodeIndex<Ix>>>, fn((usize, NodeIndex<Ix>)) -> EdgeIndex<Ix>>,
 }
 
 /// Weighted sucessor
@@ -48,7 +51,7 @@ struct WSuc<E, Ix: IndexType> {
 
 /// One row of the adjacency list.
 type Row<E, Ix> = Vec<WSuc<E, Ix>>;
-type RowIter<'a, E, Ix> = std::slice::Iter<'a, WSuc<E, Ix>>;
+type RowIter<'a, E, Ix> = core::slice::Iter<'a, WSuc<E, Ix>>;
 
 iterator_wrap! {
 impl (Iterator DoubleEndedIterator ExactSizeIterator) for
@@ -56,7 +59,7 @@ impl (Iterator DoubleEndedIterator ExactSizeIterator) for
 #[derive(Debug, Clone)]
 struct Neighbors<'a, E, Ix> where { Ix: IndexType }
 item: NodeIndex<Ix>,
-iter: std::iter::Map<RowIter<'a, E, Ix>, fn(&WSuc<E, Ix>) -> NodeIndex<Ix>>,
+iter: core::iter::Map<RowIter<'a, E, Ix>, fn(&WSuc<E, Ix>) -> NodeIndex<Ix>>,
 }
 
 /// A reference to an edge of the graph.
@@ -95,7 +98,7 @@ impl<E, Ix: IndexType> visit::EdgeRef for EdgeReference<'_, E, Ix> {
 
 #[derive(Debug, Clone)]
 pub struct EdgeIndices<'a, E, Ix: IndexType> {
-    rows: std::iter::Enumerate<std::slice::Iter<'a, Row<E, Ix>>>,
+    rows: core::iter::Enumerate<core::slice::Iter<'a, Row<E, Ix>>>,
     row_index: usize,
     row_len: usize,
     cur: usize,
@@ -132,7 +135,7 @@ iterator_wrap! {
     #[derive(Debug, Clone)]
     struct NodeIndices <Ix> where {}
     item: Ix,
-    iter: std::iter::Map<Range<usize>, fn(usize) -> Ix>,
+    iter: core::iter::Map<Range<usize>, fn(usize) -> Ix>,
 }
 
 /// An adjacency list with labeled edges.
@@ -266,7 +269,7 @@ impl<E, Ix: IndexType> List<E, Ix> {
                 successor_index,
             };
         let iter = (0..(self.suc[a.index()].len()))
-            .zip(std::iter::repeat(a))
+            .zip(core::iter::repeat(a))
             .map(proj);
         OutgoingEdgeIndices { iter }
     }
@@ -380,7 +383,7 @@ where
         let mut edge_list = f.debug_list();
         let iter: Self = self.clone();
         for e in iter {
-            if std::mem::size_of::<E>() != 0 {
+            if core::mem::size_of::<E>() != 0 {
                 edge_list.entry(&(
                     NoPretty((e.source().index(), e.target().index())),
                     e.weight(),
@@ -475,8 +478,8 @@ impl<'a, E, Ix: IndexType> IntoNeighbors for &'a List<E, Ix> {
     }
 }
 
-type SomeIter<'a, E, Ix> = std::iter::Map<
-    std::iter::Zip<std::iter::Enumerate<RowIter<'a, E, Ix>>, std::iter::Repeat<Ix>>,
+type SomeIter<'a, E, Ix> = core::iter::Map<
+    core::iter::Zip<core::iter::Enumerate<RowIter<'a, E, Ix>>, core::iter::Repeat<Ix>>,
     fn(((usize, &'a WSuc<E, Ix>), Ix)) -> EdgeReference<'a, E, Ix>,
 >;
 
@@ -485,9 +488,9 @@ impl (Iterator) for
 /// An iterator over the [`EdgeReference`] of all the edges of the graph.
 struct EdgeReferences<'a, E, Ix> where { Ix: IndexType }
 item: EdgeReference<'a, E, Ix>,
-iter: std::iter::FlatMap<
-    std::iter::Enumerate<
-        std::slice::Iter<'a, Row<E, Ix>>
+iter: core::iter::FlatMap<
+    core::iter::Enumerate<
+        core::slice::Iter<'a, Row<E, Ix>>
     >,
     SomeIter<'a, E, Ix>,
     fn(
@@ -516,7 +519,7 @@ fn proj1<E, Ix: IndexType>(
 fn proj2<E, Ix: IndexType>((row_index, row): (usize, &Vec<WSuc<E, Ix>>)) -> SomeIter<E, Ix> {
     row.iter()
         .enumerate()
-        .zip(std::iter::repeat(Ix::new(row_index)))
+        .zip(core::iter::repeat(Ix::new(row_index)))
         .map(proj1 as _)
 }
 
@@ -544,7 +547,7 @@ impl<'a, Ix: IndexType, E> visit::IntoEdges for &'a List<E, Ix> {
         let iter = self.suc[a.index()]
             .iter()
             .enumerate()
-            .zip(std::iter::repeat(a))
+            .zip(core::iter::repeat(a))
             .map(proj1 as _);
         OutgoingEdgeReferences { iter }
     }

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -1,9 +1,12 @@
+use alloc::{vec, vec::Vec};
+use core::cmp::min;
+use core::hash::Hash;
+
+use fixedbitset::FixedBitSet;
+use hashbrown::{HashMap, HashSet};
+
 use crate::visit;
 use crate::visit::{EdgeRef, IntoEdges, IntoNodeReferences, NodeIndexable, NodeRef};
-use fixedbitset::FixedBitSet;
-use std::cmp::min;
-use std::collections::{HashMap, HashSet};
-use std::hash::Hash;
 
 /// \[Generic\] Find articulation points in a graph using [Tarjan's algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm).
 ///

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -1,6 +1,5 @@
 use alloc::{vec, vec::Vec};
-use core::cmp::min;
-use core::hash::Hash;
+use core::{cmp::min, hash::Hash};
 
 use fixedbitset::FixedBitSet;
 use hashbrown::{HashMap, HashSet};

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -1,9 +1,10 @@
-use alloc::collections::BinaryHeap;
-use alloc::{vec, vec::Vec};
+use alloc::{collections::BinaryHeap, vec, vec::Vec};
 use core::hash::Hash;
 
-use hashbrown::hash_map::Entry::{Occupied, Vacant};
-use hashbrown::HashMap;
+use hashbrown::hash_map::{
+    Entry::{Occupied, Vacant},
+    HashMap,
+};
 
 use crate::algo::Measure;
 use crate::scored::MinScored;

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -1,12 +1,13 @@
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::{BinaryHeap, HashMap};
+use alloc::collections::BinaryHeap;
+use alloc::{vec, vec::Vec};
+use core::hash::Hash;
 
-use std::hash::Hash;
-
-use crate::scored::MinScored;
-use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
+use hashbrown::hash_map::Entry::{Occupied, Vacant};
+use hashbrown::HashMap;
 
 use crate::algo::Measure;
+use crate::scored::MinScored;
+use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 
 /// \[Generic\] A* shortest path algorithm.
 ///

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -1,5 +1,7 @@
 //! Bellman-Ford algorithms.
 
+use alloc::{vec, vec::Vec};
+
 use crate::prelude::*;
 
 use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeCount, NodeIndexable, VisitMap, Visitable};

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -1,5 +1,8 @@
-use std::collections::{BinaryHeap, HashMap, HashSet};
-use std::hash::Hash;
+use alloc::collections::BinaryHeap;
+use alloc::vec;
+use core::hash::Hash;
+
+use hashbrown::{HashMap, HashSet};
 
 use crate::scored::MaxScored;
 use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visitable};

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -1,5 +1,4 @@
-use alloc::collections::BinaryHeap;
-use alloc::vec;
+use alloc::{collections::BinaryHeap, vec};
 use core::hash::Hash;
 
 use hashbrown::{HashMap, HashSet};

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -1,8 +1,10 @@
 use alloc::collections::BinaryHeap;
 use core::hash::Hash;
 
-use hashbrown::hash_map::Entry::{Occupied, Vacant};
-use hashbrown::HashMap;
+use hashbrown::hash_map::{
+    Entry::{Occupied, Vacant},
+    HashMap,
+};
 
 use crate::algo::Measure;
 use crate::scored::MinScored;

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -1,7 +1,8 @@
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::{BinaryHeap, HashMap};
+use alloc::collections::BinaryHeap;
+use hashbrown::hash_map::Entry::{Occupied, Vacant};
+use hashbrown::HashMap;
 
-use std::hash::Hash;
+use core::hash::Hash;
 
 use crate::algo::Measure;
 use crate::scored::MinScored;
@@ -25,7 +26,7 @@ use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
 /// use petgraph::Graph;
 /// use petgraph::algo::dijkstra;
 /// use petgraph::prelude::*;
-/// use std::collections::HashMap;
+/// use core::collections::HashMap;
 ///
 /// let mut graph: Graph<(), (), Directed> = Graph::new();
 /// let a = graph.add_node(()); // node with no weight

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -26,7 +26,7 @@ use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
 /// use petgraph::Graph;
 /// use petgraph::algo::dijkstra;
 /// use petgraph::prelude::*;
-/// use core::collections::HashMap;
+/// use hashbrown::HashMap;
 ///
 /// let mut graph: Graph<(), (), Directed> = Graph::new();
 /// let a = graph.add_node(()); // node with no weight

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -13,8 +13,7 @@
 //! dominates **C** and **C** dominates **B**.
 
 use alloc::{vec, vec::Vec};
-use core::cmp::Ordering;
-use core::hash::Hash;
+use core::{cmp::Ordering, hash::Hash};
 
 use hashbrown::{hash_map::Iter, HashMap, HashSet};
 

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -12,9 +12,11 @@
 //! strictly dominates **B** and there does not exist any node **C** where **A**
 //! dominates **C** and **C** dominates **B**.
 
-use std::cmp::Ordering;
-use std::collections::{hash_map::Iter, HashMap, HashSet};
-use std::hash::Hash;
+use alloc::{vec, vec::Vec};
+use core::cmp::Ordering;
+use core::hash::Hash;
+
+use hashbrown::{hash_map::Iter, HashMap, HashSet};
 
 use crate::visit::{DfsPostOrder, GraphBase, IntoNeighbors, Visitable, Walker};
 

--- a/src/algo/feedback_arc_set.rs
+++ b/src/algo/feedback_arc_set.rs
@@ -1,5 +1,4 @@
-use alloc::collections::VecDeque;
-use alloc::vec::Vec;
+use alloc::{collections::VecDeque, vec::Vec};
 use core::ops::{Index, IndexMut};
 
 use hashbrown::HashMap;

--- a/src/algo/feedback_arc_set.rs
+++ b/src/algo/feedback_arc_set.rs
@@ -1,7 +1,8 @@
-use std::{
-    collections::{HashMap, VecDeque},
-    ops::{Index, IndexMut},
-};
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+use core::ops::{Index, IndexMut};
+
+use hashbrown::HashMap;
 
 use crate::{
     graph::{GraphIndex, NodeIndex},
@@ -329,7 +330,8 @@ impl Buckets {
 }
 
 mod linked_list {
-    use std::{marker::PhantomData, ops::IndexMut};
+    use alloc::vec::Vec;
+    use core::{marker::PhantomData, ops::IndexMut};
 
     #[derive(PartialEq, Debug)]
     pub struct LinkedList<Data, Container, Ix> {

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
+use alloc::vec;
+use core::hash::Hash;
 
-use std::hash::Hash;
+use hashbrown::HashMap;
 
 use crate::algo::{BoundedMeasure, NegativeCycle};
 use crate::visit::{
@@ -24,7 +25,7 @@ use crate::visit::{
 /// ```rust
 /// use petgraph::{prelude::*, Graph, Directed};
 /// use petgraph::algo::floyd_warshall;
-/// use std::collections::HashMap;
+/// use core::collections::HashMap;
 ///
 /// let mut graph: Graph<(), (), Directed> = Graph::new();
 /// let a = graph.add_node(());
@@ -54,7 +55,7 @@ use crate::visit::{
 /// //    |      v         v
 /// //     --->  d <-------
 ///
-/// let inf = std::i32::MAX;
+/// let inf = core::i32::MAX;
 /// let expected_res: HashMap<(NodeIndex, NodeIndex), i32> = [
 ///    ((a, a), 0), ((a, b), 1), ((a, c), 3), ((a, d), 3),
 ///    ((b, a), inf), ((b, b), 0), ((b, c), 2), ((b, d), 2),

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -25,7 +25,7 @@ use crate::visit::{
 /// ```rust
 /// use petgraph::{prelude::*, Graph, Directed};
 /// use petgraph::algo::floyd_warshall;
-/// use core::collections::HashMap;
+/// use hashbrown::HashMap;
 ///
 /// let mut graph: Graph<(), (), Directed> = Graph::new();
 /// let a = graph.add_node(());

--- a/src/algo/ford_fulkerson.rs
+++ b/src/algo/ford_fulkerson.rs
@@ -1,5 +1,4 @@
-use alloc::collections::VecDeque;
-use alloc::{vec, vec::Vec};
+use alloc::{collections::VecDeque, vec, vec::Vec};
 use core::ops::Sub;
 
 use crate::{

--- a/src/algo/ford_fulkerson.rs
+++ b/src/algo/ford_fulkerson.rs
@@ -1,4 +1,6 @@
-use std::{collections::VecDeque, ops::Sub};
+use alloc::collections::VecDeque;
+use alloc::{vec, vec::Vec};
+use core::ops::Sub;
 
 use crate::{
     data::DataMap,

--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -1,4 +1,5 @@
-use std::convert::TryFrom;
+use alloc::{vec, vec::Vec};
+use core::convert::TryFrom;
 
 use crate::data::DataMap;
 use crate::visit::EdgeCount;

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -1,5 +1,4 @@
-use alloc::collections::BinaryHeap;
-use alloc::{vec, vec::Vec};
+use alloc::{collections::BinaryHeap, vec, vec::Vec};
 use core::hash::Hash;
 
 use hashbrown::HashMap;

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -28,7 +28,7 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 /// use petgraph::Graph;
 /// use petgraph::algo::k_shortest_path;
 /// use petgraph::prelude::*;
-/// use core::collections::HashMap;
+/// use hashbrown::HashMap;
 ///
 /// let mut graph : Graph<(),(),Directed>= Graph::new();
 /// let a = graph.add_node(()); // node with no weight

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -1,6 +1,8 @@
-use std::collections::{BinaryHeap, HashMap};
+use alloc::collections::BinaryHeap;
+use alloc::{vec, vec::Vec};
+use core::hash::Hash;
 
-use std::hash::Hash;
+use hashbrown::HashMap;
 
 use crate::algo::Measure;
 use crate::scored::MinScored;
@@ -26,7 +28,7 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 /// use petgraph::Graph;
 /// use petgraph::algo::k_shortest_path;
 /// use petgraph::prelude::*;
-/// use std::collections::HashMap;
+/// use core::collections::HashMap;
 ///
 /// let mut graph : Graph<(),(),Directed>= Graph::new();
 /// let a = graph.add_node(()); // node with no weight

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -1,5 +1,6 @@
-use std::collections::VecDeque;
-use std::hash::Hash;
+use alloc::collections::VecDeque;
+use alloc::{vec, vec::Vec};
+use core::hash::Hash;
 
 use crate::visit::{
     EdgeRef, GraphBase, IntoEdges, IntoNeighbors, IntoNodeIdentifiers, NodeCount, NodeIndexable,
@@ -356,7 +357,7 @@ where
     assert_ne!(
         graph.node_bound(),
         usize::MAX,
-        "The input graph capacity should be strictly less than std::usize::MAX."
+        "The input graph capacity should be strictly less than core::usize::MAX."
     );
 
     // Greedy algorithm should create a fairly good initial matching. The hope
@@ -509,7 +510,7 @@ fn find_join<G, F>(
     let join = loop {
         // Swap the sides. Do not swap if the right side is already finished.
         if right != graph.dummy_idx() {
-            std::mem::swap(&mut left, &mut right);
+            core::mem::swap(&mut left, &mut right);
         }
 
         // Set left to the next inner vertex in P(source) or P(target).

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -1,5 +1,4 @@
-use alloc::collections::VecDeque;
-use alloc::{vec, vec::Vec};
+use alloc::{collections::VecDeque, vec, vec::Vec};
 use core::hash::Hash;
 
 use crate::visit::{

--- a/src/algo/min_spanning_tree.rs
+++ b/src/algo/min_spanning_tree.rs
@@ -1,11 +1,11 @@
 //! Minimum Spanning Tree algorithms.
 
 use alloc::collections::BinaryHeap;
+
 use hashbrown::{HashMap, HashSet};
 
-use crate::prelude::*;
-
 use crate::data::Element;
+use crate::prelude::*;
 use crate::scored::MinScored;
 use crate::unionfind::UnionFind;
 use crate::visit::{Data, IntoEdges, IntoNodeReferences, NodeRef};

--- a/src/algo/min_spanning_tree.rs
+++ b/src/algo/min_spanning_tree.rs
@@ -1,6 +1,7 @@
 //! Minimum Spanning Tree algorithms.
 
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use alloc::collections::BinaryHeap;
+use hashbrown::{HashMap, HashSet};
 
 use crate::prelude::*;
 

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -21,7 +21,8 @@ pub mod page_rank;
 pub mod simple_paths;
 pub mod tred;
 
-use std::num::NonZeroUsize;
+use alloc::{vec, vec::Vec};
+use core::num::NonZeroUsize;
 
 use crate::prelude::*;
 
@@ -666,14 +667,14 @@ pub struct NegativeCycle(pub ());
 pub fn is_bipartite_undirected<G, N, VM>(g: G, start: N) -> bool
 where
     G: GraphRef + Visitable<NodeId = N, Map = VM> + IntoNeighbors<NodeId = N>,
-    N: Copy + PartialEq + std::fmt::Debug,
+    N: Copy + PartialEq + core::fmt::Debug,
     VM: VisitMap<N>,
 {
     let mut red = g.visit_map();
     red.visit(start);
     let mut blue = g.visit_map();
 
-    let mut stack = ::std::collections::VecDeque::new();
+    let mut stack = ::alloc::collections::VecDeque::new();
     stack.push_front(start);
 
     while let Some(node) = stack.pop_front() {
@@ -713,8 +714,8 @@ where
     true
 }
 
-use std::fmt::Debug;
-use std::ops::Add;
+use core::fmt::Debug;
+use core::ops::Add;
 
 /// Associated data that can be used for measures (such as length).
 pub trait Measure: Debug + PartialOrd + Add<Self, Output = Self> + Default + Clone {}
@@ -745,7 +746,7 @@ impl FloatMeasure for f64 {
     }
 }
 
-pub trait BoundedMeasure: Measure + std::ops::Sub<Self, Output = Self> {
+pub trait BoundedMeasure: Measure + core::ops::Sub<Self, Output = Self> {
     fn min() -> Self;
     fn max() -> Self;
     fn overflowing_add(self, rhs: Self) -> (Self, bool);
@@ -805,10 +806,10 @@ impl_bounded_measure_float!(f32, f64);
 /// and with a default measure of proximity.  
 pub trait UnitMeasure:
     Measure
-    + std::ops::Sub<Self, Output = Self>
-    + std::ops::Mul<Self, Output = Self>
-    + std::ops::Div<Self, Output = Self>
-    + std::iter::Sum
+    + core::ops::Sub<Self, Output = Self>
+    + core::ops::Mul<Self, Output = Self>
+    + core::ops::Div<Self, Output = Self>
+    + core::iter::Sum
 {
     fn zero() -> Self;
     fn one() -> Self;

--- a/src/algo/page_rank.rs
+++ b/src/algo/page_rank.rs
@@ -1,9 +1,11 @@
+use alloc::{vec, vec::Vec};
+
+use super::UnitMeasure;
 use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable};
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
-use super::UnitMeasure;
 /// \[Generic\] Page Rank algorithm.
 ///
 /// Computes the ranks of every node in a graph using the [Page Rank algorithm][pr].
@@ -99,8 +101,8 @@ where
 #[allow(dead_code)]
 fn out_edges_info<G, D>(graph: G, index_w: usize, index_v: usize) -> (D, bool)
 where
-    G: NodeCount + IntoEdges + NodeIndexable + std::marker::Sync,
-    D: UnitMeasure + Copy + std::marker::Send + std::marker::Sync,
+    G: NodeCount + IntoEdges + NodeIndexable + core::marker::Sync,
+    D: UnitMeasure + Copy + core::marker::Send + core::marker::Sync,
 {
     let node_w = graph.from_index(index_w);
     let node_v = graph.from_index(index_v);
@@ -128,8 +130,8 @@ pub fn parallel_page_rank<G, D>(
     tol: Option<D>,
 ) -> Vec<D>
 where
-    G: NodeCount + IntoEdges + NodeIndexable + std::marker::Sync,
-    D: UnitMeasure + Copy + std::marker::Send + std::marker::Sync,
+    G: NodeCount + IntoEdges + NodeIndexable + core::marker::Sync,
+    D: UnitMeasure + Copy + core::marker::Send + core::marker::Sync,
 {
     let node_count = graph.node_count();
     if node_count == 0 {

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// # Example
 /// ```
-/// use std::hash::RandomState;
+/// use std::collections::hash_map::RandomState;
 /// use petgraph::{algo, prelude::*};
 ///
 /// let mut graph = DiGraph::<&str, i32>::new();

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -125,7 +125,7 @@ where
 mod test {
     use alloc::{vec, vec::Vec};
     use core::iter::FromIterator;
-    use std::{hash::RandomState, println};
+    use std::{collections::hash_map::RandomState, println};
 
     use hashbrown::HashSet;
     use itertools::assert_equal;

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -128,14 +128,15 @@ where
 
 #[cfg(test)]
 mod test {
+    use alloc::{vec, vec::Vec};
     use core::iter::FromIterator;
-    use hashbrown::HashSet;
+    use std::println;
 
+    use hashbrown::HashSet;
     use itertools::assert_equal;
 
-    use crate::{dot::Dot, prelude::DiGraph};
-
     use super::all_simple_paths;
+    use crate::{dot::Dot, prelude::DiGraph};
 
     #[test]
     fn test_all_simple_paths() {

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -1,6 +1,6 @@
 use alloc::vec;
 use core::{
-    hash::Hash,
+    hash::{BuildHasher, Hash},
     iter::{from_fn, FromIterator},
 };
 
@@ -51,11 +51,7 @@ use crate::{
 ///
 /// So if you have a large enough graph, be prepared to wait for the results for years.
 /// Or consider extracting only part of the simple paths using the adapter [`Iterator::take`].
-pub fn all_simple_paths<
-    TargetColl,
-    G,
-    #[cfg(not(feature = "std"))] S: core::hash::BuildHasher + Default,
->(
+pub fn all_simple_paths<TargetColl, G, S>(
     graph: G,
     from: G::NodeId,
     to: G::NodeId,
@@ -67,10 +63,8 @@ where
     G: IntoNeighborsDirected,
     G::NodeId: Eq + Hash,
     TargetColl: FromIterator<G::NodeId>,
+    S: BuildHasher + Default,
 {
-    #[cfg(feature = "std")]
-    type S = std::hash::RandomState;
-
     // how many nodes are allowed in simple path up to target node
     // it is min/max allowed path length minus one, because it is more appropriate when implementing lookahead
     // than constantly add 1 to length of current path
@@ -130,7 +124,7 @@ where
 mod test {
     use alloc::{vec, vec::Vec};
     use core::iter::FromIterator;
-    use std::println;
+    use std::{hash::RandomState, println};
 
     use hashbrown::HashSet;
     use itertools::assert_equal;
@@ -169,7 +163,7 @@ mod test {
 
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_5: HashSet<Vec<_>> =
-            all_simple_paths(&graph, 0u32.into(), 5u32.into(), 0, None)
+            all_simple_paths::<_, _, RandomState>(&graph, 0u32.into(), 5u32.into(), 0, None)
                 .map(|v: Vec<_>| v.into_iter().map(|i| i.index()).collect())
                 .collect();
         assert_eq!(actual_simple_paths_0_to_5.len(), 8);
@@ -186,7 +180,7 @@ mod test {
         let expexted_simple_paths_0_to_1 = &[vec![0usize, 1]];
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_1: Vec<Vec<_>> =
-            all_simple_paths(&graph, 0u32.into(), 1u32.into(), 0, None)
+            all_simple_paths::<_, _, RandomState>(&graph, 0u32.into(), 1u32.into(), 0, None)
                 .map(|v: Vec<_>| v.into_iter().map(|i| i.index()).collect())
                 .collect();
 
@@ -200,7 +194,7 @@ mod test {
 
         println!("{}", Dot::new(&graph));
         let actual_simple_paths_0_to_2: Vec<Vec<_>> =
-            all_simple_paths(&graph, 0u32.into(), 2u32.into(), 0, None)
+            all_simple_paths::<_, _, RandomState>(&graph, 0u32.into(), 2u32.into(), 0, None)
                 .map(|v: Vec<_>| v.into_iter().map(|i| i.index()).collect())
                 .collect();
 

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -18,6 +18,7 @@ use crate::{
 ///
 /// # Example
 /// ```
+/// use std::hash::RandomState;
 /// use petgraph::{algo, prelude::*};
 ///
 /// let mut graph = DiGraph::<&str, i32>::new();
@@ -29,14 +30,14 @@ use crate::{
 ///
 /// graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (c, d, 1), (a, b, 1), (b, d, 1)]);
 ///
-/// let paths = algo::all_simple_paths::<Vec<_>, _>(&graph, a, d, 0, None)
+/// let paths = algo::all_simple_paths::<Vec<_>, _, RandomState>(&graph, a, d, 0, None)
 ///   .collect::<Vec<_>>();
 ///
 /// assert_eq!(paths.len(), 4);
 ///
 ///
 /// // Take only 2 paths.
-/// let paths = algo::all_simple_paths::<Vec<_>, _>(&graph, a, d, 0, None)
+/// let paths = algo::all_simple_paths::<Vec<_>, _, RandomState>(&graph, a, d, 0, None)
 ///   .take(2)
 ///   .collect::<Vec<_>>();
 ///

--- a/src/algo/steiner_tree.rs
+++ b/src/algo/steiner_tree.rs
@@ -1,6 +1,5 @@
 use alloc::vec::Vec;
-use core::fmt::Debug;
-use core::hash::Hash;
+use core::{fmt::Debug, hash::Hash};
 
 use hashbrown::{HashMap, HashSet};
 

--- a/src/algo/tred.rs
+++ b/src/algo/tred.rs
@@ -8,13 +8,16 @@
 //! closure of **Gr** is the same as that of **G**.
 //! The transitive reduction is well-defined for acyclic graphs only.
 
+use alloc::{vec, vec::Vec};
+
+use fixedbitset::FixedBitSet;
+
 use crate::adj::{List, UnweightedList};
 use crate::graph::IndexType;
 use crate::visit::{
     GraphBase, IntoNeighbors, IntoNeighborsDirected, NodeCompactIndexable, NodeCount,
 };
 use crate::Direction;
-use fixedbitset::FixedBitSet;
 
 /// Creates a representation of the same graph respecting topological order for use in `tred::dag_transitive_reduction_closure`.
 ///

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -37,6 +37,10 @@ pub enum CsrError {
     IndicesOutBounds(usize, usize),
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for CsrError {}
+
+#[cfg(not(feature = "std"))]
 impl core::error::Error for CsrError {}
 
 impl fmt::Display for CsrError {

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1,12 +1,14 @@
 //! Compressed Sparse Row (CSR) is a sparse adjacency matrix graph.
 
 use alloc::{vec, vec::Vec};
-use core::cmp::{max, Ordering};
-use core::fmt;
-use core::iter::{Enumerate, Zip};
-use core::marker::PhantomData;
-use core::ops::{Index, IndexMut, Range};
-use core::slice::Windows;
+use core::{
+    cmp::{max, Ordering},
+    fmt,
+    iter::{Enumerate, Zip},
+    marker::PhantomData,
+    ops::{Index, IndexMut, Range},
+    slice::Windows,
+};
 
 use crate::visit::{
     Data, EdgeCount, EdgeRef, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences,

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -889,6 +889,9 @@ Row   : [0, 2, 5]   <- value index of row start
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+    use std::println;
+
     use super::Csr;
     use crate::algo::bellman_ford;
     use crate::algo::find_negative_cycle;

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -1,11 +1,12 @@
 //! Compressed Sparse Row (CSR) is a sparse adjacency matrix graph.
 
-use std::cmp::{max, Ordering};
-use std::fmt;
-use std::iter::{Enumerate, Zip};
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut, Range};
-use std::slice::Windows;
+use alloc::{vec, vec::Vec};
+use core::cmp::{max, Ordering};
+use core::fmt;
+use core::iter::{Enumerate, Zip};
+use core::marker::PhantomData;
+use core::ops::{Index, IndexMut, Range};
+use core::slice::Windows;
 
 use crate::visit::{
     Data, EdgeCount, EdgeRef, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences,
@@ -34,7 +35,7 @@ pub enum CsrError {
     IndicesOutBounds(usize, usize),
 }
 
-impl std::error::Error for CsrError {}
+impl core::error::Error for CsrError {}
 
 impl fmt::Display for CsrError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -639,7 +640,7 @@ where
     }
 }
 
-use std::slice::Iter as SliceIter;
+use core::slice::Iter as SliceIter;
 
 #[derive(Clone, Debug)]
 pub struct Neighbors<'a, Ix: 'a = DefaultIx> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,5 @@
 //! Graph traits for associated data and graph construction.
 
-use core::hash::BuildHasher;
-
 use alloc::vec::Vec;
 
 use crate::graph::IndexType;
@@ -13,7 +11,10 @@ use crate::Graph;
 use crate::stable_graph::StableGraph;
 
 #[cfg(feature = "graphmap")]
-use crate::graphmap::{GraphMap, NodeTrait};
+use {
+    crate::graphmap::{GraphMap, NodeTrait},
+    core::hash::BuildHasher,
+};
 
 trait_template! {
     /// Access node and edge weights (associated data).

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,13 +1,19 @@
 //! Graph traits for associated data and graph construction.
 
+use core::hash::BuildHasher;
+
+use alloc::vec::Vec;
+
 use crate::graph::IndexType;
-#[cfg(feature = "graphmap")]
-use crate::graphmap::{GraphMap, NodeTrait};
-#[cfg(feature = "stable_graph")]
-use crate::stable_graph::StableGraph;
 use crate::visit::{Data, NodeCount, NodeIndexable, Reversed};
 use crate::EdgeType;
 use crate::Graph;
+
+#[cfg(feature = "stable_graph")]
+use crate::stable_graph::StableGraph;
+
+#[cfg(feature = "graphmap")]
+use crate::graphmap::{GraphMap, NodeTrait};
 
 trait_template! {
     /// Access node and edge weights (associated data).
@@ -186,10 +192,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> Build for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> Build for GraphMap<N, E, Ty, S>
 where
     Ty: EdgeType,
     N: NodeTrait,
+    S: BuildHasher,
 {
     fn add_node(&mut self, weight: Self::NodeWeight) -> Self::NodeId {
         self.add_node(weight)
@@ -241,10 +248,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> Create for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> Create for GraphMap<N, E, Ty, S>
 where
     Ty: EdgeType,
     N: NodeTrait,
+    S: BuildHasher + Default,
 {
     fn with_capacity(nodes: usize, edges: usize) -> Self {
         Self::with_capacity(nodes, edges)
@@ -352,10 +360,11 @@ where
 }
 
 #[cfg(feature = "graphmap")]
-impl<N, E, Ty> FromElements for GraphMap<N, E, Ty>
+impl<N, E, Ty, S> FromElements for GraphMap<N, E, Ty, S>
 where
     Ty: EdgeType,
     N: NodeTrait,
+    S: BuildHasher + Default,
 {
     fn from_elements<I>(iterable: I) -> Self
     where

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -301,10 +301,12 @@ where
 
 #[cfg(test)]
 mod test {
+    use alloc::{format, string::String};
+    use core::fmt::Write;
+
     use super::{Config, Dot, Escaper};
     use crate::prelude::Graph;
     use crate::visit::NodeRef;
-    use core::fmt::Write;
 
     #[test]
     fn test_escape() {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,6 +1,7 @@
 //! Simple graphviz dot file format output.
 
-use std::fmt::{self, Display, Write};
+use alloc::string::String;
+use core::fmt::{self, Display, Write};
 
 use crate::visit::{
     EdgeRef, GraphProp, IntoEdgeReferences, IntoNodeReferences, NodeIndexable, NodeRef,
@@ -303,7 +304,7 @@ mod test {
     use super::{Config, Dot, Escaper};
     use crate::prelude::Graph;
     use crate::visit::NodeRef;
-    use std::fmt::Write;
+    use core::fmt::Write;
 
     #[test]
     fn test_escape() {

--- a/src/graph6/graph6_decoder.rs
+++ b/src/graph6/graph6_decoder.rs
@@ -1,12 +1,18 @@
 //! [graph6 format](https://users.cecs.anu.edu.au/~bdm/data/formats.txt) decoder for undirected graphs.
 
+use alloc::{
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+
 use crate::{csr::Csr, graph::IndexType, Graph, Undirected};
 
 #[cfg(feature = "graphmap")]
 use crate::graphmap::GraphMap;
 
 #[cfg(feature = "graphmap")]
-use std::hash::BuildHasher;
+use core::hash::BuildHasher;
 
 #[cfg(feature = "matrix_graph")]
 use crate::matrix_graph::{MatrixGraph, Nullable};

--- a/src/graph6/graph6_decoder.rs
+++ b/src/graph6/graph6_decoder.rs
@@ -168,15 +168,16 @@ impl<Ix: IndexType, S: BuildHasher + Default> FromGraph6 for GraphMap<Ix, (), Un
 }
 
 #[cfg(feature = "matrix_graph")]
-impl<Null, Ix> FromGraph6 for MatrixGraph<(), (), Undirected, Null, Ix>
+impl<Null, Ix, S> FromGraph6 for MatrixGraph<(), (), S, Undirected, Null, Ix>
 where
     Null: Nullable<Wrapped = ()>,
     Ix: IndexType,
+    S: BuildHasher + Default,
 {
     fn from_graph6_string(graph6_string: String) -> Self {
         let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string);
 
-        let mut graph: MatrixGraph<(), (), Undirected, Null, Ix> =
+        let mut graph: MatrixGraph<(), (), S, Undirected, Null, Ix> =
             MatrixGraph::with_capacity(order);
         for _ in 0..order {
             graph.add_node(());

--- a/src/graph6/graph6_encoder.rs
+++ b/src/graph6/graph6_encoder.rs
@@ -142,11 +142,12 @@ impl<N: NodeTrait, E, S: BuildHasher> ToGraph6 for GraphMap<N, E, Undirected, S>
 }
 
 #[cfg(feature = "matrix_graph")]
-impl<N, E, Null, Ix> ToGraph6 for MatrixGraph<N, E, Undirected, Null, Ix>
+impl<N, E, S, Null, Ix> ToGraph6 for MatrixGraph<N, E, S, Undirected, Null, Ix>
 where
     N: NodeTrait,
     Null: Nullable<Wrapped = E>,
     Ix: IndexType,
+    S: BuildHasher + Default,
 {
     fn graph6_string(&self) -> String {
         get_graph6_representation(self)

--- a/src/graph6/graph6_encoder.rs
+++ b/src/graph6/graph6_encoder.rs
@@ -1,5 +1,11 @@
 //! [graph6 format](https://users.cecs.anu.edu.au/~bdm/data/formats.txt) encoder for undirected graphs.
 
+use alloc::{
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+
 use crate::{
     csr::Csr,
     graph::IndexType,
@@ -11,7 +17,7 @@ use crate::{
 use crate::graphmap::{GraphMap, NodeTrait};
 
 #[cfg(feature = "graphmap")]
-use std::hash::BuildHasher;
+use core::hash::BuildHasher;
 
 #[cfg(feature = "matrix_graph")]
 use crate::matrix_graph::{MatrixGraph, Nullable};

--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref, Index, IndexMut};
+use core::ops::{Deref, Index, IndexMut};
 
 use super::Frozen;
 use crate::data::{DataMap, DataMapMut};

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1,11 +1,12 @@
-use std::cmp;
-use std::fmt;
-use std::hash::Hash;
-use std::iter;
-use std::marker::PhantomData;
-use std::mem::size_of;
-use std::ops::{Index, IndexMut, Range};
-use std::slice;
+use alloc::{vec, vec::Vec};
+use core::cmp;
+use core::fmt;
+use core::hash::Hash;
+use core::iter;
+use core::marker::PhantomData;
+use core::mem::size_of;
+use core::ops::{Index, IndexMut, Range};
+use core::slice;
 
 use fixedbitset::FixedBitSet;
 
@@ -433,7 +434,7 @@ enum Pair<T> {
     None,
 }
 
-use std::cmp::max;
+use core::cmp::max;
 
 /// Get mutable references at index `a` and `b`.
 fn index_twice<T>(slc: &mut [T], a: usize, b: usize) -> Pair<&mut T> {
@@ -1769,7 +1770,7 @@ where
 
 /// Iterator yielding immutable access to all node weights.
 pub struct NodeWeights<'a, N: 'a, Ix: IndexType = DefaultIx> {
-    nodes: ::std::slice::Iter<'a, Node<N, Ix>>,
+    nodes: ::core::slice::Iter<'a, Node<N, Ix>>,
 }
 impl<'a, N, Ix> Iterator for NodeWeights<'a, N, Ix>
 where
@@ -1788,7 +1789,7 @@ where
 /// Iterator yielding mutable access to all node weights.
 #[derive(Debug)]
 pub struct NodeWeightsMut<'a, N: 'a, Ix: IndexType = DefaultIx> {
-    nodes: ::std::slice::IterMut<'a, Node<N, Ix>>, // TODO: change type to something that implements Clone?
+    nodes: ::core::slice::IterMut<'a, Node<N, Ix>>, // TODO: change type to something that implements Clone?
 }
 
 impl<'a, N, Ix> Iterator for NodeWeightsMut<'a, N, Ix>
@@ -1808,7 +1809,7 @@ where
 
 /// Iterator yielding immutable access to all edge weights.
 pub struct EdgeWeights<'a, E: 'a, Ix: IndexType = DefaultIx> {
-    edges: ::std::slice::Iter<'a, Edge<E, Ix>>,
+    edges: ::core::slice::Iter<'a, Edge<E, Ix>>,
 }
 
 impl<'a, E, Ix> Iterator for EdgeWeights<'a, E, Ix>
@@ -1829,7 +1830,7 @@ where
 /// Iterator yielding mutable access to all edge weights.
 #[derive(Debug)]
 pub struct EdgeWeightsMut<'a, E: 'a, Ix: IndexType = DefaultIx> {
-    edges: ::std::slice::IterMut<'a, Edge<E, Ix>>, // TODO: change type to something that implements Clone?
+    edges: ::core::slice::IterMut<'a, Edge<E, Ix>>, // TODO: change type to something that implements Clone?
 }
 
 impl<'a, E, Ix> Iterator for EdgeWeightsMut<'a, E, Ix>

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1,12 +1,13 @@
 use alloc::{vec, vec::Vec};
-use core::cmp;
-use core::fmt;
-use core::hash::Hash;
-use core::iter;
-use core::marker::PhantomData;
-use core::mem::size_of;
-use core::ops::{Index, IndexMut, Range};
-use core::slice;
+use core::{
+    cmp, fmt,
+    hash::Hash,
+    iter,
+    marker::PhantomData,
+    mem::size_of,
+    ops::{Index, IndexMut, Range},
+    slice,
+};
 
 use fixedbitset::FixedBitSet;
 

--- a/src/graph_impl/serialization.rs
+++ b/src/graph_impl/serialization.rs
@@ -1,18 +1,17 @@
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
 use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use std::marker::PhantomData;
-
-use crate::prelude::*;
-
+use super::{EdgeIndex, NodeIndex};
 use crate::graph::Node;
 use crate::graph::{Edge, IndexType};
+use crate::prelude::*;
 use crate::serde_utils::CollectSeqWithLength;
 use crate::serde_utils::MappedSequenceVisitor;
 use crate::serde_utils::{FromDeserialized, IntoSerializable};
 use crate::EdgeType;
-
-use super::{EdgeIndex, NodeIndex};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Serialization representation for Graph
 /// Keep in sync with deserialization and StableGraph

--- a/src/graph_impl/serialization.rs
+++ b/src/graph_impl/serialization.rs
@@ -1,16 +1,14 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 use super::{EdgeIndex, NodeIndex};
-use crate::graph::Node;
-use crate::graph::{Edge, IndexType};
+use crate::graph::{Edge, IndexType, Node};
 use crate::prelude::*;
-use crate::serde_utils::CollectSeqWithLength;
-use crate::serde_utils::MappedSequenceVisitor;
-use crate::serde_utils::{FromDeserialized, IntoSerializable};
+use crate::serde_utils::{
+    CollectSeqWithLength, FromDeserialized, IntoSerializable, MappedSequenceVisitor,
+};
 use crate::EdgeType;
 
 /// Serialization representation for Graph

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -3,26 +3,25 @@
 //! Depends on `feature = "stable_graph"`.
 //!
 
-use std::cmp;
-use std::fmt;
-use std::iter;
-use std::marker::PhantomData;
-use std::mem::replace;
-use std::mem::size_of;
-use std::ops::{Index, IndexMut};
-use std::slice;
+use alloc::vec;
+use core::cmp;
+use core::fmt;
+use core::iter;
+use core::marker::PhantomData;
+use core::mem::replace;
+use core::mem::size_of;
+use core::ops::{Index, IndexMut};
+use core::slice;
 
 use fixedbitset::FixedBitSet;
 
-use crate::{Directed, Direction, EdgeType, Graph, Incoming, Outgoing, Undirected};
-
+use super::{index_twice, Edge, Frozen, Node, Pair, DIRECTIONS};
 use crate::iter_format::{DebugMap, IterFormatExt, NoPretty};
 use crate::iter_utils::IterUtilsExt;
-
-use super::{index_twice, Edge, Frozen, Node, Pair, DIRECTIONS};
 use crate::visit;
 use crate::visit::{EdgeIndexable, EdgeRef, IntoEdgeReferences, NodeIndexable};
 use crate::IntoWeightedEdge;
+use crate::{Directed, Direction, EdgeType, Graph, Incoming, Outgoing, Undirected};
 
 // reexport those things that are shared with Graph
 #[doc(no_inline)]

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -1983,6 +1983,8 @@ where
 
 #[test]
 fn stable_graph() {
+    use std::println;
+
     let mut gr = StableGraph::<_, _>::with_capacity(0, 0);
     let a = gr.add_node(0);
     let b = gr.add_node(1);
@@ -2013,6 +2015,8 @@ fn stable_graph() {
 
 #[test]
 fn dfs() {
+    use std::println;
+
     use crate::visit::Dfs;
 
     let mut gr = StableGraph::<_, _>::with_capacity(0, 0);

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -4,14 +4,13 @@
 //!
 
 use alloc::vec;
-use core::cmp;
-use core::fmt;
-use core::iter;
-use core::marker::PhantomData;
-use core::mem::replace;
-use core::mem::size_of;
-use core::ops::{Index, IndexMut};
-use core::slice;
+use core::{
+    cmp, fmt, iter,
+    marker::PhantomData,
+    mem::{replace, size_of},
+    ops::{Index, IndexMut},
+    slice,
+};
 
 use fixedbitset::FixedBitSet;
 

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -1,22 +1,19 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-use crate::graph::Node;
-use crate::graph::{Edge, IndexType};
-use crate::prelude::*;
-use crate::serde_utils::CollectSeqWithLength;
-use crate::serde_utils::MappedSequenceVisitor;
-use crate::serde_utils::{FromDeserialized, IntoSerializable};
-use crate::stable_graph::StableGraph;
-use crate::visit::{EdgeIndexable, NodeIndexable};
-use crate::EdgeType;
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 use super::super::serialization::{
     invalid_hole_err, invalid_length_err, invalid_node_err, EdgeProperty,
 };
+use crate::graph::{Edge, IndexType, Node};
+use crate::prelude::*;
+use crate::serde_utils::{
+    CollectSeqWithLength, FromDeserialized, IntoSerializable, MappedSequenceVisitor,
+};
+use crate::stable_graph::StableGraph;
+use crate::visit::{EdgeIndexable, NodeIndexable};
+use crate::EdgeType;
 
 // Serialization representation for StableGraph
 // Keep in sync with deserialization and Graph

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -1,12 +1,12 @@
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use std::marker::PhantomData;
-
-use crate::prelude::*;
-
 use crate::graph::Node;
 use crate::graph::{Edge, IndexType};
+use crate::prelude::*;
 use crate::serde_utils::CollectSeqWithLength;
 use crate::serde_utils::MappedSequenceVisitor;
 use crate::serde_utils::{FromDeserialized, IntoSerializable};

--- a/src/graph_impl/stable_graph/serialization.rs
+++ b/src/graph_impl/stable_graph/serialization.rs
@@ -260,10 +260,13 @@ where
 
 #[test]
 fn test_from_deserialized_with_holes() {
-    use crate::graph::node_index;
-    use crate::stable_graph::StableUnGraph;
+    use alloc::vec;
+
     use itertools::assert_equal;
     use serde::de::value::Error as SerdeError;
+
+    use crate::graph::node_index;
+    use crate::stable_graph::StableUnGraph;
 
     let input = DeserStableGraph::<_, (), u32> {
         nodes: vec![

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -24,7 +24,7 @@ use crate::IntoWeightedEdge;
 use crate::{Directed, Direction, EdgeType, Incoming, Outgoing, Undirected};
 
 #[cfg(feature = "std")]
-use std::collections::hash_map::RandomState;
+use std::hash::RandomState;
 
 #[cfg(feature = "rayon")]
 use indexmap::map::rayon::{ParIter, ParIterMut, ParKeys};
@@ -35,14 +35,14 @@ use rayon::prelude::*;
 ///
 /// For example, an edge between *1* and *2* is equivalent to an edge between
 /// *2* and *1*.
-pub type UnGraphMap<N, E, #[cfg(not(feature = "std"))] RandomState> =
-    GraphMap<N, E, Undirected, RandomState>;
+pub type UnGraphMap<N, E, #[cfg(not(feature = "std"))] S, #[cfg(feature = "std")] S = RandomState> =
+    GraphMap<N, E, Undirected, S>;
 /// A `GraphMap` with directed edges.
 ///
 /// For example, an edge from *1* to *2* is distinct from an edge from *2* to
 /// *1*.
-pub type DiGraphMap<N, E, #[cfg(not(feature = "std"))] RandomState> =
-    GraphMap<N, E, Directed, RandomState>;
+pub type DiGraphMap<N, E, #[cfg(not(feature = "std"))] S, #[cfg(feature = "std")] S = RandomState> =
+    GraphMap<N, E, Directed, S>;
 
 /// `GraphMap<N, E, Ty>` is a graph datastructure using an associative array
 /// of its node weights `N`.

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 #[cfg(feature = "std")]
-use std::hash::RandomState;
+use std::collections::hash_map::RandomState;
 
 #[cfg(feature = "rayon")]
 use {

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -2,34 +2,36 @@
 //! keys.
 
 use alloc::vec::Vec;
-use core::cmp::Ordering;
-use core::fmt;
-use core::hash::{self, BuildHasher, Hash};
-use core::iter::Copied;
-use core::iter::FromIterator;
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::{Deref, Index, IndexMut};
-use core::slice::Iter;
+use core::{
+    cmp::Ordering,
+    fmt,
+    hash::{self, BuildHasher, Hash},
+    iter::{Copied, FromIterator},
+    marker::PhantomData,
+    mem,
+    ops::{Deref, Index, IndexMut},
+    slice::Iter,
+};
 
 use hashbrown::HashSet;
-use indexmap::map::Keys;
-use indexmap::map::{Iter as IndexMapIter, IterMut as IndexMapIterMut};
-use indexmap::IndexMap;
+use indexmap::{
+    map::{Iter as IndexMapIter, IterMut as IndexMapIterMut, Keys},
+    IndexMap,
+};
 
-use crate::graph::node_index;
-use crate::graph::Graph;
-use crate::visit;
-use crate::IntoWeightedEdge;
-use crate::{Directed, Direction, EdgeType, Incoming, Outgoing, Undirected};
+use crate::{
+    graph::{node_index, Graph},
+    visit, Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected,
+};
 
 #[cfg(feature = "std")]
 use std::hash::RandomState;
 
 #[cfg(feature = "rayon")]
-use indexmap::map::rayon::{ParIter, ParIterMut, ParKeys};
-#[cfg(feature = "rayon")]
-use rayon::prelude::*;
+use {
+    indexmap::map::rayon::{ParIter, ParIterMut, ParKeys},
+    rayon::prelude::*,
+};
 
 /// A `GraphMap` with undirected edges.
 ///

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -335,7 +335,7 @@ where
     /// // Create a GraphMap with directed edges, and add one edge to it
     /// use petgraph::graphmap::DiGraphMap;
     ///
-    /// let mut g = DiGraphMap::new();
+    /// let mut g = DiGraphMap::<_, _>::new();
     /// g.add_edge("x", "y", -1);
     /// assert_eq!(g.node_count(), 2);
     /// assert_eq!(g.edge_count(), 1);
@@ -398,7 +398,7 @@ where
     /// // Create a GraphMap with undirected edges, and add and remove an edge.
     /// use petgraph::graphmap::UnGraphMap;
     ///
-    /// let mut g = UnGraphMap::new();
+    /// let mut g = UnGraphMap::<_, _>::new();
     /// g.add_edge("x", "y", -1);
     ///
     /// let edge_data = g.remove_edge("y", "x");

--- a/src/iter_format.rs
+++ b/src/iter_format.rs
@@ -1,7 +1,7 @@
 //! Formatting utils
 
-use std::cell::RefCell;
-use std::fmt;
+use core::cell::RefCell;
+use core::fmt;
 
 /// Format the iterator like a map
 pub struct DebugMap<F>(pub F);

--- a/src/iter_format.rs
+++ b/src/iter_format.rs
@@ -1,7 +1,6 @@
 //! Formatting utils
 
-use core::cell::RefCell;
-use core::fmt;
+use core::{cell::RefCell, fmt};
 
 /// Format the iterator like a map
 pub struct DebugMap<F>(pub F);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,12 @@
 //!   Defaults on. Enables [`MatrixGraph`](./matrix_graph/struct.MatrixGraph.html).
 //!
 #![doc(html_root_url = "https://docs.rs/petgraph/0.4/")]
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 extern crate fixedbitset;
 #[cfg(feature = "graphmap")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 
 extern crate alloc;
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", test))]
 extern crate std;
 
 extern crate fixedbitset;

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -1,23 +1,27 @@
 //! `MatrixGraph<N, E, Ty, NullN, NullE, Ix>` is a graph datastructure backed by an adjacency matrix.
 
 use alloc::{vec, vec::Vec};
-use core::cmp;
-use core::hash::BuildHasher;
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::{Index, IndexMut};
+use core::{
+    cmp,
+    hash::BuildHasher,
+    marker::PhantomData,
+    mem,
+    ops::{Index, IndexMut},
+};
 
 use fixedbitset::FixedBitSet;
 use indexmap::IndexSet;
 
-use crate::data::Build;
-use crate::graph::NodeIndex as GraphNodeIndex;
-use crate::visit::{
-    Data, EdgeCount, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
-    IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
-    IntoNodeReferences, NodeCount, NodeIndexable, Visitable,
+use crate::{
+    data::Build,
+    graph::NodeIndex as GraphNodeIndex,
+    visit::{
+        Data, EdgeCount, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+        IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
+        IntoNodeReferences, NodeCount, NodeIndexable, Visitable,
+    },
+    Directed, Direction, EdgeType, IntoWeightedEdge, Outgoing, Undirected,
 };
-use crate::{Directed, Direction, EdgeType, IntoWeightedEdge, Outgoing, Undirected};
 
 #[cfg(feature = "std")]
 use std::hash::RandomState;

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -1,26 +1,22 @@
 //! `MatrixGraph<N, E, Ty, NullN, NullE, Ix>` is a graph datastructure backed by an adjacency matrix.
 
-use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
-
-use std::cmp;
-use std::mem;
-
-use indexmap::IndexSet;
+use alloc::{vec, vec::Vec};
+use core::cmp;
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::{Index, IndexMut};
 
 use fixedbitset::FixedBitSet;
+use indexmap::IndexSet;
 
-use crate::{Directed, Direction, EdgeType, IntoWeightedEdge, Outgoing, Undirected};
-
+use crate::data::Build;
 use crate::graph::NodeIndex as GraphNodeIndex;
-
 use crate::visit::{
     Data, EdgeCount, GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
     IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
     IntoNodeReferences, NodeCount, NodeIndexable, Visitable,
 };
-
-use crate::data::Build;
+use crate::{Directed, Direction, EdgeType, IntoWeightedEdge, Outgoing, Undirected};
 
 pub use crate::graph::IndexType;
 

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 #[cfg(feature = "std")]
-use std::hash::RandomState;
+use std::collections::hash_map::RandomState;
 
 pub use crate::graph::IndexType;
 
@@ -1323,6 +1323,8 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
 
 #[cfg(test)]
 mod tests {
+    use std::collections::hash_map::RandomState;
+
     use super::*;
     use crate::{Incoming, Outgoing};
 
@@ -1371,7 +1373,7 @@ mod tests {
 
     #[test]
     fn test_add_edge() {
-        let mut g = MatrixGraph::<_, _, std::hash::RandomState>::new();
+        let mut g = MatrixGraph::<_, _, RandomState>::new();
         let a = g.add_node('a');
         let b = g.add_node('b');
         let c = g.add_node('c');
@@ -1422,7 +1424,7 @@ mod tests {
 
     #[test]
     fn test_add_edge_with_weights() {
-        let mut g = MatrixGraph::<_, _, std::hash::RandomState>::new();
+        let mut g = MatrixGraph::<_, _, RandomState>::new();
         let a = g.add_node('a');
         let b = g.add_node('b');
         let c = g.add_node('c');
@@ -1434,7 +1436,7 @@ mod tests {
 
     #[test]
     fn test_add_edge_with_weights_undirected() {
-        let mut g = MatrixGraph::<_, _, std::hash::RandomState, Undirected>::new_undirected();
+        let mut g = MatrixGraph::<_, _, RandomState, Undirected>::new_undirected();
         let a = g.add_node('a');
         let b = g.add_node('b');
         let c = g.add_node('c');
@@ -1463,7 +1465,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let mut g = MatrixGraph::<_, _, std::hash::RandomState>::new();
+        let mut g = MatrixGraph::<_, _, RandomState>::new();
         let a = g.add_node('a');
         let b = g.add_node('b');
         let c = g.add_node('c');
@@ -1496,7 +1498,7 @@ mod tests {
 
     #[test]
     fn test_clear_undirected() {
-        let mut g = MatrixGraph::<_, _, std::hash::RandomState, Undirected>::new_undirected();
+        let mut g = MatrixGraph::<_, _, RandomState, Undirected>::new_undirected();
         let a = g.add_node('a');
         let b = g.add_node('b');
         let c = g.add_node('c');
@@ -1553,7 +1555,7 @@ mod tests {
 
     #[test]
     fn test_neighbors() {
-        let mut g = MatrixGraph::<_, _, std::hash::RandomState>::new();
+        let mut g = MatrixGraph::<_, _, RandomState>::new();
         let a = g.add_node('a');
         let b = g.add_node('b');
         let c = g.add_node('c');
@@ -1572,7 +1574,7 @@ mod tests {
 
     #[test]
     fn test_neighbors_undirected() {
-        let mut g = MatrixGraph::<_, _, std::hash::RandomState, Undirected>::new_undirected();
+        let mut g = MatrixGraph::<_, _, RandomState, Undirected>::new_undirected();
         let a = g.add_node('a');
         let b = g.add_node('b');
         let c = g.add_node('c');
@@ -1774,7 +1776,7 @@ mod tests {
 
     #[test]
     fn test_not_zero() {
-        let mut g: MatrixGraph<(), i32, std::hash::RandomState, Directed, NotZero<i32>> =
+        let mut g: MatrixGraph<(), i32, RandomState, Directed, NotZero<i32>> =
             MatrixGraph::default();
 
         let a = g.add_node(());
@@ -1798,7 +1800,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_not_zero_asserted() {
-        let mut g: MatrixGraph<(), i32, std::hash::RandomState, Directed, NotZero<i32>> =
+        let mut g: MatrixGraph<(), i32, RandomState, Directed, NotZero<i32>> =
             MatrixGraph::default();
 
         let a = g.add_node(());
@@ -1809,7 +1811,7 @@ mod tests {
 
     #[test]
     fn test_not_zero_float() {
-        let mut g: MatrixGraph<(), f32, std::hash::RandomState, Directed, NotZero<f32>> =
+        let mut g: MatrixGraph<(), f32, RandomState, Directed, NotZero<f32>> =
             MatrixGraph::default();
 
         let a = g.add_node(());

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -1,14 +1,17 @@
 extern crate quickcheck;
-use self::quickcheck::{Arbitrary, Gen};
 
+use alloc::{boxed::Box, vec::Vec};
+
+use self::quickcheck::{Arbitrary, Gen};
 use crate::graph::{node_index, IndexType};
+use crate::visit::NodeIndexable;
+use crate::{EdgeType, Graph};
+
 #[cfg(feature = "stable_graph")]
 use crate::stable_graph::StableGraph;
-use crate::{EdgeType, Graph};
 
 #[cfg(feature = "graphmap")]
 use crate::graphmap::{GraphMap, NodeTrait};
-use crate::visit::NodeIndexable;
 
 /// Return a random float in the range [0, 1.)
 fn random_01<G: Gen>(g: &mut G) -> f64 {

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -3,9 +3,11 @@ extern crate quickcheck;
 use alloc::{boxed::Box, vec::Vec};
 
 use self::quickcheck::{Arbitrary, Gen};
-use crate::graph::{node_index, IndexType};
-use crate::visit::NodeIndexable;
-use crate::{EdgeType, Graph};
+use crate::{
+    graph::{node_index, IndexType},
+    visit::NodeIndexable,
+    EdgeType, Graph,
+};
 
 #[cfg(feature = "stable_graph")]
 use crate::stable_graph::StableGraph;

--- a/src/scored.rs
+++ b/src/scored.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 /// `MinScored<K, T>` holds a score `K` and a scored object `T` in
 /// a pair for use with a `BinaryHeap`.

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -1,9 +1,10 @@
 use alloc::vec::Vec;
-use core::fmt;
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
-use serde::de::{Deserialize, Error, SeqAccess, Visitor};
-use serde::ser::{Serialize, SerializeSeq, Serializer};
+use serde::{
+    de::{Deserialize, Error, SeqAccess, Visitor},
+    ser::{Serialize, SerializeSeq, Serializer},
+};
 
 /// Map to serializeable representation
 pub trait IntoSerializable {

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -1,7 +1,9 @@
+use alloc::vec::Vec;
+use core::fmt;
+use core::marker::PhantomData;
+
 use serde::de::{Deserialize, Error, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
-use std::fmt;
-use std::marker::PhantomData;
 
 /// Map to serializeable representation
 pub trait IntoSerializable {

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -1,7 +1,9 @@
 //! `UnionFind<K>` is a disjoint-set data structure.
 
+use alloc::{vec, vec::Vec};
+use core::cmp::Ordering;
+
 use super::graph::IndexType;
-use std::cmp::Ordering;
 
 /// `UnionFind<K>` is a disjoint-set data structure. It tracks set membership of *n* elements
 /// indexed from *0* to *n - 1*. The scalar type is `K` which must be an unsigned integer type.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use core::iter;
 
 pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
 where

--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -1,15 +1,17 @@
-use crate::prelude::*;
-
 use core::marker::PhantomData;
+
 use fixedbitset::FixedBitSet;
 use hashbrown::HashSet;
 
-use crate::data::DataMap;
-use crate::visit::{Data, NodeCompactIndexable, NodeCount};
-use crate::visit::{
-    EdgeIndexable, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges, IntoEdgesDirected,
-    IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, IntoNodeReferences, NodeIndexable,
-    NodeRef, VisitMap, Visitable,
+use crate::{
+    data::DataMap,
+    prelude::*,
+    visit::{
+        Data, EdgeIndexable, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+        IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
+        IntoNodeReferences, NodeCompactIndexable, NodeCount, NodeIndexable, NodeRef, VisitMap,
+        Visitable,
+    },
 };
 
 /// A graph filter for nodes.

--- a/src/visit/filter.rs
+++ b/src/visit/filter.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 
+use core::marker::PhantomData;
 use fixedbitset::FixedBitSet;
-use std::collections::HashSet;
-use std::marker::PhantomData;
+use hashbrown::HashSet;
 
 use crate::data::DataMap;
 use crate::visit::{Data, NodeCompactIndexable, NodeCount};

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -75,6 +75,7 @@ pub use self::dfsvisit::*;
 pub use self::traversal::*;
 
 use core::hash::{BuildHasher, Hash};
+
 use fixedbitset::FixedBitSet;
 use hashbrown::HashSet;
 

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -74,9 +74,9 @@ mod traversal;
 pub use self::dfsvisit::*;
 pub use self::traversal::*;
 
+use core::hash::{BuildHasher, Hash};
 use fixedbitset::FixedBitSet;
-use std::collections::HashSet;
-use std::hash::{BuildHasher, Hash};
+use hashbrown::HashSet;
 
 use super::EdgeType;
 use crate::prelude::Direction;

--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -1,7 +1,9 @@
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
+
 use super::{GraphRef, IntoNodeIdentifiers, Reversed};
 use super::{IntoNeighbors, IntoNeighborsDirected, VisitMap, Visitable};
 use crate::Incoming;
-use std::collections::VecDeque;
 
 /// Visit nodes of a graph in a depth-first-search (DFS) emitting nodes in
 /// preorder (when they are first discovered).

--- a/src/visit/traversal.rs
+++ b/src/visit/traversal.rs
@@ -1,8 +1,9 @@
-use alloc::collections::VecDeque;
-use alloc::vec::Vec;
+use alloc::{collections::VecDeque, vec::Vec};
 
-use super::{GraphRef, IntoNodeIdentifiers, Reversed};
-use super::{IntoNeighbors, IntoNeighborsDirected, VisitMap, Visitable};
+use super::{
+    GraphRef, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers, Reversed, VisitMap,
+    Visitable,
+};
 use crate::Incoming;
 
 /// Visit nodes of a graph in a depth-first-search (DFS) emitting nodes in

--- a/src/visit/undirected_adaptor.rs
+++ b/src/visit/undirected_adaptor.rs
@@ -64,6 +64,8 @@ NodeCount! {delegate_impl [[G], G, UndirectedAdaptor<G>, access0]}
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::*;
     use crate::graph::{DiGraph, Graph};
     use crate::visit::Dfs;

--- a/src/visit/undirected_adaptor.rs
+++ b/src/visit/undirected_adaptor.rs
@@ -15,7 +15,7 @@ impl<G> IntoNeighbors for UndirectedAdaptor<G>
 where
     G: IntoNeighborsDirected,
 {
-    type Neighbors = std::iter::Chain<G::NeighborsDirected, G::NeighborsDirected>;
+    type Neighbors = core::iter::Chain<G::NeighborsDirected, G::NeighborsDirected>;
     fn neighbors(self, n: G::NodeId) -> Self::Neighbors {
         self.0
             .neighbors_directed(n, Direction::Incoming)
@@ -27,7 +27,7 @@ impl<G> IntoEdges for UndirectedAdaptor<G>
 where
     G: IntoEdgesDirected,
 {
-    type Edges = std::iter::Chain<G::EdgesDirected, G::EdgesDirected>;
+    type Edges = core::iter::Chain<G::EdgesDirected, G::EdgesDirected>;
     fn edges(self, a: Self::NodeId) -> Self::Edges {
         self.0
             .edges_directed(a, Direction::Incoming)

--- a/tests/adjacency_matrix.rs
+++ b/tests/adjacency_matrix.rs
@@ -116,7 +116,8 @@ fn test_adjacency_matrix_for_graph_map_undirected() {
 #[cfg(feature = "matrix_graph")]
 fn test_adjacency_matrix_for_matrix_graph<Ty: EdgeType>() {
     for (order, edges) in TEST_CASES {
-        let mut g: MatrixGraph<(), (), Ty> = MatrixGraph::with_capacity(order);
+        let mut g: MatrixGraph<(), (), std::hash::RandomState, Ty> =
+            MatrixGraph::with_capacity(order);
 
         for _ in 0..order {
             g.add_node(());

--- a/tests/adjacency_matrix.rs
+++ b/tests/adjacency_matrix.rs
@@ -116,7 +116,7 @@ fn test_adjacency_matrix_for_graph_map_undirected() {
 #[cfg(feature = "matrix_graph")]
 fn test_adjacency_matrix_for_matrix_graph<Ty: EdgeType>() {
     for (order, edges) in TEST_CASES {
-        let mut g: MatrixGraph<(), (), std::hash::RandomState, Ty> =
+        let mut g: MatrixGraph<(), (), std::collections::hash_map::RandomState, Ty> =
             MatrixGraph::with_capacity(order);
 
         for _ in 0..order {

--- a/tests/articulation_points.rs
+++ b/tests/articulation_points.rs
@@ -3,7 +3,7 @@ use petgraph::{
     graph::{NodeIndex, UnGraph},
 };
 
-use std::collections::HashSet;
+use hashbrown::HashSet;
 
 #[test]
 fn art_single_node() {

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1,7 +1,7 @@
 extern crate petgraph;
 
+use core::hash::Hash;
 use std::collections::HashSet;
-use std::hash::Hash;
 
 use petgraph::prelude::*;
 use petgraph::EdgeType;

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -18,11 +18,15 @@ use petgraph::graph::IndexType;
 
 use petgraph::algo::{astar, dijkstra, DfsSpace};
 use petgraph::visit::{
-    IntoEdges, IntoEdgesDirected, IntoNeighbors, IntoNodeIdentifiers, NodeFiltered, Reversed, Topo,
-    VisitMap, Walker,
+    IntoEdges, IntoEdgesDirected, IntoNodeIdentifiers, NodeFiltered, Reversed, Topo, VisitMap,
+    Walker,
 };
 
 use petgraph::dot::Dot;
+
+#[cfg(feature = "stable_graph")]
+#[cfg(test)]
+use petgraph::visit::IntoNeighbors;
 
 fn set<I>(iter: I) -> HashSet<I::Item>
 where
@@ -1761,6 +1765,8 @@ fn neighbors_selfloops() {
     assert_eq!(&seen_undir, &undir_edges);
 }
 
+#[cfg(feature = "stable_graph")]
+#[cfg(test)]
 fn degree<G>(g: G, node: G::NodeId) -> usize
 where
     G: IntoNeighbors,

--- a/tests/graph6.rs
+++ b/tests/graph6.rs
@@ -8,7 +8,7 @@ use petgraph::{
 use petgraph::graphmap::GraphMap;
 
 #[cfg(feature = "matrix_graph")]
-use petgraph::matrix_graph::MatrixGraph;
+use petgraph::matrix_graph::UnMatrix;
 
 #[cfg(feature = "stable_graph")]
 use petgraph::stable_graph::StableGraph;
@@ -165,7 +165,7 @@ fn graph6_for_matrix_graph_test_cases() {
 
 #[cfg(feature = "matrix_graph")]
 fn test_graph6_for_matrix_graph(graph6_str: &str, order: usize, edges: Vec<(u16, u16)>) {
-    type G = MatrixGraph<(), (), Undirected>;
+    type G = UnMatrix<(), ()>;
     let size = edges.len();
 
     // Build test graph

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "graphmap")]
 extern crate petgraph;
 
+use core::fmt;
 use std::collections::HashSet;
-use std::fmt;
 
 use petgraph::prelude::*;
 use petgraph::visit::Walker;

--- a/tests/graphmap.rs
+++ b/tests/graphmap.rs
@@ -14,7 +14,7 @@ use petgraph::dot::{Config, Dot};
 #[test]
 fn simple() {
     //let root = TypedArena::<Node<_>>::new();
-    let mut gr = UnGraphMap::new();
+    let mut gr = UnGraphMap::<_, _>::new();
     //let node = |&: name: &'static str| Ptr(root.alloc(Node(name.to_string())));
     let a = gr.add_node("A");
     let b = gr.add_node("B");
@@ -62,7 +62,7 @@ fn simple() {
 
 #[test]
 fn edges_directed() {
-    let mut gr = DiGraphMap::new();
+    let mut gr = DiGraphMap::<_, _>::new();
     let a = gr.add_node("A");
     let b = gr.add_node("B");
     let c = gr.add_node("C");
@@ -91,7 +91,7 @@ fn edges_directed() {
 
 #[test]
 fn remov() {
-    let mut g = UnGraphMap::new();
+    let mut g = UnGraphMap::<_, _>::new();
     g.add_node(1);
     g.add_node(2);
     g.add_edge(1, 2, -1);
@@ -151,7 +151,7 @@ fn remove_directed() {
 
 #[test]
 fn dfs() {
-    let mut gr = UnGraphMap::default();
+    let mut gr = UnGraphMap::<_, _>::default();
     let h = gr.add_node("H");
     let i = gr.add_node("I");
     let j = gr.add_node("J");
@@ -189,7 +189,7 @@ fn dfs() {
 
 #[test]
 fn edge_iterator() {
-    let mut gr = UnGraphMap::new();
+    let mut gr = UnGraphMap::<_, _>::new();
     let h = gr.add_node("H");
     let i = gr.add_node("I");
     let j = gr.add_node("J");
@@ -364,7 +364,7 @@ fn test_all_edges_mut() {
 
 #[test]
 fn neighbors_incoming_includes_self_loops() {
-    let mut graph = DiGraphMap::new();
+    let mut graph = DiGraphMap::<_, _>::new();
 
     graph.add_node(());
     graph.add_edge((), (), ());
@@ -376,7 +376,7 @@ fn neighbors_incoming_includes_self_loops() {
 
 #[test]
 fn undirected_neighbors_includes_self_loops() {
-    let mut graph = UnGraphMap::new();
+    let mut graph = UnGraphMap::<_, _>::new();
 
     graph.add_node(());
     graph.add_edge((), (), ());
@@ -388,7 +388,7 @@ fn undirected_neighbors_includes_self_loops() {
 
 #[test]
 fn self_loops_can_be_removed() {
-    let mut graph = DiGraphMap::new();
+    let mut graph = DiGraphMap::<_, _>::new();
 
     graph.add_node(());
     graph.add_edge((), (), ());

--- a/tests/k_shortest_path.rs
+++ b/tests/k_shortest_path.rs
@@ -1,7 +1,7 @@
+use hashbrown::HashMap;
 use petgraph::algo::k_shortest_path;
 use petgraph::prelude::*;
 use petgraph::Graph;
-use std::collections::HashMap;
 
 #[test]
 fn second_shortest_path() {

--- a/tests/matching.rs
+++ b/tests/matching.rs
@@ -1,5 +1,6 @@
-use std::collections::HashSet;
-use std::hash::Hash;
+use core::hash::Hash;
+
+use hashbrown::HashSet;
 
 use petgraph::algo::{greedy_matching, maximum_matching};
 use petgraph::prelude::*;

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "quickcheck")]
+
+extern crate alloc;
+
 #[macro_use]
 extern crate quickcheck;
 extern crate petgraph;
@@ -11,12 +14,13 @@ extern crate odds;
 
 mod utils;
 
+use odds::prelude::*;
 use utils::{Small, Tournament};
 
-use odds::prelude::*;
-use std::collections::{BTreeSet, HashMap, HashSet};
-use std::hash::Hash;
+use alloc::collections::BTreeSet;
+use core::hash::Hash;
 
+use hashbrown::{HashMap, HashSet};
 use itertools::assert_equal;
 use itertools::cloned;
 use quickcheck::{Arbitrary, Gen};
@@ -51,8 +55,8 @@ where
     Graph::from_elements(min_spanning_tree(&g))
 }
 
+use core::fmt;
 use petgraph::algo::articulation_points::articulation_points;
-use std::fmt;
 
 quickcheck! {
     fn mst_directed(g: Small<Graph<(), u32>>) -> bool {
@@ -1330,7 +1334,7 @@ quickcheck! {
     }
 }
 
-fn sum_flows<N, F: std::iter::Sum + Copy>(
+fn sum_flows<N, F: core::iter::Sum + Copy>(
     gr: &Graph<N, F>,
     flows: &[F],
     node: NodeIndex,
@@ -1381,8 +1385,8 @@ quickcheck! {
         use petgraph::acyclic::Acyclic;
         use petgraph::data::{Build, Create};
         use petgraph::algo::toposort;
-        use std::collections::BTreeMap;
-        use std::iter;
+        use alloc::collections::BTreeMap;
+        use core::iter;
 
         // We will re-build `g` from scratch, adding edges one by one.
         let mut acylic_g =

--- a/tests/steiner_trees.rs
+++ b/tests/steiner_trees.rs
@@ -1,8 +1,12 @@
+#[cfg(feature = "stable_graph")]
+#[cfg(test)]
 use petgraph::{
     graph::{NodeIndex, UnGraph},
     Graph, Undirected,
 };
 
+#[cfg(feature = "stable_graph")]
+#[cfg(test)]
 fn b01_example() -> (UnGraph<(), i32>, Vec<NodeIndex>) {
     // Implementing b01 case from Vienna test set B
     let mut graph = Graph::<(), i32, Undirected>::new_undirected();
@@ -133,6 +137,8 @@ fn b01_example() -> (UnGraph<(), i32>, Vec<NodeIndex>) {
     (graph, terminals)
 }
 
+#[cfg(feature = "stable_graph")]
+#[cfg(test)]
 fn b07_example() -> (UnGraph<(), i32>, Vec<NodeIndex>) {
     // Implementing b07 case from Vienna test set B
     let mut graph = Graph::<(), i32, Undirected>::new_undirected();
@@ -322,6 +328,8 @@ fn b07_example() -> (UnGraph<(), i32>, Vec<NodeIndex>) {
     (graph, terminals)
 }
 
+#[cfg(feature = "stable_graph")]
+#[cfg(test)]
 fn example_kou_paper() -> (UnGraph<(), i32>, Vec<NodeIndex>) {
     let mut graph = Graph::<(), i32, Undirected>::new_undirected();
     // Add nodes

--- a/tests/utils/qc.rs
+++ b/tests/utils/qc.rs
@@ -1,6 +1,6 @@
+use core::ops::Deref;
 use petgraph::{graph::DiGraph, graphmap::NodeTrait};
 use quickcheck::{Arbitrary, Gen, StdGen};
-use std::ops::Deref;
 
 #[derive(Copy, Clone, Debug)]
 /// quickcheck Arbitrary adaptor - half the size of `T` on average


### PR DESCRIPTION
# Objective

- Alternative to #238
- Alternative to #370
- Implements Item 6 from #551

## Solution

- Promoted `hashbrown` to a direct dependency (currently transient through `indexmap`)
- Added a new `std` feature, and included it in all features which rely on `std` for documentation purposes.
- Added new CI task to ensure `no_std` support works (using `wasm32v1-none` as an example `no_std` target)
- Added several lints which help minimise `std` usage
- Adjusted certain public APIs to allow passing a `S: BuildHasher` instead of implicitly relying on `std::hash::RandomState` when the `std` feature is disabled

---

## Notes

I know this has been attempted several times before and delayed due to a desire to refactor the crate _first_ before adding this functionality. Delays in adding `no_std` support forced Bevy to drop `petgraph` from its core crates, relying on a specialised alternative. We'd love to keep using `petgraph`, but `no_std` support is now a requirement going forward. This will also come up with `wgpu` which is _also_ pursuing `no_std` support [here](https://github.com/gfx-rs/wgpu/issues/6826).

---

BREAKING CHANGE:

Petgraph previously assumed the usage of `std::hash::RandomState` as the hashing implementation across its codebase. In `no_std`, this is not possible. To minimise friction for libraries supporting both `std` and `no_std` with Petgraph, I have made the following changes to the public API:

### `petgraph::algo::simple_paths::all_simple_paths`

This function now has a 3rd generic parameter `S` which controls the hashing implementation used. Because `all_simple_paths` is a function it cannot have default generic parameters, so users must specify the hasher themselves.

```rust
// Before
let foo = all_simple_paths(/* ... */);

// After
let foo = all_simple_paths::<_, _, std::hash::RandomState>(/* ... */);
```

### Switched from `std::collections::{HashMap, HashSet}` to `hashbrown::{HashMap, HashSet}`

To support `no_std`, we cannot use the standard library's implementations of `HashMap` or `HashSet`. Methods and types previously referencing those collections from `std` will now reference them from `hashbrown`. Note that `hashbrown` was already a dependency of Petgraph, so no change in audit requirements.

### Added Hashing Parameter

The following types have had a new generic parameter `S` added to specify the hashing implementation. Note that when `std` is enabled, these will all default to `std::hash::RandomState`, as before.

- `UnGraphMap`
- `DiGraphMap`
- `MatrixGraph`
- `DiMatrix`
- `UnMatrix`
- `NodeIdentifiers`
- `NodeReferences`

Note that for `MatrixGraph`, `DiMatrix`, `UnMatrix` the new `S` parameter is in the 3rd position (all others have `S` in the last position). The reason is `S` has a default parameter with `std` enabled, but is required with `std` disabled. This means it must be the last _required_ parameter.

```rust
// Before
let foo: MatrixGraph<Foo, Bar, Directed, Option<Bar>, DefaultIx>;

// After
let foo: MatrixGraph<Foo, Bar, std::hash::RandomState, Directed, Option<Bar>, DefaultIx>;
```

Also note that because `Default` can now be implemented for multiple versions of the above types (generic over the hasher), you may need to either specify the hasher, or explicitly declare it as default (with the `std` feature enabled):

```rust
// Note that N and E are inferred by code below.
// Before
let foo = UnMatrix::default();

// After (Explicitly infer N and E, but use defaults otherwise)
let foo = UnMatrix::<_, _>::default();
```

### `default-features = false` MSRV is 1.81

If you don't enable the `std` feature, the MSRV increases to 1.81, when `core::error::Error` was stabilised. To preserve the original MSRV of 1.64, just enable the `std` feature.