### PR TITLE
ci: new triggers for semver-checks

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -4,6 +4,11 @@ on:
     pull_request_target:
         branches:
             - master
+        types:
+            - opened
+            - edited
+            - synchronize
+            - reopened
     workflow_dispatch:
         inputs:
             base:


### PR DESCRIPTION
Extended triggers for run/re-run CI "semver-checks": opened, edited (title or description), synchronized.