### PR TITLE
feat: Add bidirectional Dijkstra algorithm

### DIFF
--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -3,29 +3,14 @@
 extern crate petgraph;
 extern crate test;
 
-use core::cmp::{max, min};
+#[allow(dead_code)]
+mod common;
+
 use petgraph::prelude::*;
-use test::Bencher;
-
 use petgraph::algo::{bidirectional_dijkstra, dijkstra};
+use test::Bencher;
+use common::*;
 
-#[allow(clippy::needless_range_loop)]
-fn build_random_graph(node_count: usize) -> Graph<usize, usize, Undirected> {
-    let mut graph = Graph::new_undirected();
-    let nodes: Vec<NodeIndex<_>> = (0..node_count).map(|i| graph.add_node(i)).collect();
-    for i in 0..node_count {
-        let n1 = nodes[i];
-        let neighbour_count = i % 8 + 3;
-        let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
-        let j_to = min(node_count, j_from + neighbour_count);
-        for j in j_from..j_to {
-            let n2 = nodes[j];
-            let distance = (i + 3) % 10;
-            graph.add_edge(n1, n2, distance);
-        }
-    }
-    graph
-}
 
 const RANDOM_GRAPH_SIZE: usize = 10_000;
 const RANDOM_GRAPH_START: usize = 1;
@@ -33,7 +18,7 @@ const RANDOM_GRAPH_GOAL: usize = 9_000;
 
 #[bench]
 fn dijkstra_bench_random(bench: &mut Bencher) {
-    let g = build_random_graph(RANDOM_GRAPH_SIZE);
+    let g = build_graph(RANDOM_GRAPH_SIZE, false);
 
     bench.iter(|| {
         let _scores = dijkstra(&g, NodeIndex::new(RANDOM_GRAPH_START), None, |e| {
@@ -44,7 +29,7 @@ fn dijkstra_bench_random(bench: &mut Bencher) {
 
 #[bench]
 fn dijkstra_bench_random_with_target(bench: &mut Bencher) {
-    let g = build_random_graph(RANDOM_GRAPH_SIZE);
+    let g = build_graph(RANDOM_GRAPH_SIZE, false);
 
     bench.iter(|| {
         let _scores = dijkstra(
@@ -58,7 +43,7 @@ fn dijkstra_bench_random_with_target(bench: &mut Bencher) {
 
 #[bench]
 fn dijkstra_bench_random_bidirectional(bench: &mut Bencher) {
-    let g = build_random_graph(RANDOM_GRAPH_SIZE);
+    let g = build_graph(RANDOM_GRAPH_SIZE, false);
 
     bench.iter(|| {
         let _result = bidirectional_dijkstra(

--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -7,27 +7,133 @@ use core::cmp::{max, min};
 use petgraph::prelude::*;
 use test::Bencher;
 
-use petgraph::algo::dijkstra;
+use petgraph::algo::{bidirectional_dijkstra, dijkstra};
 
-#[bench]
 #[allow(clippy::needless_range_loop)]
-fn dijkstra_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 10_000;
-    let mut g = Graph::new_undirected();
-    let nodes: Vec<NodeIndex<_>> = (0..NODE_COUNT).map(|i| g.add_node(i)).collect();
-    for i in 0..NODE_COUNT {
+fn build_random_graph(node_count: usize) -> Graph<usize, usize, Undirected> {
+    let mut graph = Graph::new_undirected();
+    let nodes: Vec<NodeIndex<_>> = (0..node_count).map(|i| graph.add_node(i)).collect();
+    for i in 0..node_count {
         let n1 = nodes[i];
         let neighbour_count = i % 8 + 3;
         let j_from = max(0, i as i32 - neighbour_count as i32 / 2) as usize;
-        let j_to = min(NODE_COUNT, j_from + neighbour_count);
+        let j_to = min(node_count, j_from + neighbour_count);
         for j in j_from..j_to {
             let n2 = nodes[j];
             let distance = (i + 3) % 10;
-            g.add_edge(n1, n2, distance);
+            graph.add_edge(n1, n2, distance);
+        }
+    }
+    graph
+}
+
+const RANDOM_GRAPH_SIZE: usize = 10_000;
+const RANDOM_GRAPH_START: usize = 1;
+const RANDOM_GRAPH_GOAL: usize = 9_000;
+
+#[bench]
+fn dijkstra_bench_random(bench: &mut Bencher) {
+    let g = build_random_graph(RANDOM_GRAPH_SIZE);
+
+    bench.iter(|| {
+        let _scores = dijkstra(&g, NodeIndex::new(RANDOM_GRAPH_START), None, |e| {
+            *e.weight()
+        });
+    });
+}
+
+#[bench]
+fn dijkstra_bench_random_with_target(bench: &mut Bencher) {
+    let g = build_random_graph(RANDOM_GRAPH_SIZE);
+
+    bench.iter(|| {
+        let _scores = dijkstra(
+            &g,
+            NodeIndex::new(RANDOM_GRAPH_START),
+            Some(NodeIndex::new(RANDOM_GRAPH_GOAL)),
+            |e| *e.weight(),
+        );
+    });
+}
+
+#[bench]
+fn dijkstra_bench_random_bidirectional(bench: &mut Bencher) {
+    let g = build_random_graph(RANDOM_GRAPH_SIZE);
+
+    bench.iter(|| {
+        let _result = bidirectional_dijkstra(
+            &g,
+            NodeIndex::new(RANDOM_GRAPH_START),
+            NodeIndex::new(RANDOM_GRAPH_GOAL),
+            |e| *e.weight(),
+        );
+    });
+}
+
+fn build_grid_graph(side: usize) -> Graph<(), usize, Undirected> {
+    let mut graph = Graph::new_undirected();
+
+    let mut node_indices = vec![vec![NodeIndex::end(); side]; side];
+
+    for row in 0..side {
+        for col in 0..side {
+            let node = graph.add_node(());
+            node_indices[row][col] = node;
         }
     }
 
+    for row in 0..side {
+        for col in 0..side {
+            let node = node_indices[row][col];
+            if row > 0 {
+                graph.add_edge(node, node_indices[row - 1][col], 1);
+            }
+            if col > 0 {
+                graph.add_edge(node, node_indices[row][col - 1], 1);
+            }
+        }
+    }
+
+    graph
+}
+
+const GRID_SIDE: usize = 100;
+const GRID_START: usize = 50;
+const GRID_GOAL: usize = 399;
+
+#[bench]
+fn dijkstra_bench_grid(bench: &mut Bencher) {
+    let g = build_grid_graph(GRID_SIDE);
+
     bench.iter(|| {
-        let _scores = dijkstra(&g, nodes[0], None, |e| *e.weight());
+        let _scores = dijkstra(&g, NodeIndex::new(GRID_START), None, |e| *e.weight());
+    });
+}
+
+#[bench]
+fn dijkstra_bench_grid_with_target(bench: &mut Bencher) {
+    let g = build_grid_graph(GRID_SIDE);
+
+    bench.iter(|| {
+        let _scores = dijkstra(
+            &g,
+            NodeIndex::new(GRID_START),
+            Some(NodeIndex::new(GRID_GOAL)),
+            |e| *e.weight(),
+        );
+    });
+}
+
+#[bench]
+fn dijkstra_bench_grid_bidirectional(bench: &mut Bencher) {
+    let g = build_grid_graph(GRID_SIDE);
+
+    bench.iter(|| {
+        let _result = bidirectional_dijkstra(
+            &g,
+            NodeIndex::new(GRID_START),
+            NodeIndex::new(GRID_GOAL),
+            |e| *e.weight(),
+        );
     });
 }

--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -6,11 +6,10 @@ extern crate test;
 #[allow(dead_code)]
 mod common;
 
-use petgraph::prelude::*;
-use petgraph::algo::{bidirectional_dijkstra, dijkstra};
-use test::Bencher;
 use common::*;
-
+use petgraph::algo::{bidirectional_dijkstra, dijkstra};
+use petgraph::prelude::*;
+use test::Bencher;
 
 const RANDOM_GRAPH_SIZE: usize = 10_000;
 const RANDOM_GRAPH_START: usize = 1;

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -221,7 +221,13 @@ where
 ///
 /// Compute the length of the shortest path from `start` to `target`.
 ///
-/// The graph should be `Visitable` and implement `IntoEdgesDirected`.
+/// Bidirectional Dijkstra has the same time complexity as standard [`Dijkstra`][dijkstra]. However, because it
+/// searches simultaneously from both the start and goal nodes, meeting in the middle, it often
+/// explores roughly half the nodes that regular [`Dijkstra`][dijkstra] would explore. This is especially the case
+/// when the path is long relative to the graph size or when working with sparse graphs.
+///
+/// However, regular [`Dijkstra`][dijkstra] may be preferable when you need the shortest paths from the start node
+/// to multiple goals or when the start and goal are relatively close to each other.
 ///
 /// The function `edge_cost` should return the cost for a particular edge, which is used
 /// to compute path costs. Edge costs must be non-negative.
@@ -241,14 +247,6 @@ where
 /// * Auxiliary space: **O(|V|+|E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
-///
-/// Bidirectional Dijkstra has the same time complexity as standard Dijkstra. However, because it
-/// searches simultaneously from both the start and goal nodes, meeting in the middle, it often
-/// explores roughly half the nodes that regular Dijkstra would explore. This is especially the case
-/// when the path is long relative to the graph size or when working with sparse graphs.
-///
-/// However, regular Dijkstra may be preferable when you need the shortest paths from the start node
-/// to multiple goals or when the start and goal are relatively close to each other.
 ///
 /// # Example
 /// ```rust

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -221,11 +221,27 @@ where
 ///
 /// Compute the length of the shortest path from `start` to `target`.
 ///
-/// The graph should be `Visitable` and implement `IntoEdgesDirected`. The function
-/// `edge_cost` should return the cost for a particular edge, which is used
+/// The graph should be `Visitable` and implement `IntoEdgesDirected`.
+///
+/// The function `edge_cost` should return the cost for a particular edge, which is used
 /// to compute path costs. Edge costs must be non-negative.
 ///
-/// Returns the cost of the shortest path from `start` to `target` if it exists, `None` otherwise.
+/// # Arguments
+/// * `graph`: weighted graph.
+/// * `start`: the start node.
+/// * `goal`: the goal node.
+/// * `edge_cost`: closure that returns cost of a particular edge.
+///
+/// # Returns
+/// * `Some(K)` - the total cost from start to finish, if one was found.
+/// * `None` - if such a path was not found.
+///
+/// # Complexity
+/// * Time complexity: **O((|V|+|E|)log(|V|))**.
+/// * Auxiliary space: **O(|V|+|E|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 /// # Example
 /// ```rust
 /// use petgraph::Graph;
@@ -325,7 +341,6 @@ where
                 continue;
             }
 
-            // check for a path s --- u - x --- t
             let potential_best_value = distance_to_u + edge_cost + backward_distance[&x];
 
             let improves_best_value = match best_value {

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -321,9 +321,16 @@ where
                 }
             }
 
-            if backward_visited.is_visited(&x)
-                && best_value.is_none_or(|mu| backward_distance[&x] + edge_cost < mu)
-            {
+            if !backward_visited.is_visited(&x) {
+                continue;
+            }
+
+            let improves_best_value = match best_value {
+                None => true,
+                Some(mu) => backward_distance[&x] + edge_cost < mu,
+            };
+
+            if improves_best_value {
                 best_value = Some(distance_to_u + edge_cost + backward_distance[&x]);
             }
         }
@@ -349,9 +356,16 @@ where
                 }
             }
 
-            if forward_visited.is_visited(&x)
-                && best_value.is_none_or(|mu| forward_distance[&x] + edge_cost < mu)
-            {
+            if !forward_visited.is_visited(&x) {
+                continue;
+            }
+
+            let improves_best_value = match best_value {
+                None => true,
+                Some(mu) => forward_distance[&x] + edge_cost < mu,
+            };
+
+            if improves_best_value {
                 best_value = Some(distance_to_v + edge_cost + forward_distance[&x]);
             }
         }

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -230,7 +230,7 @@ where
 /// * `graph`: weighted graph.
 /// * `start`: the start node.
 /// * `goal`: the goal node.
-/// * `edge_cost`: closure that returns cost of a particular edge.
+/// * `edge_cost`: closure that returns the cost of a particular edge.
 ///
 /// # Returns
 /// * `Some(K)` - the total cost from start to finish, if one was found.
@@ -353,7 +353,7 @@ where
 
             let improves_best_value = match best_value {
                 None => true,
-                Some(mu) => potential_best_value < mu,
+                Some(current_best_value) => potential_best_value < current_best_value,
             };
 
             if improves_best_value {

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -242,6 +242,14 @@ where
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
+/// Bidirectional Dijkstra has the same time complexity as standard Dijkstra. However, because it
+/// searches simultaneously from both the start and goal nodes, meeting in the middle, it often
+/// explores roughly half the nodes that regular Dijkstra would explore. This is especially the case
+/// when the path is long relative to the graph size or when working with sparse graphs.
+///
+/// However, regular Dijkstra may be preferable when you need the shortest paths from the start node
+/// to multiple goals or when the start and goal are relatively close to each other.
+///
 /// # Example
 /// ```rust
 /// use petgraph::Graph;
@@ -318,10 +326,10 @@ where
 
         for edge in graph.edges_directed(u, Direction::Outgoing) {
             let x = edge.target();
-            let edge_cost = edge_cost(edge);
+            let current_edge_cost = edge_cost(edge);
 
             if !forward_visited.is_visited(&x) {
-                let next_score = distance_to_u + edge_cost;
+                let next_score = distance_to_u + current_edge_cost;
 
                 match forward_distance.entry(x) {
                     Occupied(entry) => {
@@ -341,7 +349,7 @@ where
                 continue;
             }
 
-            let potential_best_value = distance_to_u + edge_cost + backward_distance[&x];
+            let potential_best_value = distance_to_u + current_edge_cost + backward_distance[&x];
 
             let improves_best_value = match best_value {
                 None => true,

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -325,13 +325,16 @@ where
                 continue;
             }
 
+            // check for a path s --- u - x --- t
+            let potential_best_value = distance_to_u + edge_cost + backward_distance[&x];
+
             let improves_best_value = match best_value {
                 None => true,
-                Some(mu) => backward_distance[&x] + edge_cost < mu,
+                Some(mu) => potential_best_value < mu,
             };
 
             if improves_best_value {
-                best_value = Some(distance_to_u + edge_cost + backward_distance[&x]);
+                best_value = Some(potential_best_value);
             }
         }
 
@@ -360,13 +363,15 @@ where
                 continue;
             }
 
+            let potential_best_value = distance_to_v + edge_cost + forward_distance[&x];
+
             let improves_best_value = match best_value {
                 None => true,
-                Some(mu) => forward_distance[&x] + edge_cost < mu,
+                Some(mu) => potential_best_value < mu,
             };
 
             if improves_best_value {
-                best_value = Some(distance_to_v + edge_cost + forward_distance[&x]);
+                best_value = Some(potential_best_value);
             }
         }
 

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -1,6 +1,5 @@
 use alloc::collections::BinaryHeap;
 use core::hash::Hash;
-
 use hashbrown::hash_map::{
     Entry::{Occupied, Vacant},
     HashMap,
@@ -8,7 +7,8 @@ use hashbrown::hash_map::{
 
 use crate::algo::Measure;
 use crate::scored::MinScored;
-use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
+use crate::visit::{EdgeRef, IntoEdges, IntoEdgesDirected, VisitMap, Visitable};
+use crate::Direction;
 
 /// Dijkstra's shortest path algorithm.
 ///
@@ -215,4 +215,153 @@ where
         visited.visit(node);
     }
     AlgoResult { scores, goal_node }
+}
+
+/// Bidirectional Dijkstra's shortest path algorithm.
+///
+/// Compute the length of the shortest path from `start` to `target`.
+///
+/// The graph should be `Visitable` and implement `IntoEdgesDirected`. The function
+/// `edge_cost` should return the cost for a particular edge, which is used
+/// to compute path costs. Edge costs must be non-negative.
+///
+/// Returns the cost of the shortest path from `start` to `target` if it exists, `None` otherwise.
+/// # Example
+/// ```rust
+/// use petgraph::Graph;
+/// use petgraph::algo::bidirectional_dijkstra;
+/// use petgraph::prelude::*;
+/// use hashbrown::HashMap;
+///
+/// let mut graph: Graph<(), (), Directed> = Graph::new();
+/// let a = graph.add_node(());
+/// let b = graph.add_node(());
+/// let c = graph.add_node(());
+/// let d = graph.add_node(());
+/// let e = graph.add_node(());
+/// let f = graph.add_node(());
+/// let g = graph.add_node(());
+/// let h = graph.add_node(());
+///
+/// graph.extend_with_edges(&[
+///     (a, b),
+///     (b, c),
+///     (c, d),
+///     (d, a),
+///     (e, f),
+///     (b, e),
+///     (f, g),
+///     (g, h),
+///     (h, e),
+/// ]);
+/// // a ----> b ----> e ----> f
+/// // ^       |       ^       |
+/// // |       v       |       v
+/// // d <---- c       h <---- g
+///
+/// let result = bidirectional_dijkstra(&graph, a, g, |_| 1);
+/// assert_eq!(result, Some(4));
+/// ```
+pub fn bidirectional_dijkstra<G, F, K>(
+    graph: G,
+    start: G::NodeId,
+    goal: G::NodeId,
+    mut edge_cost: F,
+) -> Option<K>
+where
+    G: Visitable + IntoEdgesDirected,
+    G::NodeId: Eq + Hash,
+    F: FnMut(G::EdgeRef) -> K,
+    K: Measure + Copy,
+{
+    let mut forward_visited = graph.visit_map();
+    let mut forward_distance = HashMap::new();
+    forward_distance.insert(start, K::default());
+
+    let mut backward_visited = graph.visit_map();
+    let mut backward_distance = HashMap::new();
+    backward_distance.insert(goal, K::default());
+
+    let mut forward_heap = BinaryHeap::new();
+    let mut backward_heap = BinaryHeap::new();
+
+    forward_heap.push(MinScored(K::default(), start));
+    backward_heap.push(MinScored(K::default(), goal));
+
+    let mut best_value = None;
+
+    while !forward_heap.is_empty() && !backward_heap.is_empty() {
+        let MinScored(_, u) = forward_heap.pop().unwrap();
+        let MinScored(_, v) = backward_heap.pop().unwrap();
+
+        forward_visited.visit(u);
+        backward_visited.visit(v);
+
+        let distance_to_u = forward_distance[&u];
+        let distance_to_v = backward_distance[&v];
+
+        for edge in graph.edges_directed(u, Direction::Outgoing) {
+            let x = edge.target();
+            let edge_cost = edge_cost(edge);
+
+            if !forward_visited.is_visited(&x) {
+                let next_score = distance_to_u + edge_cost;
+
+                match forward_distance.entry(x) {
+                    Occupied(entry) => {
+                        if next_score < *entry.get() {
+                            *entry.into_mut() = next_score;
+                            forward_heap.push(MinScored(next_score, x));
+                        }
+                    }
+                    Vacant(entry) => {
+                        entry.insert(next_score);
+                        forward_heap.push(MinScored(next_score, x));
+                    }
+                }
+            }
+
+            if backward_visited.is_visited(&x)
+                && best_value.is_none_or(|mu| backward_distance[&x] + edge_cost < mu)
+            {
+                best_value = Some(distance_to_u + edge_cost + backward_distance[&x]);
+            }
+        }
+
+        for edge in graph.edges_directed(v, Direction::Incoming) {
+            let x = edge.source();
+            let edge_cost = edge_cost(edge);
+
+            if !backward_visited.is_visited(&x) {
+                let next_score = distance_to_v + edge_cost;
+
+                match backward_distance.entry(x) {
+                    Occupied(entry) => {
+                        if next_score < *entry.get() {
+                            *entry.into_mut() = next_score;
+                            backward_heap.push(MinScored(next_score, x));
+                        }
+                    }
+                    Vacant(entry) => {
+                        entry.insert(next_score);
+                        backward_heap.push(MinScored(next_score, x));
+                    }
+                }
+            }
+
+            if forward_visited.is_visited(&x)
+                && best_value.is_none_or(|mu| forward_distance[&x] + edge_cost < mu)
+            {
+                best_value = Some(distance_to_v + edge_cost + forward_distance[&x]);
+            }
+        }
+
+        if let Some(best_value) = best_value {
+            if distance_to_u + distance_to_v >= best_value {
+                return Some(best_value);
+            }
+        }
+    }
+
+    None
 }

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -46,7 +46,7 @@ pub use astar::astar;
 pub use bellman_ford::{bellman_ford, find_negative_cycle};
 pub use bridges::bridges;
 pub use coloring::dsatur_coloring;
-pub use dijkstra::dijkstra;
+pub use dijkstra::{bidirectional_dijkstra, dijkstra};
 pub use feedback_arc_set::greedy_feedback_arc_set;
 pub use floyd_warshall::floyd_warshall;
 pub use isomorphism::{

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -33,8 +33,9 @@ use petgraph::algo::{
     bellman_ford, bidirectional_dijkstra, bridges, condensation, connected_components, dijkstra,
     dsatur_coloring, find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set,
     greedy_matching, is_cyclic_directed, is_cyclic_undirected, is_isomorphic,
-    is_isomorphic_matching, k_shortest_path, kosaraju_scc, maximal_cliques as maximal_cliques_algo,
-    maximum_matching, min_spanning_tree, page_rank, spfa, tarjan_scc, toposort, Matching,
+    is_isomorphic_matching, johnson, k_shortest_path, kosaraju_scc,
+    maximal_cliques as maximal_cliques_algo, maximum_matching, min_spanning_tree, page_rank, spfa,
+    tarjan_scc, toposort, Matching,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -811,36 +811,48 @@ quickcheck! {
 }
 
 quickcheck! {
-    // checks bidirectional dijkstra against normal dijkstra
-    fn bidirectional_dijkstra_(g: Graph<u32, u32>) -> bool {
-        if g.node_count() <= 1 {
-            return true;
-        }
-
-        for node1 in g.node_identifiers() {
-            let dijkstra_res = dijkstra(&g, node1, None, |e| *e.weight());
-
-            for node2 in g.node_identifiers() {
-                if node1 == node2 {
-                    continue;
-                }
-
-                let bidirectional_dijkstra_res = bidirectional_dijkstra(&g, node1, node2, |e| *e.weight());
-
-                match (dijkstra_res.get(&node2), bidirectional_dijkstra_res) {
-                    (None, None) => continue,
-                    (Some(distance), Some(bidirectional_distance)) => {
-                        if *distance != bidirectional_distance {
-                            return false;
-                        }
-                    }
-                    // Both algorithms must find a solution for the same problem.
-                    (Some(_), None) | (None, Some(_)) => return false,
-                }
-            }
-         }
-        true
+    fn bidirectional_dijkstra_directed(g: Graph<u32, u32, Directed>) -> bool {
+        test_bidirectional_dijkstra_impl(g)
     }
+
+    fn bidirectional_dijkstra_undirected(g: Graph<u32, u32, Undirected>) -> bool {
+        test_bidirectional_dijkstra_impl(g)
+    }
+}
+
+fn test_bidirectional_dijkstra_impl<Ty>(g: Graph<u32, u32, Ty>) -> bool
+where
+    Ty: EdgeType,
+{
+    if g.node_count() <= 1 || g.node_count() > 50 {
+        return true;
+    }
+
+    for node1 in g.node_identifiers() {
+        let dijkstra_res = dijkstra(&g, node1, None, |e| *e.weight());
+
+        for node2 in g.node_identifiers() {
+            if node1 == node2 {
+                continue;
+            }
+
+            let bidirectional_dijkstra_res =
+                bidirectional_dijkstra(&g, node1, node2, |e| *e.weight());
+
+            match (dijkstra_res.get(&node2), bidirectional_dijkstra_res) {
+                (None, None) => continue,
+                (Some(distance), Some(bidirectional_distance)) => {
+                    if *distance != bidirectional_distance {
+                        return false;
+                    }
+                }
+                // Both algorithms must find a solution for the same problem.
+                (Some(_), None) | (None, Some(_)) => return false,
+            }
+        }
+    }
+
+    true
 }
 
 quickcheck! {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -810,6 +810,37 @@ quickcheck! {
 }
 
 quickcheck! {
+    // checks bidirectional dijkstra against normal dijkstra
+    fn bidirectional_dijkstra(g: Graph<u32, u32>) -> bool {
+        if g.node_count() == 0 {
+            return true;
+        }
+
+        let fw_res = floyd_warshall(&g, |e| *e.weight()).unwrap();
+
+        for node1 in g.node_identifiers() {
+            let dijkstra_res = dijkstra(&g, node1, None, |e| *e.weight());
+
+            for node2 in g.node_identifiers() {
+                let bidirectional_dijkstra_res = bidirectional_dijkstra(&g, node1, node2, |e| *e.weight());
+
+                match (dijkstra_res.get(&node2), bidirectional_dijkstra_res) {
+                    (None, None) => continue,
+                    (Some(distance), Some(bidirectional_distance)) => {
+                        if distance != bidirectional_distance {
+                            return false;
+                        }
+                    }
+                    // Both algorithms must find a solution for the same problem.
+                    (Some(_), None) | (None, Some(_)) => return false,
+                }
+            }
+         }
+        true
+    }
+}
+
+quickcheck! {
     // checks floyd_warshall against dijkstra results
     fn floyd_warshall_(g: Graph<u32, u32>) -> bool {
         if g.node_count() == 0 {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -813,7 +813,7 @@ quickcheck! {
 quickcheck! {
     // checks bidirectional dijkstra against normal dijkstra
     fn bidirectional_dijkstra_(g: Graph<u32, u32>) -> bool {
-        if g.node_count() == 0 {
+        if g.node_count() <= 1 {
             return true;
         }
 
@@ -821,6 +821,10 @@ quickcheck! {
             let dijkstra_res = dijkstra(&g, node1, None, |e| *e.weight());
 
             for node2 in g.node_identifiers() {
+                if node1 == node2 {
+                    continue;
+                }
+                
                 let bidirectional_dijkstra_res = bidirectional_dijkstra(&g, node1, node2, |e| *e.weight());
 
                 match (dijkstra_res.get(&node2), bidirectional_dijkstra_res) {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -816,7 +816,6 @@ quickcheck! {
             return true;
         }
 
-        let fw_res = floyd_warshall(&g, |e| *e.weight()).unwrap();
 
         for node1 in g.node_identifiers() {
             let dijkstra_res = dijkstra(&g, node1, None, |e| *e.weight());

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -816,7 +816,6 @@ quickcheck! {
             return true;
         }
 
-
         for node1 in g.node_identifiers() {
             let dijkstra_res = dijkstra(&g, node1, None, |e| *e.weight());
 

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -824,7 +824,7 @@ quickcheck! {
                 if node1 == node2 {
                     continue;
                 }
-                
+
                 let bidirectional_dijkstra_res = bidirectional_dijkstra(&g, node1, node2, |e| *e.weight());
 
                 match (dijkstra_res.get(&node2), bidirectional_dijkstra_res) {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -30,11 +30,11 @@ use rand::Rng;
 #[cfg(feature = "stable_graph")]
 use petgraph::algo::steiner_tree;
 use petgraph::algo::{
-    bellman_ford, bridges, condensation, connected_components, dijkstra, dsatur_coloring,
-    find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set, greedy_matching,
-    is_cyclic_directed, is_cyclic_undirected, is_isomorphic, is_isomorphic_matching, johnson,
-    k_shortest_path, kosaraju_scc, maximal_cliques as maximal_cliques_algo, maximum_matching,
-    min_spanning_tree, page_rank, spfa, tarjan_scc, toposort, Matching,
+    bellman_ford, bidirectional_dijkstra, bridges, condensation, connected_components, dijkstra,
+    dsatur_coloring, find_negative_cycle, floyd_warshall, ford_fulkerson, greedy_feedback_arc_set,
+    greedy_matching, is_cyclic_directed, is_cyclic_undirected, is_isomorphic,
+    is_isomorphic_matching, k_shortest_path, kosaraju_scc, maximal_cliques as maximal_cliques_algo,
+    maximum_matching, min_spanning_tree, page_rank, spfa, tarjan_scc, toposort, Matching,
 };
 use petgraph::data::FromElements;
 use petgraph::dot::{Config, Dot};
@@ -811,7 +811,7 @@ quickcheck! {
 
 quickcheck! {
     // checks bidirectional dijkstra against normal dijkstra
-    fn bidirectional_dijkstra(g: Graph<u32, u32>) -> bool {
+    fn bidirectional_dijkstra_(g: Graph<u32, u32>) -> bool {
         if g.node_count() == 0 {
             return true;
         }
@@ -827,7 +827,7 @@ quickcheck! {
                 match (dijkstra_res.get(&node2), bidirectional_dijkstra_res) {
                     (None, None) => continue,
                     (Some(distance), Some(bidirectional_distance)) => {
-                        if distance != bidirectional_distance {
+                        if *distance != bidirectional_distance {
                             return false;
                         }
                     }


### PR DESCRIPTION
## Brief
Add [bidirectional Dijkstra's](https://en.wikipedia.org/wiki/Bidirectional_search) algorithm for the shortest path between two points.
```rust
pub fn bidirectional_dijkstra<G, F, K>(
    graph: G,
    start: G::NodeId,
    goal: G::NodeId,
    mut edge_cost: F,
) -> Option<K>
where
    G: Visitable + IntoEdgesDirected,
    G::NodeId: Eq + Hash,
    F: FnMut(G::EdgeRef) -> K,
    K: Measure + Copy,
   ```

## About the algorithm and implementation
The time complexity of bi-directional dijkstra is the same as normal dijkstra. However, in certain scenarios (e.g. grids and sparse road networks), it has to explore significantly less nodes to find the shortest path. https://www.ucl.ac.uk/~ucahmto/math/2020/05/30/bidirectional-dijkstra.html is a great resource on the correctness of the algorithm.

## Benchmarks
Under the right circumstances (large & sparse networks), it clearly shows that bidirectional dijkstra is faster than normal dijkstra.
```
test dijkstra_bench_grid                 ... bench:     469,582.30 ns/iter (+/- 12,469.78)
test dijkstra_bench_grid_bidirectional   ... bench:      47,145.54 ns/iter (+/- 1,139.01)
test dijkstra_bench_grid_with_target     ... bench:     118,156.60 ns/iter (+/- 3,168.78)
```

However, the existing benchmark also shows that it's not always beneficial.
```
test dijkstra_bench_random               ... bench:     745,014.06 ns/iter (+/- 22,892.76)
test dijkstra_bench_random_bidirectional ... bench:   1,556,466.68 ns/iter (+/- 77,702.84)
test dijkstra_bench_random_with_target   ... bench:     694,060.94 ns/iter (+/- 18,275.15)
```

On macbook pro M1
