### PR TITLE
ci: Disable semver-checks lints with false positives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,10 @@ std = ["indexmap/std"]
 alloc_instead_of_core = "warn"
 std_instead_of_alloc = "warn"
 std_instead_of_core = "warn"
+
+[package.metadata.cargo-semver-checks.lints]
+# Lint temporarily disabled, as this bug is causing a false positives:
+# https://github.com/obi1kenobi/cargo-semver-checks/issues/1200
+#
+# TODO: re-enable once the bug is fixed
+trait_newly_sealed = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ std_instead_of_alloc = "warn"
 std_instead_of_core = "warn"
 
 [package.metadata.cargo-semver-checks.lints]
-# Lint temporarily disabled, as this bug is causing a false positives:
+# Lint temporarily disabled, as this bug is causing false positives:
 # https://github.com/obi1kenobi/cargo-semver-checks/issues/1200
 #
 # TODO: re-enable once the bug is fixed


### PR DESCRIPTION
Disables a failing semver-checks that's causing [false positives](https://github.com/petgraph/petgraph/pull/764#issuecomment-2782207938).

This seems to be caused by https://github.com/obi1kenobi/cargo-semver-checks/issues/1200