### PR TITLE
ci: Enable automatic CHANGELOG generation

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -42,8 +42,6 @@ jobs:
   release-plz-pr:
     name: Generate release PR
     runs-on: ubuntu-latest
-    # Disabled for now.
-    if: false
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
This will enable automatic release PR generation by `release-plz`.
This includes a semver-checks run to ensure that no breaking checks get released in a minor version bump, and CHANGELOG generation based on the commits merged since the last release, grouped by their conventional commits tag (#734).

PRs marked as breaking (by adding a `!` after the tag) will be marked as so in the CHANGELOG, and they will force a major version bump.

It is possible to modify the created PR before merging as needed; either to reword parts of the changelog or to override the version bump.