### PR TITLE
ci: Fix wrong trigger for pr-title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,6 +5,7 @@ on:
   pull_request_target:
     branches:
       - main
+      - master
     types:
       - opened
       - edited


### PR DESCRIPTION
#734 added a CI check for conventional commit PR titles.

However, I wrote `main` instead of `master` as target branch for the trigger -.-'
This fix won't be applied until after merging the PR, since the `pull_request_target` trigger uses the workflow definition in the target branch.