### PR TITLE
feat: Implement `DataMap` for `GraphMap` graphs

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -1367,11 +1367,11 @@ where
     Ty: EdgeType,
     S: BuildHasher,
 {
-    fn edge_weight(self: &Self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
+    fn edge_weight(&self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
         self.edge_weight(id.0, id.1)
     }
 
-    fn node_weight(self: &Self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
+    fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
         // Technically `id` is already the weight for `GraphMap`, but since we need to return a reference, this is a O(1) borrowing alternative:
         self.nodes.get_key_value(&id).map(|(k, _)| k)
     }

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -20,8 +20,7 @@ use indexmap::{
 };
 
 use crate::{
-    graph::{node_index, Graph},
-    visit, Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected,
+    data, graph::{node_index, Graph}, visit, Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected
 };
 
 #[cfg(feature = "std")]
@@ -1357,6 +1356,22 @@ where
     #[inline]
     fn is_adjacent(&self, _: &(), a: N, b: N) -> bool {
         self.contains_edge(a, b)
+    }
+}
+
+impl<N, E, Ty, S> data::DataMap for GraphMap<N, E, Ty, S>
+where
+    N: Copy + Ord + Hash,
+    Ty: EdgeType,
+    S: BuildHasher,
+{
+    fn edge_weight(self: &Self,id:Self::EdgeId) -> Option< &Self::EdgeWeight> {
+        self.edge_weight(id.0, id.1)
+    }
+
+    fn node_weight(self: &Self,id:Self::NodeId) -> Option< &Self::NodeWeight> {
+        // Technically `id` is already the weight for `GraphMap`, but since we need to return a reference, this is a O(1) borrowing alternative:
+        self.nodes.get_key_value(&id).map(|(k, _)| k)
     }
 }
 

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -20,7 +20,9 @@ use indexmap::{
 };
 
 use crate::{
-    data, graph::{node_index, Graph}, visit, Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected
+    data,
+    graph::{node_index, Graph},
+    visit, Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected,
 };
 
 #[cfg(feature = "std")]
@@ -1365,11 +1367,11 @@ where
     Ty: EdgeType,
     S: BuildHasher,
 {
-    fn edge_weight(self: &Self,id:Self::EdgeId) -> Option< &Self::EdgeWeight> {
+    fn edge_weight(self: &Self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
         self.edge_weight(id.0, id.1)
     }
 
-    fn node_weight(self: &Self,id:Self::NodeId) -> Option< &Self::NodeWeight> {
+    fn node_weight(self: &Self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
         // Technically `id` is already the weight for `GraphMap`, but since we need to return a reference, this is a O(1) borrowing alternative:
         self.nodes.get_key_value(&id).map(|(k, _)| k)
     }


### PR DESCRIPTION
The `DataMap` implementation is the only trait missing to make `GraphMap` graphs usable with `isomorphism` functions.

The `Vec<usize>` return type of isomorphism matchings is slightly confusing for `GraphMap`, but I think it's fine to include this PR by itself. In the future a specific "MatchResolver" or similar could always be added for `GraphMap`s that turns the `Vec<usize>` (which is using the order of `GraphMap::nodes`) into a `G0::N ==> G1::N` mapping.