### PR TITLE
perf: Make A* tie break on lower h-values

### DIFF
--- a/benches/astar.rs
+++ b/benches/astar.rs
@@ -1,0 +1,103 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use petgraph::prelude::*;
+use test::Bencher;
+
+mod common;
+use petgraph::algo::astar;
+
+#[bench]
+fn astar_2d_grid_line_bench(bench: &mut Bencher) {
+    // Same line grid as ./dijkstra.rs
+    const N: usize = 500;
+    const M: usize = 5;
+    let g = common::build_2d_grid(N, M);
+
+    let heuristic_for = |goal: NodeIndex| {
+        let g = &g;
+        move |node: NodeIndex| -> usize {
+            let (x1, y1): (usize, usize) = g[node];
+            let (x2, y2): (usize, usize) = g[goal];
+
+            x2.abs_diff(x1) + y2.abs_diff(y1)
+        }
+    };
+
+    let start_i = 0;
+    let goal_i = N * M - 1;
+    let start = NodeIndex::new(start_i);
+    let goal = NodeIndex::new(goal_i);
+
+    if let Some((cost, path)) = astar(
+        &g,
+        start,
+        |n| n == goal,
+        |e| *e.weight(),
+        heuristic_for(goal),
+    ) {
+        assert_eq!(cost, N + M - 2);
+
+        assert_eq!(path.first().unwrap().index(), start_i);
+        assert_eq!(path.last().unwrap().index(), goal_i);
+        assert_eq!(path.len(), cost + 1);
+    }
+
+    bench.iter(|| {
+        let _ = astar(
+            &g,
+            start,
+            |n| n == goal,
+            |e| *e.weight(),
+            heuristic_for(goal),
+        );
+    });
+}
+
+#[bench]
+fn astar_2d_grid_bench(bench: &mut Bencher) {
+    // Same 2D grid as ./dijkstra.rs
+    const N: usize = 500;
+    let g = common::build_2d_grid(N, N);
+
+    let heuristic_for = |goal: NodeIndex| {
+        let g = &g;
+        move |node: NodeIndex| -> usize {
+            let (x1, y1): (usize, usize) = g[node];
+            let (x2, y2): (usize, usize) = g[goal];
+
+            x2.abs_diff(x1) + y2.abs_diff(y1)
+        }
+    };
+
+    let start_i = 0;
+    let goal_i = N * N - 1;
+    let start = NodeIndex::new(start_i);
+    let goal = NodeIndex::new(goal_i);
+
+    if let Some((cost, path)) = astar(
+        &g,
+        start,
+        |n| n == goal,
+        |e| *e.weight(),
+        heuristic_for(goal),
+    ) {
+        assert_eq!(cost, 2 * (N - 1));
+
+        assert_eq!(path.first().unwrap().index(), start_i);
+        assert_eq!(path.last().unwrap().index(), goal_i);
+        assert_eq!(path.len(), cost + 1);
+    }
+
+    bench.iter(|| {
+        let _ = astar(
+            &g,
+            start,
+            |n| n == goal,
+            |e| *e.weight(),
+            heuristic_for(goal),
+        );
+    });
+}

--- a/benches/common/factories.rs
+++ b/benches/common/factories.rs
@@ -355,3 +355,24 @@ pub fn build_graph(node_count: usize, dense: bool) -> Graph<usize, i32, Undirect
     }
     graph
 }
+
+pub fn build_2d_grid(width: usize, height: usize) -> Graph<(usize, usize), usize, Undirected> {
+    let mut g = Graph::new_undirected();
+
+    for j in 0..height {
+        for i in 0..width {
+            let node = g.add_node((i, j));
+
+            if j > 0 {
+                let up = NodeIndex::new(node.index() - width);
+                g.add_edge(node, up, 1);
+            }
+            if i > 0 {
+                let right = NodeIndex::new(node.index() - 1);
+                g.add_edge(node, right, 1);
+            }
+        }
+    }
+
+    g
+}

--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -33,7 +33,6 @@ fn dijkstra_bench(bench: &mut Bencher) {
     });
 }
 
-
 #[bench]
 fn dijkstra_2d_grid_line_bench(bench: &mut Bencher) {
     // Same line grid as ./astar.rs

--- a/benches/dijkstra.rs
+++ b/benches/dijkstra.rs
@@ -3,10 +3,11 @@
 extern crate petgraph;
 extern crate test;
 
+use core::cmp::{max, min};
 use petgraph::prelude::*;
-use std::cmp::{max, min};
 use test::Bencher;
 
+mod common;
 use petgraph::algo::dijkstra;
 
 #[bench]
@@ -29,5 +30,45 @@ fn dijkstra_bench(bench: &mut Bencher) {
 
     bench.iter(|| {
         let _scores = dijkstra(&g, nodes[0], None, |e| *e.weight());
+    });
+}
+
+
+#[bench]
+fn dijkstra_2d_grid_line_bench(bench: &mut Bencher) {
+    // Same line grid as ./astar.rs
+    const N: usize = 500;
+    const M: usize = 5;
+    let g = common::build_2d_grid(N, M);
+
+    let start_i = 0;
+    let goal_i = N * M - 1;
+    let start = NodeIndex::new(start_i);
+    let goal = NodeIndex::new(goal_i);
+
+    let costs = dijkstra(&g, start, None, |e| *e.weight());
+    assert_eq!(costs[&goal], N + M - 2);
+
+    bench.iter(|| {
+        let _ = dijkstra(&g, start, None, |e| *e.weight());
+    });
+}
+
+#[bench]
+fn dijkstra_2d_grid_bench(bench: &mut Bencher) {
+    // Same 2D grid as ./astar.rs
+    const N: usize = 500;
+    let g = common::build_2d_grid(N, N);
+
+    let start_i = 0;
+    let goal_i = N * N - 1;
+    let start = NodeIndex::new(start_i);
+    let goal = NodeIndex::new(goal_i);
+
+    let costs = dijkstra(&g, start, None, |e| *e.weight());
+    assert_eq!(costs[&goal], 2 * (N - 1));
+
+    bench.iter(|| {
+        let _ = dijkstra(&g, start, None, |e| *e.weight());
     });
 }


### PR DESCRIPTION
This implements the trick from #806 and adds an empty 2d maze benchmark

Update: This dropped original breaking change of making cost be `core::ops::Sub`, so it can be merged earlier.