### PR TITLE
docs: Add examples to minimum spanning tree functions

### DIFF
--- a/src/algo/min_spanning_tree.rs
+++ b/src/algo/min_spanning_tree.rs
@@ -24,9 +24,58 @@ use crate::visit::{IntoEdgeReferences, NodeIndexable};
 ///
 /// Use `from_elements` to create a graph from the resulting iterator.
 ///
-/// See also: [`.min_spanning_tree_prim(g)`][1] for implementation using Prim's algorithm.
+/// See also: [`min_spanning_tree_prim`][1] for an implementation using Prim's algorithm.
 ///
 /// [1]: fn.min_spanning_tree_prim.html
+///
+/// # Example
+/// ```rust
+/// use petgraph::Graph;
+/// use petgraph::algo::min_spanning_tree;
+/// use petgraph::data::FromElements;
+/// use petgraph::graph::UnGraph;
+///
+/// let mut g = Graph::new_undirected();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// let c = g.add_node(());
+/// let d = g.add_node(());
+/// let e = g.add_node(());
+/// let f = g.add_node(());
+/// g.extend_with_edges(&[
+///     (0, 1, 2.0),
+///     (0, 3, 4.0),
+///     (1, 2, 1.0),
+///     (1, 5, 7.0),
+///     (2, 4, 5.0),
+///     (4, 5, 1.0),
+///     (3, 4, 1.0),
+/// ]);
+///
+/// // The graph looks like this:
+/// //     2       1
+/// // a ----- b ----- c
+/// // | 4     | 7     |
+/// // d       f       | 5
+/// // | 1     | 1     |
+/// // \------ e ------/
+///
+/// let mst = UnGraph::<_, _>::from_elements(min_spanning_tree(&g));
+/// assert_eq!(g.node_count(), mst.node_count());
+/// assert_eq!(mst.node_count() - 1, mst.edge_count());
+///
+/// // The resulting minimum spanning tree looks like this:
+/// //     2       1
+/// // a ----- b ----- c
+/// // | 4             
+/// // d       f       
+/// // | 1     | 1       
+/// // \------ e
+///
+/// let mut edge_weight_vec = mst.edge_weights().cloned().collect::<Vec<_>>();
+/// edge_weight_vec.sort_by(|a, b| a.partial_cmp(b).unwrap());
+/// assert_eq!(edge_weight_vec , vec![1.0, 1.0, 1.0, 2.0, 4.0]);
+/// ```
 pub fn min_spanning_tree<G>(g: G) -> MinSpanningTree<G>
 where
     G::NodeWeight: Clone,
@@ -141,6 +190,55 @@ where
 /// See also: [`.min_spanning_tree(g)`][1] for implementation using Kruskal's algorithm and support for minimum spanning forest.
 ///
 /// [1]: fn.min_spanning_tree.html
+///
+/// # Example
+/// ```rust
+/// use petgraph::Graph;
+/// use petgraph::algo::min_spanning_tree_prim;
+/// use petgraph::data::FromElements;
+/// use petgraph::graph::UnGraph;
+///
+/// let mut g = Graph::new_undirected();
+/// let a = g.add_node(());
+/// let b = g.add_node(());
+/// let c = g.add_node(());
+/// let d = g.add_node(());
+/// let e = g.add_node(());
+/// let f = g.add_node(());
+/// g.extend_with_edges(&[
+///     (0, 1, 2.0),
+///     (0, 3, 4.0),
+///     (1, 2, 1.0),
+///     (1, 5, 7.0),
+///     (2, 4, 5.0),
+///     (4, 5, 1.0),
+///     (3, 4, 1.0),
+/// ]);
+///
+/// // The graph looks like this:
+/// //     2       1
+/// // a ----- b ----- c
+/// // | 4     | 7     |
+/// // d       f       | 5
+/// // | 1     | 1     |
+/// // \------ e ------/
+///
+/// let mst = UnGraph::<_, _>::from_elements(min_spanning_tree_prim(&g));
+/// assert_eq!(g.node_count(), mst.node_count());
+/// assert_eq!(mst.node_count() - 1, mst.edge_count());
+///
+/// // The resulting minimum spanning tree looks like this:
+/// //     2       1
+/// // a ----- b ----- c
+/// // | 4
+/// // d       f
+/// // | 1     | 1
+/// // \------ e
+///
+/// let mut edge_weight_vec = mst.edge_weights().cloned().collect::<Vec<_>>();
+/// edge_weight_vec.sort_by(|a, b| a.partial_cmp(b).unwrap());
+/// assert_eq!(edge_weight_vec , vec![1.0, 1.0, 1.0, 2.0, 4.0]);
+/// ```
 pub fn min_spanning_tree_prim<G>(g: G) -> MinSpanningTreePrim<G>
 where
     G::EdgeWeight: PartialOrd,


### PR DESCRIPTION
This PR simply adds examples (really the same one for both) to the minimum spanning tree functions (the default one and the prim variant). Adding these makes them more consistent with the rest of the doc strings for other functions, since most of them include examples of how to use them.

This seems particularly useful, since in case of computing msts with petgraph, one needs to use `from_elements`, which is mentioned in the docstring already, but it might not be clear how to actually use `from_elements` to obtain a graph.