### PR TITLE
docs: Add some missed features into crate-lvl doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,15 @@
 //!   Defaults on. Enables [`StableGraph`](./stable_graph/struct.StableGraph.html).
 //! * **matrix_graph** -
 //!   Defaults on. Enables [`MatrixGraph`](./matrix_graph/struct.MatrixGraph.html).
+//! * **rayon** -
+//!   Defaults off. Enables parallel versions of iterators and algorithms using
+//!   [`rayon`](https://docs.rs/rayon/latest/rayon/) crate. Requires the `std` feature.
+//! * **std** -
+//!    Defaults on. Enables the Rust Standard Library. Disabling the `std` feature makes it possible to use `petgraph` in `no_std` contexts.
+//! * **generate** -
+//!    Defaults off. Enables graph generators.
+//! * **unstable** -
+//!    Defaults off. Enables unstable crate features (currently onle `generate`).
 //!
 #![doc(html_root_url = "https://docs.rs/petgraph/0.4/")]
 #![no_std]


### PR DESCRIPTION
This routine PR adds a mention to the crate-level documentation of previously missed & new added features: `rayon`, `generate`, `unstable` and `std`.