### PR TITLE
feat: Add general subgraph monomorphisms iteration and make "induced" nature of existing functions explicit

### DIFF
--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -979,7 +979,7 @@ where
 /// isomorphism (graph structure and matching node and edge weights) and,
 /// if `g0` is isomorphic to an *induced* subgraph of `g1`, return the mappings between
 /// them.
-/// 
+///
 /// If you are looking for general (non-induced) subgraph isomorphisms, see [`general_subgraph_monomorphisms_iter`].
 ///
 /// The graphs should not be multigraphs.
@@ -1020,9 +1020,9 @@ where
 /// isomorphism (graph structure and matching node and edge weights) and,
 /// if `g0` is monomorphic to a general subgraph of `g1`, return the mappings between
 /// them.
-/// 
-/// If you only interested in finding *induced* subgraph isomorphisms, see [`subgraph_isomorphisms_iter`].
-/// 
+///
+/// If you are only interested in finding *induced* subgraph isomorphisms, see [`subgraph_isomorphisms_iter`].
+///
 /// For motivation behind the difference of "isomorphic" and "monomorphic", see discussion in [`is_isomorphic_subgraph`].
 ///
 /// The graphs should not be multigraphs.

--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -281,10 +281,11 @@ mod matching {
     }
 
     fn is_feasible<G0, G1, NM, EM>(
-        st: &mut (Vf2State<'_, G0>, Vf2State<'_, G1>),
+        st: &(Vf2State<'_, G0>, Vf2State<'_, G1>),
         nodes: (G0::NodeId, G1::NodeId),
         node_match: &mut NM,
         edge_match: &mut EM,
+        induced_only: bool,
     ) -> bool
     where
         G0: GetAdjacencyMatrix + GraphProp + NodeCompactIndexable + IntoNeighborsDirected,
@@ -324,6 +325,11 @@ mod matching {
                     if m_neigh == usize::MAX {
                         continue;
                     }
+                    if !induced_only && $j == 1 {
+                        // The code we're skipping is for checking that the query's graph (g0) contains all edges that g1 contains. This is the definition of an induced subgraph.
+                        // If we're not interested in only induced subgraphs, we must skip this check.
+                        continue;
+                    }
                     let has_edge = field!(st, 1 - $j).graph.is_adjacent(
                         &field!(st, 1 - $j).adjacency_matrix,
                         field!(nodes, 1 - $j),
@@ -348,6 +354,11 @@ mod matching {
                     // the self loop case is handled in outgoing
                     let m_neigh = field!(st, $j).mapping[field!(st, $j).graph.to_index(n_neigh)];
                     if m_neigh == usize::MAX {
+                        continue;
+                    }
+                    if !induced_only && $j == 1 {
+                        // The code we're skipping is for checking that the query's graph (g0) contains all edges that g1 contains. This is the definition of an induced subgraph.
+                        // If we're not interested in only induced subgraphs, we must skip this check.
                         continue;
                     }
                     let has_edge = field!(st, 1 - $j).graph.is_adjacent(
@@ -456,7 +467,10 @@ mod matching {
             }
 
             edge_feasibility!(0);
-            edge_feasibility!(1);
+            if induced_only {
+                // Only check all edges from g1 for semantic feasibility if we're looking for induced subgraphs.
+                edge_feasibility!(1);
+            }
         }
         true
     }
@@ -575,7 +589,7 @@ mod matching {
         EM: EdgeMatcher<G0, G1>,
     {
         let mut stack = vec![Frame::Outer];
-        if isomorphisms(st, node_match, edge_match, match_subgraph, &mut stack).is_some() {
+        if isomorphisms(st, node_match, edge_match, match_subgraph, true, &mut stack).is_some() {
             Some(true)
         } else {
             None
@@ -587,6 +601,7 @@ mod matching {
         node_match: &mut NM,
         edge_match: &mut EM,
         match_subgraph: bool,
+        induced_only: bool,
         stack: &mut Vec<Frame<G0, G1>>,
     ) -> Option<Vec<usize>>
     where
@@ -638,7 +653,7 @@ mod matching {
                     }
                 },
                 Frame::Inner { nodes, open_list } => {
-                    if is_feasible(st, nodes, node_match, edge_match) {
+                    if is_feasible(st, nodes, node_match, edge_match, induced_only) {
                         push_state(st, nodes);
                         if st.0.is_complete() {
                             result = Some(st.0.mapping.clone());
@@ -696,6 +711,7 @@ mod matching {
         node_match: &'c mut NM,
         edge_match: &'c mut EM,
         match_subgraph: bool,
+        induced_only: bool,
         stack: Vec<Frame<G0, G1>>,
     }
 
@@ -720,6 +736,7 @@ mod matching {
             node_match: &'c mut NM,
             edge_match: &'c mut EM,
             match_subgraph: bool,
+            induced_only: bool,
         ) -> Self {
             let stack = vec![Frame::Outer];
             Self {
@@ -727,6 +744,7 @@ mod matching {
                 node_match,
                 edge_match,
                 match_subgraph,
+                induced_only,
                 stack,
             }
         }
@@ -755,6 +773,7 @@ mod matching {
                 self.node_match,
                 self.edge_match,
                 self.match_subgraph,
+                self.induced_only,
                 &mut self.stack,
             )
         }
@@ -868,7 +887,7 @@ where
     self::matching::try_match(&mut st, &mut node_match, &mut edge_match, false).unwrap_or(false)
 }
 
-/// \[Generic\] Return `true` if `g0` is isomorphic to a subgraph of `g1`.
+/// \[Generic\] Return `true` if `g0` is isomorphic to an *induced* subgraph of `g1`.
 ///
 /// Using the VF2 algorithm, only matching graph syntactically (graph
 /// structure).
@@ -896,6 +915,7 @@ where
 /// ‘subgraph’ always means a ‘node-induced subgraph’. Edge-induced subgraph
 /// isomorphisms are not directly supported. For subgraphs which are not
 /// induced, the term ‘monomorphism’ is preferred over ‘isomorphism’.
+/// For such subgraphs, the function [`general_subgraph_monomorphisms_iter`] may be of interest.
 ///
 /// **Reference**
 ///
@@ -919,7 +939,7 @@ where
         .unwrap_or(false)
 }
 
-/// \[Generic\] Return `true` if `g0` is isomorphic to a subgraph of `g1`.
+/// \[Generic\] Return `true` if `g0` is isomorphic to an *induced* subgraph of `g1`.
 ///
 /// Using the VF2 algorithm, examining both syntactic and semantic
 /// graph isomorphism (graph structure and matching node and edge weights).
@@ -957,8 +977,10 @@ where
 
 /// Using the VF2 algorithm, examine both syntactic and semantic graph
 /// isomorphism (graph structure and matching node and edge weights) and,
-/// if `g0` is isomorphic to a subgraph of `g1`, return the mappings between
+/// if `g0` is isomorphic to an *induced* subgraph of `g1`, return the mappings between
 /// them.
+/// 
+/// If you are looking for general (non-induced) subgraph isomorphisms, see [`general_subgraph_monomorphisms_iter`].
 ///
 /// The graphs should not be multigraphs.
 pub fn subgraph_isomorphisms_iter<'a, G0, G1, NM, EM>(
@@ -990,6 +1012,49 @@ where
     }
 
     Some(self::matching::GraphMatcher::new(
-        g0, g1, node_match, edge_match, true,
+        g0, g1, node_match, edge_match, true, true,
+    ))
+}
+
+/// Using the VF2 algorithm, examine both syntactic and semantic graph
+/// isomorphism (graph structure and matching node and edge weights) and,
+/// if `g0` is monomorphic to a general subgraph of `g1`, return the mappings between
+/// them.
+/// 
+/// If you only interested in finding *induced* subgraph isomorphisms, see [`subgraph_isomorphisms_iter`].
+/// 
+/// For motivation behind the difference of "isomorphic" and "monomorphic", see discussion in [`is_isomorphic_subgraph`].
+///
+/// The graphs should not be multigraphs.
+pub fn general_subgraph_monomorphisms_iter<'a, G0, G1, NM, EM>(
+    g0: &'a G0,
+    g1: &'a G1,
+    node_match: &'a mut NM,
+    edge_match: &'a mut EM,
+) -> Option<impl Iterator<Item = Vec<usize>> + 'a>
+where
+    G0: 'a
+        + NodeCompactIndexable
+        + EdgeCount
+        + DataMap
+        + GetAdjacencyMatrix
+        + GraphProp
+        + IntoEdgesDirected,
+    G1: 'a
+        + NodeCompactIndexable
+        + EdgeCount
+        + DataMap
+        + GetAdjacencyMatrix
+        + GraphProp<EdgeType = G0::EdgeType>
+        + IntoEdgesDirected,
+    NM: 'a + FnMut(&G0::NodeWeight, &G1::NodeWeight) -> bool,
+    EM: 'a + FnMut(&G0::EdgeWeight, &G1::EdgeWeight) -> bool,
+{
+    if g0.node_count() > g1.node_count() || g0.edge_count() > g1.edge_count() {
+        return None;
+    }
+
+    Some(self::matching::GraphMatcher::new(
+        g0, g1, node_match, edge_match, true, false,
     ))
 }

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -47,8 +47,8 @@ pub use feedback_arc_set::greedy_feedback_arc_set;
 pub use floyd_warshall::floyd_warshall;
 pub use ford_fulkerson::ford_fulkerson;
 pub use isomorphism::{
-    is_isomorphic, is_isomorphic_matching, is_isomorphic_subgraph, is_isomorphic_subgraph_matching,
-    subgraph_isomorphisms_iter, general_subgraph_monomorphisms_iter,
+    general_subgraph_monomorphisms_iter, is_isomorphic, is_isomorphic_matching,
+    is_isomorphic_subgraph, is_isomorphic_subgraph_matching, subgraph_isomorphisms_iter,
 };
 pub use k_shortest_path::k_shortest_path;
 pub use matching::{greedy_matching, maximum_matching, Matching};

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -48,7 +48,7 @@ pub use floyd_warshall::floyd_warshall;
 pub use ford_fulkerson::ford_fulkerson;
 pub use isomorphism::{
     is_isomorphic, is_isomorphic_matching, is_isomorphic_subgraph, is_isomorphic_subgraph_matching,
-    subgraph_isomorphisms_iter,
+    subgraph_isomorphisms_iter, general_subgraph_monomorphisms_iter,
 };
 pub use k_shortest_path::k_shortest_path;
 pub use matching::{greedy_matching, maximum_matching, Matching};

--- a/tests/iso.rs
+++ b/tests/iso.rs
@@ -513,42 +513,38 @@ fn iter_subgraph() {
             let b_ref = &b;
             let mut node_match = { |x: &(), y: &()| x == y };
             let mut edge_match = { |x: &(), y: &()| x == y };
-        
-            let mappings =
-                $fn_name(&a_ref, &b_ref, &mut node_match, &mut edge_match).unwrap();
-        
+
+            let mappings = $fn_name(&a_ref, &b_ref, &mut node_match, &mut edge_match).unwrap();
+
             // Verify the iterator returns the expected mappings
-            let expected_mappings: Vec<Vec<usize>> = vec![vec![0, 1, 2], vec![1, 2, 0], vec![2, 0, 1]];
+            let expected_mappings: Vec<Vec<usize>> =
+                vec![vec![0, 1, 2], vec![1, 2, 0], vec![2, 0, 1]];
             for mapping in mappings {
                 assert!(expected_mappings.contains(&mapping))
             }
-        
+
             // Verify all the mappings from the iterator are different
             let a = str_to_digraph(COXETER_A);
             let b = str_to_digraph(COXETER_B);
             let a_ref = &a;
             let b_ref = &b;
-        
+
             let mut unique = HashSet::new();
-            assert!(
-                $fn_name(&a_ref, &b_ref, &mut node_match, &mut edge_match)
-                    .unwrap()
-                    .all(|x| unique.insert(x))
-            );
-        
+            assert!($fn_name(&a_ref, &b_ref, &mut node_match, &mut edge_match)
+                .unwrap()
+                .all(|x| unique.insert(x)));
+
             // The iterator should return None for graphs that are not isomorphic
             let a = str_to_digraph(G8_1);
             let b = str_to_digraph(G8_2);
             let a_ref = &a;
             let b_ref = &b;
-        
-            assert!(
-                $fn_name(&a_ref, &b_ref, &mut node_match, &mut edge_match)
-                    .unwrap()
-                    .next()
-                    .is_none()
-            );
-        
+
+            assert!($fn_name(&a_ref, &b_ref, &mut node_match, &mut edge_match)
+                .unwrap()
+                .next()
+                .is_none());
+
             // https://github.com/petgraph/petgraph/issues/534
             let mut g = Graph::<String, ()>::new();
             let e1 = g.add_node("l1".to_string());
@@ -558,12 +554,12 @@ fn iter_subgraph() {
             g.add_edge(e2, e3, ());
             let e4 = g.add_node("l4".to_string());
             g.add_edge(e3, e4, ());
-        
+
             let mut sub = Graph::<String, ()>::new();
             let e3 = sub.add_node("l3".to_string());
             let e4 = sub.add_node("l4".to_string());
             sub.add_edge(e3, e4, ());
-        
+
             let mut node_match = { |x: &String, y: &String| x == y };
             let mut edge_match = { |x: &(), y: &()| x == y };
             assert_eq!(
@@ -572,7 +568,7 @@ fn iter_subgraph() {
                     .collect::<Vec<_>>(),
                 vec![vec![2, 3]]
             );
-        }
+        };
     }
 
     test_for_iter_subgraph_type!(subgraph_isomorphisms_iter);

--- a/tests/iso.rs
+++ b/tests/iso.rs
@@ -9,7 +9,8 @@ use petgraph::prelude::*;
 use petgraph::EdgeType;
 
 use petgraph::algo::{
-    is_isomorphic, is_isomorphic_matching, is_isomorphic_subgraph, subgraph_isomorphisms_iter, general_subgraph_monomorphisms_iter,
+    general_subgraph_monomorphisms_iter, is_isomorphic, is_isomorphic_matching,
+    is_isomorphic_subgraph, subgraph_isomorphisms_iter,
 };
 
 /// Petersen A and B are isomorphic
@@ -586,15 +587,15 @@ fn iter_subgraph_induced_difference() {
     let mut edge_match = { |x: &(), y: &()| x == y };
 
     let mappings =
-        subgraph_isomorphisms_iter(&a_ref, &b_ref, &mut node_match, &mut edge_match)
-            .unwrap();
+        subgraph_isomorphisms_iter(&a_ref, &b_ref, &mut node_match, &mut edge_match).unwrap();
 
     // a is not an induced subgraph of b due to the missing edge 1->2
     assert_eq!(mappings.count(), 0);
 
     // it is a general subgraph of b, however
-    let mappings = general_subgraph_monomorphisms_iter(&a_ref, &b_ref, &mut node_match, &mut edge_match)
-        .unwrap();
+    let mappings =
+        general_subgraph_monomorphisms_iter(&a_ref, &b_ref, &mut node_match, &mut edge_match)
+            .unwrap();
     // Verify the iterator returns the expected mappings
     let expected_mappings: Vec<Vec<usize>> = vec![vec![0, 1, 2], vec![0, 2, 1]];
     let actual_mappings: Vec<Vec<usize>> = mappings.collect();


### PR DESCRIPTION
This adds a function `general_subgraph_monomorphisms_iter` that corresponds to `subgraph_isomorphisms_iter`, except that non-induced subgraphs are also found.

For example:
```rust
let a = Graph::<(), ()>::from_edges([(0, 1), (0, 2)]);
let b = Graph::<(), ()>::from_edges([(0, 1), (0, 2), (1, 2)]);
```
`a` is not an induced subgraph of `b`, hence it is not found by `subgraph_isomorphisms_iter`, but it is a general subgraph, hence it _is_ returned by `general_subgraph_monomorphisms_iter`.

I added some tests, but this probably requires more testing. I have not found any "big" and known testcases out in the internet.

Also it is worth discussing whether the existing APIs should be changed to talk about "subgraphs" and "induced subgraphs" vs. "general subgraphs" and "subgraphs". This would be breaking though.

Also, I have not added corresponding `is_monomorphic_general_subgraph_*` functions.

The changes were inspired by @OwenTrokeBillard's https://github.com/OwenTrokeBillard/vf2. (sorry for the tag - just in case your knowledge is applicable for reviewing! feel free to ignore)