### PR TITLE
ci: Remove one test from miri test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,4 +120,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
+      # Exclude the `b07_vienna_test` test, as it takes very long to run with miri
       - run: cargo miri test -- --skip b07_vienna_test


### PR DESCRIPTION
There is one test, namely b07_vienna_test which seems to take ~5-10 minutes for each run of miri. Therefore, I would suggest excuding this test when running miri, since the test is also run in the various 'normal' cargo test runs.

For the workflows of this PR, a significant speedup should already be seen.