### PR TITLE
fix: Run Maximal Cliques Quickcheck only on Digraphs which are symmetrical

### DIFF
--- a/src/algo/maximal_cliques.rs
+++ b/src/algo/maximal_cliques.rs
@@ -6,6 +6,13 @@ use hashbrown::HashSet;
 
 /// Finds maximal cliques containing all the vertices in r, some of the
 /// vertices in p, and none of the vertices in x.
+///
+/// By default, only works on undirected graphs. It can be used on directed graphs
+/// if the graph is symmetric. I.e., if an edge (u, v) exists, then (v, u) also exists.
+///
+/// Uses the [Bron–Kerbosch algorithm][1] with pivoting.
+///
+/// [1]: https://en.wikipedia.org/wiki/Bron%E2%80%93Kerbosch_algorithm
 fn bron_kerbosch_pivot<G>(
     g: G,
     adj_mat: &G::AdjMatrix,
@@ -54,13 +61,18 @@ where
     cliques
 }
 
-/// Find all maximal cliques in a graph using Bron–Kerbosch algorithm
-/// with pivoting.
+/// Find all maximal cliques in an undirected graph using [Bron–Kerbosch algorithm][1]
+/// with pivoting. Also works on symmetric directed graphs, see the note below.
 ///
 /// A clique is a set of nodes such that every node connects to
 /// every other. A maximal clique is a clique that cannot be extended
 /// by including one more adjacent vertex. A graph may have multiple
 /// maximal cliques.
+///
+/// This method may also be called on directed graphs, but one needs to ensure that
+/// if an edge (u, v) exists, then (v, u) also exists.
+///
+/// [1]: https://en.wikipedia.org/wiki/Bron%E2%80%93Kerbosch_algorithm
 ///
 /// Example
 /// ```

--- a/src/algo/maximal_cliques.rs
+++ b/src/algo/maximal_cliques.rs
@@ -72,9 +72,16 @@ where
 /// This method may also be called on directed graphs, but one needs to ensure that
 /// if an edge (u, v) exists, then (v, u) also exists.
 ///
+/// ## Arguments
+/// * `g`: The graph to find maximal cliques in.
+///
+/// ## Returns
+/// A vector of sets making up the maximal cliques in the graph.
+///
 /// [1]: https://en.wikipedia.org/wiki/Bron%E2%80%93Kerbosch_algorithm
 ///
-/// Example
+/// # Example
+///
 /// ```
 /// use petgraph::algo::maximal_cliques;
 /// use petgraph::graph::UnGraph;

--- a/tests/maximal_cliques.rs
+++ b/tests/maximal_cliques.rs
@@ -208,7 +208,7 @@ fn test_maximal_cliques_undirected() {
     let f = g.add_node(5);
     g.extend_with_edges([(a, b), (a, e), (b, e), (b, c), (c, d), (d, e), (e, f)]);
 
-    let mut cliques = maximal_cliques(&g);
+    let cliques = maximal_cliques(&g);
     println!("{:?}", &cliques);
 
     let expected_cliques = vec![
@@ -239,7 +239,7 @@ fn test_maximal_cliques_ref_undirected() {
     let f = g.add_node(5);
     g.extend_with_edges([(a, b), (a, e), (b, e), (b, c), (c, d), (d, e), (e, f)]);
 
-    let mut cliques = maximal_cliques_ref(&g);
+    let cliques = maximal_cliques_ref(&g);
     println!("{:?}", &cliques);
 
     let expected_cliques = vec![
@@ -287,7 +287,7 @@ fn test_maximal_cliques_directed() {
         (f, d),
     ]);
 
-    let mut cliques = maximal_cliques(&g);
+    let cliques = maximal_cliques(&g);
     println!("{:?}", &cliques);
 
     let expected_cliques = vec![
@@ -335,7 +335,7 @@ fn test_maximal_cliques_ref_directed() {
         (f, d),
     ]);
 
-    let mut cliques = maximal_cliques_ref(&g);
+    let cliques = maximal_cliques_ref(&g);
     println!("{:?}", &cliques);
 
     let expected_cliques = vec![

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1533,14 +1533,40 @@ fn maximal_cliques_matches_ref_impl() {
     where
         Ty: EdgeType,
     {
+        // Our implementations of maximal cliques only works for undirected graphs
+        // or symmetric directed graphs. So we filter out directed edges if needed.
+        let g = if Ty::is_directed() {
+            g.filter_map(
+                |_, node_weight| Some(node_weight.clone()),
+                |edge_index, edge_weight| {
+                    let (source, target) = g.edge_endpoints(edge_index).unwrap();
+                    if g.contains_edge(target, source) {
+                        Some(edge_weight.clone())
+                    } else {
+                        None
+                    }
+                },
+            )
+        } else {
+            g
+        };
         if g.edge_count() <= 200 && g.node_count() <= 200 {
             let cliques = maximal_cliques_algo(&g);
             let cliques_ref = maximal_cliques_ref(&g);
 
-            assert!(cliques.len() == cliques_ref.len());
+            assert!(cliques.len() == cliques_ref.len(),
+                "Maximal cliques algo returned different number of cliques than the reference implementation: {} != {}",
+                cliques.len(),
+                cliques_ref.len()
+            );
 
             for c in &cliques_ref {
-                assert!(cliques.contains(c));
+                assert!(
+                    cliques.contains(c),
+                    "Ref Clique {:?} not found in the result of maximal_cliques_algo: {:?}",
+                    c,
+                    cliques
+                );
             }
         }
         true

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1537,11 +1537,11 @@ fn maximal_cliques_matches_ref_impl() {
         // or symmetric directed graphs. So we filter out directed edges if needed.
         let g = if Ty::is_directed() {
             g.filter_map(
-                |_, node_weight| Some(node_weight.clone()),
-                |edge_index, edge_weight| {
+                |_, _| Some(()),
+                |edge_index, _| {
                     let (source, target) = g.edge_endpoints(edge_index).unwrap();
                     if g.contains_edge(target, source) {
-                        Some(edge_weight.clone())
+                        Some(())
                     } else {
                         None
                     }


### PR DESCRIPTION
Splitted off from https://github.com/petgraph/petgraph/pull/798. See there for details