### PR TITLE
ci: Pin `once_cell` version for MSRV builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           cargo generate-lockfile
           cargo update -p hashbrown --precise 0.15.0
+          cargo update -p once_cell --precise 1.20.3
 
       - name: Build with no features
         run: cargo build --verbose --no-default-features


### PR DESCRIPTION
`once_cell 1.21` [bumped its MSRV](https://github.com/matklad/once_cell/blob/master/CHANGELOG.md#1210) to 1.65, so it no longer builds in CI.

This PR pins the version when testing with our MSRV.