### PR TITLE
fix: Quickcheck random01 function only outputs 0

### DIFF
--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -20,7 +20,7 @@ fn random_01<G: Gen>(g: &mut G) -> f64 {
     // from rand
     let bits = 53;
     let scale = 1. / ((1u64 << bits) as f64);
-    let x: u64 = Arbitrary::arbitrary(g);
+    let x: u64 = g.next_u64();
     (x >> (64 - bits)) as f64 * scale
 }
 


### PR DESCRIPTION
Closes #796.

As discussed in the Issue #796, this should be fixed with the version bump of Quickcheck to 1.0, but until then, this should fix the issue.

We simply use an interface exposed by the Gen trait which is a subtrait of RngCore, which exposes the next_u64 function.

As a result of the Quickchecks running properly there are now two tests which fail:
```
failures:
    maximal_cliques_matches_ref_impl
    test_steiner_tree
```
I will try to fix these as well and incorporate the changes into this PR to not make the CI fail a bunch of times.