### PR TITLE
fix!: Conditionally use `std` hash set in impl of `Visitable` for `GraphMap`

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -13,7 +13,6 @@ use core::{
     slice::Iter,
 };
 
-use hashbrown::HashSet;
 use indexmap::{
     map::{Iter as IndexMapIter, IterMut as IndexMapIterMut, Keys},
     IndexMap,
@@ -24,6 +23,12 @@ use crate::{
     graph::{node_index, Graph},
     visit, Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected,
 };
+
+#[cfg(feature = "std")]
+use std::collections::hash_set::HashSet;
+
+#[cfg(not(feature = "std"))]
+use hashbrown::HashSet;
 
 #[cfg(feature = "std")]
 use std::collections::hash_map::RandomState;


### PR DESCRIPTION
Fixes #784.

This is a very narrow fix. A more comprehensive fix could be to create a `hash` subdomule that encapsulates the `std`-conditional choice of `HashSet`/`HashMap` and then require all modules to import from that. This would catch any other similarly-leaked changes of hash containers. I'll leave that to your judgement.

BREAKING CHANGE: when `std` is enabled, impl `Visitable<Map = std::collections::HashSet>` for `GraphMap`.