### PR TITLE
fix: Infinite `subgraph_isomorphisms_iter` for empty isomorphisms

### DIFF
--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -553,7 +553,7 @@ mod matching {
         st.1.push_mapping(nodes.1, st.0.graph.to_index(nodes.0));
     }
 
-    // Note: This function will not find the empty isomorphism (i.e., if g0 is the empty graph). 
+    // Note: This function will not find the empty isomorphism (i.e., if g0 is the empty graph).
     fn isomorphisms<G0, G1, NM, EM>(
         st: &mut (Vf2State<'_, G0>, Vf2State<'_, G1>),
         node_match: &mut NM,
@@ -809,9 +809,9 @@ where
         return false;
     }
 
-    self::matching::GraphMatcher::new(
-        &g0, &g1, &mut NoSemanticMatch, &mut NoSemanticMatch, false,
-    ).next().is_some()
+    self::matching::GraphMatcher::new(&g0, &g1, &mut NoSemanticMatch, &mut NoSemanticMatch, false)
+        .next()
+        .is_some()
 }
 
 /// \[Generic\] Return `true` if the graphs `g0` and `g1` are isomorphic.
@@ -846,9 +846,9 @@ where
         return false;
     }
 
-    self::matching::GraphMatcher::new(
-        &g0, &g1, &mut node_match, &mut edge_match, false,
-    ).next().is_some()
+    self::matching::GraphMatcher::new(&g0, &g1, &mut node_match, &mut edge_match, false)
+        .next()
+        .is_some()
 }
 
 /// \[Generic\] Return `true` if `g0` is isomorphic to a subgraph of `g1`.
@@ -897,9 +897,9 @@ where
         return false;
     }
 
-    self::matching::GraphMatcher::new(
-        &g0, &g1, &mut NoSemanticMatch, &mut NoSemanticMatch, true,
-    ).next().is_some()
+    self::matching::GraphMatcher::new(&g0, &g1, &mut NoSemanticMatch, &mut NoSemanticMatch, true)
+        .next()
+        .is_some()
 }
 
 /// \[Generic\] Return `true` if `g0` is isomorphic to a subgraph of `g1`.
@@ -934,9 +934,9 @@ where
         return false;
     }
 
-    self::matching::GraphMatcher::new(
-        &g0, &g1, &mut node_match, &mut edge_match, true,
-    ).next().is_some()
+    self::matching::GraphMatcher::new(&g0, &g1, &mut node_match, &mut edge_match, true)
+        .next()
+        .is_some()
 }
 
 /// Using the VF2 algorithm, examine both syntactic and semantic graph

--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -553,35 +553,7 @@ mod matching {
         st.1.push_mapping(nodes.1, st.0.graph.to_index(nodes.0));
     }
 
-    /// Return Some(bool) if isomorphism is decided, else None.
-    pub fn try_match<G0, G1, NM, EM>(
-        st: &mut (Vf2State<'_, G0>, Vf2State<'_, G1>),
-        node_match: &mut NM,
-        edge_match: &mut EM,
-        match_subgraph: bool,
-    ) -> Option<bool>
-    where
-        G0: NodeCompactIndexable
-            + EdgeCount
-            + GetAdjacencyMatrix
-            + GraphProp
-            + IntoNeighborsDirected,
-        G1: NodeCompactIndexable
-            + EdgeCount
-            + GetAdjacencyMatrix
-            + GraphProp
-            + IntoNeighborsDirected,
-        NM: NodeMatcher<G0, G1>,
-        EM: EdgeMatcher<G0, G1>,
-    {
-        let mut stack = vec![Frame::Outer];
-        if isomorphisms(st, node_match, edge_match, match_subgraph, &mut stack).is_some() {
-            Some(true)
-        } else {
-            None
-        }
-    }
-
+    // Note: This function will not find the empty isomorphism (i.e., if g0 is the empty graph). 
     fn isomorphisms<G0, G1, NM, EM>(
         st: &mut (Vf2State<'_, G0>, Vf2State<'_, G1>),
         node_match: &mut NM,
@@ -603,10 +575,6 @@ mod matching {
         NM: NodeMatcher<G0, G1>,
         EM: EdgeMatcher<G0, G1>,
     {
-        if st.0.is_complete() {
-            return Some(st.0.mapping.clone());
-        }
-
         // A "depth first" search of a valid mapping from graph 1 to graph 2
         // F(s, n, m) -- evaluate state s and add mapping n <-> m
         // Find least T1out node (in st.out[1] but not in M[1])
@@ -697,6 +665,8 @@ mod matching {
         edge_match: &'c mut EM,
         match_subgraph: bool,
         stack: Vec<Frame<G0, G1>>,
+        // if this is `Some(iter)` we're overriding any calls to `isomorphisms()` with calls to `iter` instead. that is, we return the single known mapping once.
+        iter_override: Option<Option<Vec<usize>>>,
     }
 
     impl<'a, 'b, 'c, G0, G1, NM, EM> GraphMatcher<'a, 'b, 'c, G0, G1, NM, EM>
@@ -722,12 +692,20 @@ mod matching {
             match_subgraph: bool,
         ) -> Self {
             let stack = vec![Frame::Outer];
+            let st = (Vf2State::new(g0), Vf2State::new(g1));
+            let iter_override = if st.0.is_complete() {
+                // the initial state is already complete. if this is the case, need to return the mapping immediately, because `next_candidate` in Frame::Outer will not succeed.
+                Some(Some(st.0.mapping.clone()))
+            } else {
+                None
+            };
             Self {
-                st: (Vf2State::new(g0), Vf2State::new(g1)),
+                st,
                 node_match,
                 edge_match,
                 match_subgraph,
                 stack,
+                iter_override,
             }
         }
     }
@@ -750,6 +728,10 @@ mod matching {
         type Item = Vec<usize>;
 
         fn next(&mut self) -> Option<Self::Item> {
+            if let Some(iter) = self.iter_override.as_mut() {
+                // if we are overriding calls to `isomorphisms`, we return the mapping once
+                return iter.take();
+            }
             isomorphisms(
                 &mut self.st,
                 self.node_match,
@@ -827,9 +809,9 @@ where
         return false;
     }
 
-    let mut st = (Vf2State::new(&g0), Vf2State::new(&g1));
-    self::matching::try_match(&mut st, &mut NoSemanticMatch, &mut NoSemanticMatch, false)
-        .unwrap_or(false)
+    self::matching::GraphMatcher::new(
+        &g0, &g1, &mut NoSemanticMatch, &mut NoSemanticMatch, false,
+    ).next().is_some()
 }
 
 /// \[Generic\] Return `true` if the graphs `g0` and `g1` are isomorphic.
@@ -864,8 +846,9 @@ where
         return false;
     }
 
-    let mut st = (Vf2State::new(&g0), Vf2State::new(&g1));
-    self::matching::try_match(&mut st, &mut node_match, &mut edge_match, false).unwrap_or(false)
+    self::matching::GraphMatcher::new(
+        &g0, &g1, &mut node_match, &mut edge_match, false,
+    ).next().is_some()
 }
 
 /// \[Generic\] Return `true` if `g0` is isomorphic to a subgraph of `g1`.
@@ -914,9 +897,9 @@ where
         return false;
     }
 
-    let mut st = (Vf2State::new(&g0), Vf2State::new(&g1));
-    self::matching::try_match(&mut st, &mut NoSemanticMatch, &mut NoSemanticMatch, true)
-        .unwrap_or(false)
+    self::matching::GraphMatcher::new(
+        &g0, &g1, &mut NoSemanticMatch, &mut NoSemanticMatch, true,
+    ).next().is_some()
 }
 
 /// \[Generic\] Return `true` if `g0` is isomorphic to a subgraph of `g1`.
@@ -951,8 +934,9 @@ where
         return false;
     }
 
-    let mut st = (Vf2State::new(&g0), Vf2State::new(&g1));
-    self::matching::try_match(&mut st, &mut node_match, &mut edge_match, true).unwrap_or(false)
+    self::matching::GraphMatcher::new(
+        &g0, &g1, &mut node_match, &mut edge_match, true,
+    ).next().is_some()
 }
 
 /// Using the VF2 algorithm, examine both syntactic and semantic graph

--- a/tests/iso.rs
+++ b/tests/iso.rs
@@ -509,8 +509,8 @@ fn iter_subgraph_empty() {
     let b_ref = &b;
     let mut node_match = { |x: &(), y: &()| x == y };
     let mut edge_match = { |x: &(), y: &()| x == y };
-    let mut mappings = subgraph_isomorphisms_iter(&a_ref, &b_ref, &mut node_match, &mut edge_match)
-        .unwrap();
+    let mut mappings =
+        subgraph_isomorphisms_iter(&a_ref, &b_ref, &mut node_match, &mut edge_match).unwrap();
     assert_eq!(mappings.next(), Some(vec![]));
     assert_eq!(mappings.next(), None);
 }

--- a/tests/iso.rs
+++ b/tests/iso.rs
@@ -501,6 +501,21 @@ fn iso_subgraph() {
 }
 
 #[test]
+fn iter_subgraph_empty() {
+    let a = Graph::<(), ()>::new();
+    let b = Graph::<(), ()>::from_edges([(0, 1), (1, 2), (2, 0)]);
+
+    let a_ref = &a;
+    let b_ref = &b;
+    let mut node_match = { |x: &(), y: &()| x == y };
+    let mut edge_match = { |x: &(), y: &()| x == y };
+    let mut mappings = subgraph_isomorphisms_iter(&a_ref, &b_ref, &mut node_match, &mut edge_match)
+        .unwrap();
+    assert_eq!(mappings.next(), Some(vec![]));
+    assert_eq!(mappings.next(), None);
+}
+
+#[test]
 #[cfg_attr(miri, ignore = "Takes too long to run in Miri")]
 fn iter_subgraph() {
     let a = Graph::<(), ()>::from_edges([(0, 1), (1, 2), (2, 0)]);


### PR DESCRIPTION
The newly added test fails with the old code, since initial state is always complete and hence the iterator's return value will always be `Some(_)`.

I fixed this by making `GraphMatcher` the only entrypoint to `isomorphisms`, and moving that edge case logic into its `Iterator` implementation. This is a bit awkward, but I am unsure how to adapt `isomorphisms` itself, since it currently assumes having at least one mapped node pair before returning a result.