### PR TITLE
fix: Ford Fulkerson sometimes Panics on StableGraphs

### DIFF
--- a/src/algo/ford_fulkerson.rs
+++ b/src/algo/ford_fulkerson.rs
@@ -109,12 +109,14 @@ where
     }
 }
 
-/// \[Generic\] Ford-Fulkerson algorithm.
+/// \[Generic\] [Ford-Fulkerson][ff] algorithm.
 ///
-/// Computes the [maximum flow][ff] of a weighted directed graph.
+/// Computes the [maximum flow] of a weighted directed graph.
 ///
-/// If it terminates, it returns the maximum flow and also the computed edge flows.
+/// If it terminates, it returns the computed maximum flow and a vector containing the flow of
+/// each edge. The vector is indexed by the indices of the edges in the graph.
 ///
+/// [maximum flow]: https://en.wikipedia.org/wiki/Maximum_flow_problem
 /// [ff]: https://en.wikipedia.org/wiki/Ford%E2%80%93Fulkerson_algorithm
 ///
 /// # Example
@@ -160,7 +162,7 @@ where
     N::EdgeWeight: Sub<Output = N::EdgeWeight> + PositiveMeasure,
 {
     let mut edge_to = vec![None; network.node_count()];
-    let mut flows = vec![N::EdgeWeight::zero(); network.edge_count()];
+    let mut flows = vec![N::EdgeWeight::zero(); network.edge_bound()];
     let mut max_flow = N::EdgeWeight::zero();
     while has_augmented_path(&network, source, destination, &mut edge_to, &flows) {
         let mut path_flow = N::EdgeWeight::max();

--- a/tests/ford_fulkerson.rs
+++ b/tests/ford_fulkerson.rs
@@ -1,5 +1,7 @@
 use petgraph::algo::ford_fulkerson;
-use petgraph::prelude::{Graph, StableDiGraph, StableGraph};
+use petgraph::prelude::Graph;
+#[cfg(feature = "stable_graph")]
+use petgraph::prelude::{StableDiGraph, StableGraph};
 use petgraph::Directed;
 
 #[test]
@@ -121,6 +123,7 @@ fn test_ford_fulkerson() {
     assert_eq!(19, max_flow);
 }
 
+#[cfg(feature = "stable_graph")]
 #[test]
 fn test_ford_fulkerson_stable_graphs() {
     // See issue https://github.com/petgraph/petgraph/issues/792


### PR DESCRIPTION
This Resolves #792 and should fix the problem as a whole for Ford Fulkerson.

As explained in #792 , the previous implementation assumed continuous edge indices (that is, without gaps), which is not necessarily the case with StableGraphs. This implementation will now use a bit more memory by creating and returning a vector of `edge_bound()` size, instead of `edge_count()`.

This should not change the behaviour of the algorithm for any other graph class except for StableGraphs.

This new behavior is also reflected in the new docstrings of the algorithm. A test was also added to check that the issue does not reappear.

In the future, one could think about returning a `HashMap` with `edge_count()` many entries instead of a `Vec`, but this would change the API.