### PR TITLE
Make `Csr::from_sorted_edges` generic over edge type

### DIFF
--- a/src/csr.rs
+++ b/src/csr.rs
@@ -162,8 +162,9 @@ pub struct EdgesNotSorted {
     first_error: (usize, usize),
 }
 
-impl<N, E, Ix> Csr<N, E, Directed, Ix>
+impl<N, E, Ty, Ix> Csr<N, E, Ty, Ix>
 where
+    Ty: EdgeType,
     Ix: IndexType,
 {
     /// Create a new `Csr` from a sorted sequence of edges


### PR DESCRIPTION
I am not sure if there was a reason for the constraint, but it seems to work fine for undirected graphs.

Fixes #588.