### PR TITLE
feat/astar with timeout

### DIFF
--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -207,7 +207,9 @@ where
 /// 
 /// let path = astar_with_timeout( &g, a, |finish| finish == f, timeout_reached_larger, |e| *e.weight(), |_| 0, );
 /// println!("Path: {:?}", path);
-/// assert_eq!(path, Some((0, vec![a])));
+/// // The best node found so far is `a` with a cost of 0.
+/// // The reason that we don't get a better result is because we don't use a heuristic here and we are essentially just using dijkstra (there is no usefull notion of best so far).
+/// assert_eq!(path, Some((0, vec![a]))); 
 /// 
 /// ```
 pub fn astar_with_timeout<G, F, H, K, IsGoal, TimeOut>(

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -1,5 +1,5 @@
 use alloc::{collections::BinaryHeap, vec, vec::Vec};
-use core::hash::Hash;
+use core::{hash::Hash, ops::Sub};
 
 use hashbrown::hash_map::{
     Entry::{Occupied, Vacant},
@@ -99,6 +99,157 @@ where
         // This lookup can be unwrapped without fear of panic since the node was necessarily scored
         // before adding it to `visit_next`.
         let node_score = scores[&node];
+
+        match estimate_scores.entry(node) {
+            Occupied(mut entry) => {
+                // If the node has already been visited with an equal or lower score than now, then
+                // we do not need to re-visit it.
+                if *entry.get() <= estimate_score {
+                    continue;
+                }
+                entry.insert(estimate_score);
+            }
+            Vacant(entry) => {
+                entry.insert(estimate_score);
+            }
+        }
+
+        for edge in graph.edges(node) {
+            let next = edge.target();
+            let next_score = node_score + edge_cost(edge);
+
+            match scores.entry(next) {
+                Occupied(mut entry) => {
+                    // No need to add neighbors that we have already reached through a shorter path
+                    // than now.
+                    if *entry.get() <= next_score {
+                        continue;
+                    }
+                    entry.insert(next_score);
+                }
+                Vacant(entry) => {
+                    entry.insert(next_score);
+                }
+            }
+
+            path_tracker.set_predecessor(next, node);
+            let next_estimate_score = next_score + estimate_cost(next);
+            visit_next.push(MinScored(next_estimate_score, next));
+        }
+    }
+
+    None
+}
+
+/// \[Generic\] A* shortest path algorithm with a timeout.
+/// 
+/// Similar to the `astar` function, but with an additional timeout check.
+/// If the timeout is reached, the function will return the best node found so far.
+/// What is considered the best node is determined by the heuristic score (estimate - cost).
+/// 
+/// The function `time_out_reached` should return `true` if the timeout has been reached.
+/// 
+/// You can construct such a function using either an atomic boolean (set from another thread) or check the system time on each iteration.
+/// 
+/// Example with an atomic boolean:
+/// ```
+/// use petgraph::Graph;
+/// use petgraph::algo::astar_with_timeout;
+///
+/// let mut g = Graph::new();
+/// let a = g.add_node((0., 0.));
+/// let b = g.add_node((2., 0.));
+/// let c = g.add_node((1., 1.));
+/// let d = g.add_node((0., 2.));
+/// let e = g.add_node((3., 3.));
+/// let f = g.add_node((4., 2.));
+/// g.extend_with_edges(&[
+///     (a, b, 2),
+///     (a, d, 4),
+///     (b, c, 1),
+///     (b, f, 7),
+///     (c, e, 5),
+///     (e, f, 1),
+///     (d, e, 1),
+/// ]);
+///
+/// // Graph represented with the weight of each edge
+/// // Edges with '*' are part of the optimal path.
+/// //
+/// //     2       1
+/// // a ----- b ----- c
+/// // | 4*    | 7     |
+/// // d       f       | 5
+/// // | 1*    | 1*    |
+/// // \------ e ------/
+///
+/// use std::sync::atomic::{AtomicBool, Ordering};
+/// use std::sync::Arc;
+/// use std::thread;
+/// 
+/// let timeout_reached = Arc::new(AtomicBool::new(false));
+/// let timeout_reached_clone = Arc::clone(&timeout_reached);
+/// 
+/// thread::spawn(move || {
+///    // Simulate some work
+///   thread::sleep(std::time::Duration::from_secs(2));
+///   timeout_reached_clone.store(true, Ordering::SeqCst);
+/// });
+/// 
+/// let path = astar_with_timeout( &g, a, |finish| finish == f, || timeout_reached.load(Ordering::SeqCst), |e| *e.weight(), |_| 0, );
+/// assert_eq!(path, Some((6, vec![a, d, e, f])));
+/// ```
+pub fn astar_with_timeout<G, F, H, K, IsGoal, TimeOut>(
+    graph: G,
+    start: G::NodeId,
+    mut is_goal: IsGoal,
+    mut time_out_reached: TimeOut,
+    mut edge_cost: F,
+    mut estimate_cost: H,
+) -> Option<(K, Vec<G::NodeId>)>
+where
+    G: IntoEdges + Visitable,
+    IsGoal: FnMut(G::NodeId) -> bool,
+    TimeOut: FnMut() -> bool,
+    G::NodeId: Eq + Hash,
+    F: FnMut(G::EdgeRef) -> K,
+    H: FnMut(G::NodeId) -> K,
+    K: Measure + Copy + Sub<Output = K> ,
+{
+    let mut visit_next = BinaryHeap::new();
+    let mut scores = HashMap::new(); // g-values, cost to reach the node
+    let mut estimate_scores = HashMap::new(); // f-values, cost to reach + estimate cost to goal
+    let mut path_tracker = PathTracker::<G>::new();
+
+    let mut best_so_far = start; // The best node so far (the one with the lowest heuristic (estimate - cost) score)
+    let mut best_so_far_score = K::default(); // The best heuristic (estimate - cost) score so far
+
+    let zero_score = K::default();
+    scores.insert(start, zero_score);
+    visit_next.push(MinScored(estimate_cost(start), start));
+
+    while let Some(MinScored(estimate_score, node)) = visit_next.pop() {
+        if is_goal(node) {
+            let path = path_tracker.reconstruct_path_to(node);
+            let cost = scores[&node];
+            return Some((cost, path));
+        }
+        
+        // This lookup can be unwrapped without fear of panic since the node was necessarily scored
+        // before adding it to `visit_next`.
+        let node_score = scores[&node];
+
+        if best_so_far_score > estimate_score - node_score {
+            best_so_far = node;
+            best_so_far_score = estimate_score - node_score;
+        }
+
+        if time_out_reached() {
+            // If we have reached a timeout, we return the best node so far
+            let path = path_tracker.reconstruct_path_to(best_so_far);
+            let cost = scores[&best_so_far];
+            return Some((cost, path));
+        }
 
         match estimate_scores.entry(node) {
             Occupied(mut entry) => {

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -39,7 +39,7 @@ use super::visit::{
 use super::EdgeType;
 use crate::visit::Walker;
 
-pub use astar::astar;
+pub use astar::{astar, astar_with_timeout};
 pub use bellman_ford::{bellman_ford, find_negative_cycle};
 pub use coloring::dsatur_coloring;
 pub use dijkstra::dijkstra;


### PR DESCRIPTION
I found there are many time critical applications where the astar algorithm cannot find its target in time. In such  situations, it can be useful to track the node in your history that comes closest to the destination. That way, when a timeout triggers you can still use this incomplete path.

This is what I attempted to do with the function astar_with_timeout I added.