### PR TITLE
feat: add `#[track_caller]` to functions that panic 

### DIFF
--- a/src/acyclic.rs
+++ b/src/acyclic.rs
@@ -169,6 +169,9 @@ where
     /// when multi-edges are allowed, as in [`DiGraph`] and [`StableDiGraph`]),
     /// this will return an error if and only if [`Self::is_valid_edge`]
     /// returns `false`.
+    ///
+    /// **Panics** if `a` or `b` are not found.
+    #[track_caller]
     pub fn try_add_edge(
         &mut self,
         a: G::NodeId,
@@ -197,6 +200,8 @@ where
     ///
     /// This will return an error if and only if [`Self::is_valid_edge`] returns
     /// `false`.
+    ///
+    /// **Panics** if `a` or `b` are not found.
     pub fn try_update_edge(
         &mut self,
         a: G::NodeId,
@@ -216,6 +221,8 @@ where
     }
 
     /// Check if an edge would be valid, i.e. adding it would not create a cycle.
+    ///
+    /// **Panics** if `a` or `b` are not found.
     pub fn is_valid_edge(&self, a: G::NodeId, b: G::NodeId) -> bool
     where
         G::NodeId: IndexType,
@@ -237,6 +244,7 @@ where
     /// If a cycle is detected, an error is returned and `self` remains unchanged.
     ///
     /// Implements the core update logic of the PK algorithm.
+    #[track_caller]
     fn update_ordering(&mut self, a: G::NodeId, b: G::NodeId) -> Result<(), Cycle<G::NodeId>>
     where
         G::NodeId: IndexType,
@@ -315,7 +323,7 @@ where
             // These are disjoint from the nodes in the forward cone, otherwise
             // we would have a cycle.
             self.past_cone(max_node, min_order, max_order, &mut backward_cone)
-                .expect("cycles already detected in future_cone");
+                .expect("cycles already checked in future_cone");
 
             Ok(())
         };
@@ -383,7 +391,7 @@ where
                 debug_assert!(order <= max_position, "invalid topological order");
                 match order.cmp(&min_position) {
                     Ordering::Less => Ok(false), // node beyond [min_node, max_node]
-                    Ordering::Equal => panic!("found by future_cone"), // cycle!
+                    Ordering::Equal => unreachable!("checked by future_cone"), // cycle!
                     Ordering::Greater => Ok(true), // node within [min_node, max_node]
                 }
             },

--- a/src/acyclic/order_map.rs
+++ b/src/acyclic/order_map.rs
@@ -89,6 +89,7 @@ impl<N: Copy> OrderMap<N> {
     /// Map a node to its position in the topological order.
     ///
     /// Panics if the node index is out of bounds.
+    #[track_caller]
     pub(super) fn get_position(
         &self,
         id: N,
@@ -150,6 +151,7 @@ impl<N: Copy> OrderMap<N> {
     /// Remove a node from the order map.
     ///
     /// Panics if the node index is out of bounds.
+    #[track_caller]
     pub(super) fn remove_node(&mut self, id: N, graph: impl NodeIndexable<NodeId = N>) {
         let idx = graph.to_index(id);
         assert!(idx < self.node_to_pos.len());
@@ -162,6 +164,7 @@ impl<N: Copy> OrderMap<N> {
     /// Set the position of a node.
     ///
     /// Panics if the node index is out of bounds.
+    #[track_caller]
     pub(super) fn set_position(
         &mut self,
         id: N,
@@ -180,6 +183,7 @@ impl<G: Visitable> super::Acyclic<G> {
     /// Get the position of a node in the topological sort.
     ///
     /// Panics if the node index is out of bounds.
+    #[track_caller]
     pub fn get_position<'a>(&'a self, id: G::NodeId) -> TopologicalPosition
     where
         &'a G: NodeIndexable + GraphBase<NodeId = G::NodeId>,

--- a/src/adj.rs
+++ b/src/adj.rs
@@ -225,6 +225,7 @@ impl<E, Ix: IndexType> List<E, Ix> {
     ///
     /// **Note:** `List` allows adding parallel (“duplicate”) edges. If you want
     /// to avoid this, use [`.update_edge(a, b, weight)`](#method.update_edge) instead.
+    #[track_caller]
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
         if b.index() >= self.suc.len() {
             panic!(
@@ -470,6 +471,7 @@ impl<'a, E, Ix: IndexType> IntoNeighbors for &'a List<E, Ix> {
     /// Panics if `a` is out of bounds.
     /// Use [`List::edge_indices_from`] instead if you do not want to borrow the adjacency list while
     /// iterating.
+    #[track_caller]
     fn neighbors(self, a: NodeIndex<Ix>) -> Self::Neighbors {
         let proj: fn(&WSuc<E, Ix>) -> NodeIndex<Ix> = |x| x.suc;
         let iter = self.suc[a.index()].iter().map(proj);

--- a/src/algo/page_rank.rs
+++ b/src/algo/page_rank.rs
@@ -52,6 +52,7 @@ use rayon::prelude::*;
 /// let expected_ranks = vec![0.14685437, 0.20267677, 0.22389607, 0.27971846, 0.14685437];
 /// assert_eq!(expected_ranks, output_ranks);
 /// ```
+#[track_caller]
 pub fn page_rank<G, D>(graph: G, damping_factor: D, nb_iter: usize) -> Vec<D>
 where
     G: NodeCount + IntoEdges + NodeIndexable,

--- a/src/csr.rs
+++ b/src/csr.rs
@@ -309,6 +309,7 @@ where
     /// is **O(|V|·|E|)** for the whole operation.
     ///
     /// **Panics** if `a` or `b` are out of bounds.
+    #[track_caller]
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> bool
     where
         E: Clone,
@@ -394,6 +395,7 @@ where
     /// Computes in **O(log |V|)** time.
     ///
     /// **Panics** if the node `a` does not exist.
+    #[track_caller]
     pub fn contains_edge(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
         self.find_edge_pos(a, b).is_ok()
     }
@@ -416,6 +418,7 @@ where
     /// Computes in **O(1)** time.
     ///
     /// **Panics** if the node `a` does not exist.
+    #[track_caller]
     pub fn out_degree(&self, a: NodeIndex<Ix>) -> usize {
         let r = self.neighbors_range(a);
         r.end - r.start
@@ -424,6 +427,7 @@ where
     /// Computes in **O(1)** time.
     ///
     /// **Panics** if the node `a` does not exist.
+    #[track_caller]
     pub fn neighbors_slice(&self, a: NodeIndex<Ix>) -> &[NodeIndex<Ix>] {
         self.neighbors_of(a).1
     }
@@ -431,6 +435,7 @@ where
     /// Computes in **O(1)** time.
     ///
     /// **Panics** if the node `a` does not exist.
+    #[track_caller]
     pub fn edges_slice(&self, a: NodeIndex<Ix>) -> &[E] {
         &self.edges[self.neighbors_range(a)]
     }
@@ -442,6 +447,7 @@ where
     ///
     /// **Panics** if the node `a` does not exist.<br>
     /// Iterator element type is `EdgeReference<E, Ty, Ix>`.
+    #[track_caller]
     pub fn edges(&self, a: NodeIndex<Ix>) -> Edges<E, Ty, Ix> {
         let r = self.neighbors_range(a);
         Edges {
@@ -682,6 +688,7 @@ where
     ///
     /// **Panics** if the node `a` does not exist.<br>
     /// Iterator element type is `NodeIndex<Ix>`.
+    #[track_caller]
     fn neighbors(self, a: Self::NodeId) -> Self::Neighbors {
         Neighbors {
             iter: self.neighbors_slice(a).iter(),

--- a/src/data.rs
+++ b/src/data.rs
@@ -54,6 +54,9 @@ pub trait Build: Data + NodeCount {
     fn add_node(&mut self, weight: Self::NodeWeight) -> Self::NodeId;
     /// Add a new edge. If parallel edges (duplicate) are not allowed and
     /// the edge already exists, return `None`.
+    ///
+    /// Might panic if `a` or `b` are out of bounds.
+    #[track_caller]
     fn add_edge(
         &mut self,
         a: Self::NodeId,
@@ -64,6 +67,9 @@ pub trait Build: Data + NodeCount {
     }
     /// Add or update the edge from `a` to `b`. Return the id of the affected
     /// edge.
+    ///
+    /// Might panic if `a` or `b` are out of bounds.
+    #[track_caller]
     fn update_edge(
         &mut self,
         a: Self::NodeId,

--- a/src/graph_impl/frozen.rs
+++ b/src/graph_impl/frozen.rs
@@ -57,6 +57,7 @@ where
     /// node or edge indices is fine.
     ///
     /// **Panics** if the indices are equal or if they are out of bounds.
+    #[track_caller]
     pub fn index_twice_mut<T, U>(
         &mut self,
         i: T,

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -565,6 +565,7 @@ where
     ///
     /// **Panics** if the `Graph` is at the maximum number of nodes for its index
     /// type (N/A if usize).
+    #[track_caller]
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
         self.try_add_node(weight).unwrap()
     }
@@ -620,6 +621,7 @@ where
     ///
     /// **Note:** `Graph` allows adding parallel (“duplicate”) edges. If you want
     /// to avoid this, use [`.update_edge(a, b, weight)`](#method.update_edge) instead.
+    #[track_caller]
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
         let res = self.try_add_edge(a, b, weight);
         if res == Err(GraphError::NodeOutBounds) {
@@ -686,6 +688,7 @@ where
     ///
     /// **Panics** if any of the nodes doesn't exist.
     /// or the graph is at the maximum number of edges for its index (when adding new edge)
+    #[track_caller]
     pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
         self.try_update_edge(a, b, weight).unwrap()
     }
@@ -1248,6 +1251,7 @@ where
     /// assert_eq!(gr[b], 4.);
     /// assert_eq!(gr[c], 2.);
     /// ```
+    #[track_caller]
     pub fn index_twice_mut<T, U>(
         &mut self,
         i: T,
@@ -1310,6 +1314,7 @@ where
     /// the graph. Graph may reserve more space to avoid frequent reallocations.
     ///
     /// **Panics** if the new capacity overflows `usize`.
+    #[track_caller]
     pub fn reserve_nodes(&mut self, additional: usize) {
         self.nodes.reserve(additional);
     }
@@ -1318,6 +1323,7 @@ where
     /// the graph. Graph may reserve more space to avoid frequent reallocations.
     ///
     /// **Panics** if the new capacity overflows `usize`.
+    #[track_caller]
     pub fn reserve_edges(&mut self, additional: usize) {
         self.edges.reserve(additional);
     }
@@ -1329,6 +1335,7 @@ where
     /// Prefer `reserve_nodes` if future insertions are expected.
     ///
     /// **Panics** if the new capacity overflows `usize`.
+    #[track_caller]
     pub fn reserve_exact_nodes(&mut self, additional: usize) {
         self.nodes.reserve_exact(additional);
     }
@@ -1340,6 +1347,7 @@ where
     /// Prefer `reserve_edges` if future insertions are expected.
     ///
     /// **Panics** if the new capacity overflows `usize`.
+    #[track_caller]
     pub fn reserve_exact_edges(&mut self, additional: usize) {
         self.edges.reserve_exact(additional);
     }

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -259,6 +259,7 @@ where
     ///
     /// **Panics** if the `StableGraph` is at the maximum number of nodes for
     /// its index type.
+    #[track_caller]
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
         self.try_add_node(weight).unwrap()
     }
@@ -357,6 +358,7 @@ where
     /// its index type.
     ///
     /// **Note:** `StableGraph` allows adding parallel (“duplicate”) edges.
+    #[track_caller]
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
         let res = self.try_add_edge(a, b, weight);
         if let Err(GraphError::NodeMissed(i)) = res {
@@ -473,6 +475,7 @@ where
     ///
     /// **Panics** if any of the nodes don't exist
     /// or the stable graph is at the maximum number of edges for its index (when adding new edge).
+    #[track_caller]
     pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> EdgeIndex<Ix> {
         self.try_update_edge(a, b, weight).unwrap()
     }
@@ -814,7 +817,8 @@ where
     /// Index the `StableGraph` by two indices, any combination of
     /// node or edge indices is fine.
     ///
-    /// **Panics** if the indices are equal or if they are out of bounds.
+    /// **Panics** if the indices are equal or if they are not found.
+    #[track_caller]
     pub fn index_twice_mut<T, U>(
         &mut self,
         i: T,

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -596,6 +596,7 @@ where
     ///
     /// **Panics** if the number of nodes or edges does not fit with
     /// the resulting graph's index type.
+    #[track_caller]
     pub fn into_graph<Ix>(self) -> Graph<N, E, Ty, Ix>
     where
         Ix: crate::graph::IndexType,
@@ -1224,7 +1225,7 @@ where
         self.node_count()
     }
     fn to_index(&self, ix: Self::NodeId) -> usize {
-        self.nodes.get_index_of(&ix).unwrap()
+        self.nodes.get_index_of(&ix).expect("node not found")
     }
     fn from_index(&self, ix: usize) -> Self::NodeId {
         assert!(
@@ -1280,7 +1281,7 @@ where
     }
 
     fn to_index(&self, ix: Self::EdgeId) -> usize {
-        self.edges.get_index_of(&ix).unwrap()
+        self.edges.get_index_of(&ix).expect("edge not found")
     }
 
     fn from_index(&self, ix: usize) -> Self::EdgeId {

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -358,6 +358,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     /// Return the index of the new node.
     ///
     /// **Panics** if the MatrixGraph is at the maximum number of nodes for its index type.
+    #[track_caller]
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
         NodeIndex::new(self.nodes.add(weight))
     }
@@ -383,6 +384,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     /// Computes in **O(V)** time, due to the removal of edges with other nodes.
     ///
     /// **Panics** if the node `a` does not exist.
+    #[track_caller]
     pub fn remove_node(&mut self, a: NodeIndex<Ix>) -> N {
         for id in self.nodes.iter_ids() {
             let position = self.to_edge_position(a, NodeIndex::new(id));
@@ -427,6 +429,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     /// Computes in **O(|V|^2)** time, worst case (matrix needs to be re-allocated).
     ///
     /// **Panics** if any of the nodes don't exist.
+    #[track_caller]
     pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) -> Option<E> {
         self.extend_capacity_for_edge(a, b);
         let p = self.to_edge_position_unchecked(a, b);
@@ -467,6 +470,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     ///
     /// **Note:** `MatrixGraph` does not allow adding parallel (“duplicate”) edges. If you want to avoid
     /// this, use [`.update_edge(a, b, weight)`](#method.update_edge) instead.
+    #[track_caller]
     pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E) {
         let old_edge_id = self.update_edge(a, b, weight);
         assert!(old_edge_id.is_none());
@@ -496,6 +500,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     ///
     /// **Panics** if any of the nodes don't exist.
     /// **Panics** if no edge exists between `a` and `b`.
+    #[track_caller]
     pub fn remove_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> E {
         let p = self
             .to_edge_position(a, b)
@@ -522,6 +527,8 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     /// Return `true` if there is an edge between `a` and `b`.
     ///
     /// If any of the nodes don't exist - returns `false`.
+    /// **Panics** if any of the nodes don't exist.
+    #[track_caller]
     pub fn has_edge(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
         if let Some(p) = self.to_edge_position(a, b) {
             return self
@@ -538,6 +545,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     /// Also available with indexing syntax: `&graph[a]`.
     ///
     /// **Panics** if the node doesn't exist.
+    #[track_caller]
     pub fn node_weight(&self, a: NodeIndex<Ix>) -> &N {
         &self.nodes[a.index()]
     }
@@ -554,6 +562,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     /// Also available with indexing syntax: `&mut graph[a]`.
     ///
     /// **Panics** if the node doesn't exist.
+    #[track_caller]
     pub fn node_weight_mut(&mut self, a: NodeIndex<Ix>) -> &mut N {
         &mut self.nodes[a.index()]
     }
@@ -570,6 +579,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     /// Also available with indexing syntax: `&graph[e]`.
     ///
     /// **Panics** if no edge exists between `a` and `b`.
+    #[track_caller]
     pub fn edge_weight(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> &E {
         let p = self
             .to_edge_position(a, b)
@@ -592,6 +602,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     /// Also available with indexing syntax: `&mut graph[e]`.
     ///
     /// **Panics** if no edge exists between `a` and `b`.
+    #[track_caller]
     pub fn edge_weight_mut(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> &mut E {
         let p = self
             .to_edge_position(a, b)

--- a/src/unionfind.rs
+++ b/src/unionfind.rs
@@ -95,6 +95,7 @@ where
     /// Return the representative for `x`.
     ///
     /// **Panics** if `x` is out of bounds.
+    #[track_caller]
     pub fn find(&self, x: K) -> K {
         self.try_find(x).expect("The index is out of bounds")
     }
@@ -123,6 +124,7 @@ where
     /// datastructure in the process and quicken future lookups.
     ///
     /// **Panics** if `x` is out of bounds.
+    #[track_caller]
     pub fn find_mut(&mut self, x: K) -> K {
         assert!(x.index() < self.len());
         unsafe { self.find_mut_recursive(x) }
@@ -154,6 +156,7 @@ where
     /// `false` otherwise.
     ///
     /// **Panics** if `x` or `y` is out of bounds.
+    #[track_caller]
     pub fn equiv(&self, x: K, y: K) -> bool {
         self.find(x) == self.find(y)
     }
@@ -173,6 +176,7 @@ where
     /// Return `false` if the sets were already the same, `true` if they were unified.
     ///
     /// **Panics** if `x` or `y` is out of bounds.
+    #[track_caller]
     pub fn union(&mut self, x: K, y: K) -> bool {
         self.try_union(x, y).unwrap()
     }

--- a/src/visit/dfsvisit.rs
+++ b/src/visit/dfsvisit.rs
@@ -151,7 +151,7 @@ impl<B> Default for Control<B> {
 /// `C: ControlFlow`. The implementation for `()` will continue until finished.
 /// For `Result`, upon encountering an `E` it will break, otherwise acting the same as `C`.
 ///
-/// ***Panics** if you attempt to prune a node from its `Finish` event.
+/// **Panics** if you attempt to prune a node from its `Finish` event.
 ///
 /// [de]: enum.DfsEvent.html
 ///
@@ -237,6 +237,7 @@ impl<B> Default for Control<B> {
 /// println!("number of backedges encountered: {}", back_edges);
 /// println!("back edge: {:?}", result);
 /// ```
+#[track_caller]
 pub fn depth_first_search<G, I, F, C>(graph: G, starts: I, mut visitor: F) -> C
 where
     G: IntoNeighbors + Visitable,

--- a/src/visit/mod.rs
+++ b/src/visit/mod.rs
@@ -345,8 +345,10 @@ trait_template! {
         /// (suitable for the size of a bitmap).
         fn node_bound(self: &Self) -> usize;
         /// Convert `a` to an integer index.
+        #[track_caller]
         fn to_index(self: &Self, a: Self::NodeId) -> usize;
         /// Convert `i` to a node index. `i` must be a valid value in the graph.
+        #[track_caller]
         fn from_index(self: &Self, i: usize) -> Self::NodeId;
     }
 }
@@ -362,8 +364,10 @@ trait_template! {
         /// (suitable for the size of a bitmap).
         fn edge_bound(self: &Self) -> usize;
         /// Convert `a` to an integer index.
+        #[track_caller]
         fn to_index(self: &Self, a: Self::EdgeId) -> usize;
         /// Convert `i` to an edge index. `i` must be a valid value in the graph.
+        #[track_caller]
         fn from_index(self: &Self, i: usize) -> Self::EdgeId;
     }
 }


### PR DESCRIPTION
While using `Acyclic` I got this panic:

```
thread 'tests::panic_on_short_cycle' panicked at /home/marcospb19/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/petgraph-0.7.1/src/graphmap.rs:1203:38:
called `Option::unwrap()` on a `None` value
```

While expected, it'd be more helpful if it pointed to the caller in my code, not the upstream code.

I started adding `#[track_caller]` for `Acyclic` and ended up going through all functions that contain "panics" in their docs, except for `std::ops::Index[Mut]` cause those have `#[track_caller]` in the trait definition.

