### PR TITLE
ci: Speedup miri by using nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: '*'
   merge_group:
     types: [ checks_requested ]
-  workflow_dispatch: {} 
+  workflow_dispatch: { }
 
 name: Continuous integration
 
@@ -120,4 +120,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
-      - run: cargo miri test
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - run: cargo miri nextest test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,4 +123,4 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
-      - run: cargo miri nextest test
+      - run: cargo miri nextest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,4 +123,5 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest
-      - run: cargo miri nextest run
+      # Exclude the `b07_vienna_test` test, as it takes very long to run with miri
+      - run: cargo miri nextest run -- --skip b07_vienna_test


### PR DESCRIPTION
[Nextest](https://github.com/nextest-rs/nextest) is an alternative test runner for rust projects which should speedup the tests, which is particularly interesting for the miri test run, since that one takes very long in comparison to the others.

I also included the changes from PR #809 already. If those should not be desireable, I can adjust the PR accordingly. However, the speedup should be even more noticeable if the test as suggest in PR #809 is removed, since most notably, nextest runs some tests in parallel, which is not very helpful if there are single tests which take extraordinarily long. 

There is an [integration with miri](https://nexte.st/docs/integrations/miri/) which is used for this PR, for which there is one thing to note however:

"Note, however, that `cargo miri test` is able to detect data races where two tests race on a shared resource. Miri with nextest will not detect such races."

I thought that covering such cases is not important for `petgraph`, but I am open to discussion on that.

