### PR TITLE
fix: Run Steiner Tree Quickcheck on the connected components to properly support disconnected graphs

### DIFF
--- a/src/algo/steiner_tree.rs
+++ b/src/algo/steiner_tree.rs
@@ -127,21 +127,29 @@ where
     removed_leaves
 }
 
-/// \[Generic\] Steiner Tree algorithm.
+/// \[Generic\] [Steiner Tree][1] algorithm.
 ///
-/// Computes the Steiner tree of an undirected graph given a set of terminal nodes via [Kou's algorithm][pr]. Implementation details mirrors NetworkX implementation.
+/// Computes the Steiner tree of an undirected connected graph given a set of terminal nodes via
+/// [Kou's algorithm][2]. Implementation details are the same as in the [NetworkX implementation][3].
 ///
-/// Returns a `Graph` representing the Steiner tree of the input graph.
+/// ## Arguments
+/// * `graph`: The undirected graph in which to find the Steiner tree.
+/// * `terminals`: A slice of node indices representing the terminals for which the Steiner tree is computed.
 ///
+/// ## Returns
+/// A `StableGraph` containing the nodes and edges of the Steiner tree.
 ///
-/// # Complexity
+/// ## Complexity
 /// Time complexity is **O(|S| |V|²)**.
-/// where **|V|** the number of vertices (i.e nodes) and **|E|** the number of edges.
+/// where **|V|** the number of vertices (i.e nodes) and **|S|** the number of provided terminals.
 ///
-/// [pr]: https://networkx.org/documentation/stable/_modules/networkx/algorithms/approximation/steinertree.html#steiner_tree
+/// [1]: https://en.wikipedia.org/wiki/Steiner_tree_problem
+/// [2]: https://doi.org/10.1007/BF00288961
+/// [3]: https://networkx.org/documentation/stable/_modules/networkx/algorithms/approximation/steinertree.html#steiner_tree
 ///
 /// # Example
-/// ```rust
+///
+/// ```
 /// use petgraph::Graph;
 /// use petgraph::algo::steiner_tree::steiner_tree;
 /// use petgraph::graph::UnGraph;
@@ -166,7 +174,7 @@ where
 /// let terminals = vec![a, c, e, f];
 /// let tree = steiner_tree(&graph, &terminals);
 /// assert_eq!(tree.edge_weights().sum::<i32>(), 12);
-///
+/// ```
 #[cfg(feature = "stable_graph")]
 pub fn steiner_tree<N, E, Ix>(
     graph: &UnGraph<N, E, Ix>,

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -63,7 +63,6 @@ where
 
 use core::fmt;
 use petgraph::algo::articulation_points::articulation_points;
-use petgraph::unionfind::UnionFind;
 
 quickcheck! {
     fn mst_directed(g: Small<Graph<(), u32>>) -> bool {

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1555,8 +1555,7 @@ fn steiner_tree_spans_terminals() {
                     },
                 );
 
-                let mut terminals = g.node_indices().collect::<Vec<_>>();
-                terminals = terminals.into_iter().take(5).collect();
+                let terminals = g.node_indices().take(5).collect::<Vec<_>>();
                 let m_steiner_tree = steiner_tree(&g, &terminals);
 
                 let steiner_tree_nodes: Vec<NodeIndex> = m_steiner_tree.node_indices().collect();

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -63,6 +63,7 @@ where
 
 use core::fmt;
 use petgraph::algo::articulation_points::articulation_points;
+use petgraph::unionfind::UnionFind;
 
 quickcheck! {
     fn mst_directed(g: Small<Graph<(), u32>>) -> bool {
@@ -1507,10 +1508,15 @@ quickcheck! {
 }
 
 #[cfg(feature = "stable_graph")]
-quickcheck! {
-    fn test_steiner_tree(g: Graph<(), u32, Undirected>) -> bool {
+#[test]
+fn test_steiner_tree() {
+    fn prop(g: Graph<(), u32, Undirected>) -> bool {
         if g.node_count() <= 1 {
             return true; // We naturally don't support steiner trees with zero or one node
+        }
+
+        if connected_components(&g) > 1 {
+            return true; // We only want to test connected graphs
         }
 
         let mut terminals = g.node_indices().collect::<Vec<_>>();
@@ -1523,6 +1529,8 @@ quickcheck! {
 
         spans_terminals
     }
+
+    quickcheck::quickcheck(prop as fn(Graph<(), u32, Undirected>) -> bool);
 }
 
 #[test]


### PR DESCRIPTION
Splitted off from https://github.com/petgraph/petgraph/pull/798. See there for details