### PR TITLE
fix!: Correct typing for steiner_tree

### DIFF
--- a/src/algo/steiner_tree.rs
+++ b/src/algo/steiner_tree.rs
@@ -6,7 +6,7 @@ use hashbrown::{HashMap, HashSet};
 use crate::algo::floyd_warshall::floyd_warshall_path;
 use crate::algo::{dijkstra, min_spanning_tree, BoundedMeasure, Measure};
 use crate::data::FromElements;
-use crate::graph::{NodeIndex, UnGraph};
+use crate::graph::{IndexType, NodeIndex, UnGraph};
 use crate::visit::{
     Data, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges, IntoNeighbors,
     IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeIndexable, Visitable,
@@ -168,13 +168,14 @@ where
 /// assert_eq!(tree.edge_weights().sum::<i32>(), 12);
 ///
 #[cfg(feature = "stable_graph")]
-pub fn steiner_tree<N, E>(
-    graph: &UnGraph<N, E>,
-    terminals: &[NodeIndex],
-) -> StableGraph<N, E, Undirected>
+pub fn steiner_tree<N, E, Ix>(
+    graph: &UnGraph<N, E, Ix>,
+    terminals: &[NodeIndex<Ix>],
+) -> StableGraph<N, E, Undirected, Ix>
 where
     N: Default + Clone + Eq + Hash + Debug,
     E: Copy + Eq + Ord + Measure + BoundedMeasure,
+    Ix: IndexType,
 {
     let metric_closure = compute_metric_closure(&graph, terminals);
     let metric_closure_graph: UnGraph<N, E, _> = UnGraph::from_edges(

--- a/tests/steiner_trees.rs
+++ b/tests/steiner_trees.rs
@@ -330,8 +330,8 @@ fn b07_example() -> (UnGraph<(), i32>, Vec<NodeIndex>) {
 
 #[cfg(feature = "stable_graph")]
 #[cfg(test)]
-fn example_kou_paper() -> (UnGraph<(), i32>, Vec<NodeIndex>) {
-    let mut graph = Graph::<(), i32, Undirected>::new_undirected();
+fn example_kou_paper() -> (UnGraph<(), usize>, Vec<NodeIndex>) {
+    let mut graph = Graph::<(), usize, Undirected>::new_undirected();
     // Add nodes
     let nodes: Vec<_> = (0..9).map(|_| graph.add_node(())).collect();
 
@@ -395,7 +395,7 @@ mod test {
         let (graph, terminals) = example_kou_paper();
         let st = steiner_tree(&graph, &terminals);
 
-        let weights = st.edge_weights().cloned().sum::<i32>();
+        let weights = st.edge_weights().cloned().sum::<usize>();
         let steiner_tree_nodes: Vec<_> = st.node_indices().collect();
         assert!(terminals.iter().all(|&t| steiner_tree_nodes.contains(&t)));
         assert!(st.edge_count() == st.node_count() - 1);


### PR DESCRIPTION
# The issue
`steiner_tree` is not usable with other index types then `i32`, hence make the indextype a variable.

Sorry for the previous oversight

BREAKING CHANGE: Will require an additional index type on the `steiner_tree` function