### PR TITLE
docs: Unify algo docs

### DIFF
--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -19,7 +19,7 @@ use crate::visit::{EdgeRef, IntoEdges, IntoNodeReferences, NodeIndexable, NodeRe
 ///
 /// # Complexity
 /// - Time complexity: **O(|V| + |E|)**,
-/// - Space complexity: **O(|V|)**,
+/// - Auxiliary space: **O(|V|)**,
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -12,10 +12,17 @@ use crate::visit::{EdgeRef, IntoEdges, IntoNodeReferences, NodeIndexable, NodeRe
 /// Compute the articulation points of a graph (Nodes, which would increase the number of connected components in the graph.
 ///
 /// # Arguments
-/// * `graph`: A directed graph
+/// * `graph`: A directed graph.
 ///
 /// # Returns
-/// * `HashSet`: HashSet of the node ids which correspond to the articulation points of the graph.
+/// * `HashSet`: [`struct@hashbrown::HashSet`] of the node ids which correspond to the articulation points of the graph.
+///
+/// # Complexity
+/// - Time complexity: **O(|V| + |E|)**,
+/// - Space complexity: **O(|V|)**,
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 ///
 /// # Examples
 /// ```rust

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -25,9 +25,6 @@ use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 /// it should never overestimate the actual cost to get to the nearest goal node. Estimate costs
 /// must also be non-negative.
 ///
-/// The graph should be `Visitable` and implement `IntoEdges`.
-///
-///
 /// # Arguments
 /// * `graph`: weighted graph.
 /// * `start`: the start node.
@@ -40,9 +37,9 @@ use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 /// * `None` - if such a path was not found.
 ///
 /// # Complexity
-/// * Time complexity: **O(b^d)**, where **b** is the branching factor (the average number of successors per state)
-///   and **d** is the depth of *goal* node.
+/// The time complexity largely depends on the heuristic used. You can contribute to improve the documentation in this place ;)
 ///
+/// With a trivial heuristic, the algorithm will work like [`fn@crate::algo::dijkstra`], but other situations are possible too.
 ///
 /// # Example
 /// ```

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -25,7 +25,27 @@ use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 /// it should never overestimate the actual cost to get to the nearest goal node. Estimate costs
 /// must also be non-negative.
 ///
+/// Returns the total cost + the path of subsequent `NodeId` from start to finish, if one was
+/// found.
+///
 /// The graph should be `Visitable` and implement `IntoEdges`.
+///
+///
+/// # Arguments
+/// * `graph`: weighted graph
+/// * `start`: the start node
+/// * `is_goal`: the callback defines the goal node
+/// * `edge_cost`: closure that returns cost of a particular edge
+/// * `estimate_cost`: closure that returns the estimated cost to the finish for particular node
+///
+/// # Returns
+/// * `Some(...)` - the total cost and path from start to finish, if one was found.
+/// * `None` - if such path was not found.
+///
+/// # Complexity
+/// * Time complexity: **O(b^d)**, where **b** is branching factor (the average number of successors per state)
+///   and **d** is the depth of *goal* node.
+///
 ///
 /// # Example
 /// ```
@@ -62,9 +82,6 @@ use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 /// let path = astar(&g, a, |finish| finish == f, |e| *e.weight(), |_| 0);
 /// assert_eq!(path, Some((6, vec![a, d, e, f])));
 /// ```
-///
-/// Returns the total cost + the path of subsequent `NodeId` from start to finish, if one was
-/// found.
 pub fn astar<G, F, H, K, IsGoal>(
     graph: G,
     start: G::NodeId,

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -37,9 +37,9 @@ use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 /// * `None` - if such a path was not found.
 ///
 /// # Complexity
-/// The time complexity largely depends on the heuristic used. You can contribute to improve the documentation in this place ;)
+/// The time complexity largely depends on the heuristic used. Feel free to contribute and provide the exact time complexity :)
 ///
-/// With a trivial heuristic, the algorithm will work like [`fn@crate::algo::dijkstra`], but other situations are possible too.
+/// With a trivial heuristic, the algorithm will behave like [`fn@crate::algo::dijkstra`].
 ///
 /// # Example
 /// ```

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -25,25 +25,22 @@ use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 /// it should never overestimate the actual cost to get to the nearest goal node. Estimate costs
 /// must also be non-negative.
 ///
-/// Returns the total cost + the path of subsequent `NodeId` from start to finish, if one was
-/// found.
-///
 /// The graph should be `Visitable` and implement `IntoEdges`.
 ///
 ///
 /// # Arguments
-/// * `graph`: weighted graph
-/// * `start`: the start node
-/// * `is_goal`: the callback defines the goal node
-/// * `edge_cost`: closure that returns cost of a particular edge
-/// * `estimate_cost`: closure that returns the estimated cost to the finish for particular node
+/// * `graph`: weighted graph.
+/// * `start`: the start node.
+/// * `is_goal`: the callback defines the goal node.
+/// * `edge_cost`: closure that returns cost of a particular edge.
+/// * `estimate_cost`: closure that returns the estimated cost to the finish for particular node.
 ///
 /// # Returns
-/// * `Some(...)` - the total cost and path from start to finish, if one was found.
-/// * `None` - if such path was not found.
+/// * `Some(K, Vec<G::NodeId>)` - the total cost and path from start to finish, if one was found.
+/// * `None` - if such a path was not found.
 ///
 /// # Complexity
-/// * Time complexity: **O(b^d)**, where **b** is branching factor (the average number of successors per state)
+/// * Time complexity: **O(b^d)**, where **b** is the branching factor (the average number of successors per state)
 ///   and **d** is the depth of *goal* node.
 ///
 ///

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -31,7 +31,7 @@ pub struct Paths<NodeId, EdgeWeight> {
 ///
 /// # Complexity
 /// * Time complexity: **O(|V||E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -138,7 +138,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V||E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -24,6 +24,21 @@ pub struct Paths<NodeId, EdgeWeight> {
 /// out the predecessor of a node along a shortest path. The vectors
 /// are indexed by the graph's node indices.
 ///
+/// # Arguments
+/// * `g`: graph with no negative cycle
+/// * `source`: the source node
+///
+/// # Returns
+/// * `Ok`: (if graph contains no negative cycle) a struct [`Paths`] containing distances and
+///   predecessors along each shortest path.
+/// * `Err`: if graph contains negative cycle.
+///
+/// # Complexity
+/// * Time complexity: **O(|V||E|)**
+/// * Space complexity: **O(|V|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 /// [bf]: https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
 ///
 /// # Example
@@ -117,7 +132,20 @@ where
 ///
 /// If a negative cycle is found from source, return one vec with a path of `NodeId`s.
 ///
-/// The time complexity of this algorithm should be the same as the Bellman-Ford (O(|V|·|E|)).
+/// # Arguments
+/// * `g`: graph
+/// * `source`: the source node
+///
+/// # Returns
+/// * `Some(Vec<G::NodeId>)` - the path of the negative cycle (if found)
+/// * `None` - if `g` doesn't contain negative cycles reachable from `source`
+///
+/// # Complexity
+/// * Time complexity: **O(|V||E|)**
+/// * Space complexity: **O(|V|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 ///
 /// [nc]: https://blogs.asarkar.com/assets/docs/algorithms-curated/Negative-Weight%20Cycle%20Algorithms%20-%20Huang.pdf
 /// [bf]: https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -20,22 +20,18 @@ pub struct Paths<NodeId, EdgeWeight> {
 /// permitted, but the graph must not have a cycle of negative weights
 /// (in that case it will return an error).
 ///
-/// On success, return one vec with path costs, and another one which points
-/// out the predecessor of a node along a shortest path. The vectors
-/// are indexed by the graph's node indices.
-///
 /// # Arguments
-/// * `g`: graph with no negative cycle
-/// * `source`: the source node
+/// * `g`: graph with no negative cycle.
+/// * `source`: the source node.
 ///
 /// # Returns
 /// * `Ok`: (if graph contains no negative cycle) a struct [`Paths`] containing distances and
-///   predecessors along each shortest path.
+///   predecessors along each shortest path. The vectors in [`Paths`] are indexed by the graph's node indices.
 /// * `Err`: if graph contains negative cycle.
 ///
 /// # Complexity
-/// * Time complexity: **O(|V||E|)**
-/// * Space complexity: **O(|V|)**
+/// * Time complexity: **O(|V||E|)**.
+/// * Space complexity: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -127,22 +123,22 @@ where
 
 /// \[Generic\] Find the path of a negative cycle reachable from node `source`.
 ///
-/// Using the [find_negative_cycle][nc]; will search the Graph for negative cycles using
+/// Using the [find_negative_cycle][nc]; will search the graph for negative cycles using
 /// [Bellman–Ford algorithm][bf]. If no negative cycle is found the function will return `None`.
 ///
 /// If a negative cycle is found from source, return one vec with a path of `NodeId`s.
 ///
 /// # Arguments
-/// * `g`: graph
-/// * `source`: the source node
+/// * `g`: graph.
+/// * `source`: the source node.
 ///
 /// # Returns
-/// * `Some(Vec<G::NodeId>)` - the path of the negative cycle (if found)
-/// * `None` - if `g` doesn't contain negative cycles reachable from `source`
+/// * `Some(Vec<G::NodeId>)` - the path of the negative cycle (if found).
+/// * `None` - if `g` doesn't contain negative cycles reachable from `source`.
 ///
 /// # Complexity
-/// * Time complexity: **O(|V||E|)**
-/// * Space complexity: **O(|V|)**
+/// * Time complexity: **O(|V||E|)**.
+/// * Space complexity: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/bridges.rs
+++ b/src/algo/bridges.rs
@@ -5,11 +5,23 @@ use crate::visit::{
 use alloc::{vec, vec::Vec};
 
 /// Find all [bridges](https://en.wikipedia.org/wiki/Bridge_(graph_theory)) in a simple undirected graph.
-/// The algorithm is **O(|E|)** where **|E|** is the number of edges in the graph.
 ///
-/// Returns the vector of pairs `(G::NodeID, G:: NodeID)`,
+/// Returns the iterator of edge references `G::EdgeRef`,
 /// representing the edges of the input graph that are bridges.
-/// The order of the vertices in the pair and the order of the edges themselves are arbitrary.
+/// The order of the edges is arbitrary.
+///
+/// # Arguments
+/// * `graph`: a simple undirected graph
+///
+/// # Returns
+/// * `impl Iterator`:  the iterator of edge references `G::EdgeRef`
+///
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**
+/// * Space complexity: **O(|V| + |E|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 ///
 /// # Examples
 ///

--- a/src/algo/bridges.rs
+++ b/src/algo/bridges.rs
@@ -15,7 +15,7 @@ use alloc::{vec, vec::Vec};
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/bridges.rs
+++ b/src/algo/bridges.rs
@@ -6,19 +6,16 @@ use alloc::{vec, vec::Vec};
 
 /// Find all [bridges](https://en.wikipedia.org/wiki/Bridge_(graph_theory)) in a simple undirected graph.
 ///
-/// Returns the iterator of edge references `G::EdgeRef`,
-/// representing the edges of the input graph that are bridges.
-/// The order of the edges is arbitrary.
-///
 /// # Arguments
-/// * `graph`: a simple undirected graph
+/// * `graph`: a simple undirected graph.
 ///
 /// # Returns
-/// * `impl Iterator`:  the iterator of edge references `G::EdgeRef`
+/// * `impl Iterator`:  the iterator of edge references `G::EdgeRef` representing the edges
+///   of the input graph that are bridges. The order of the edges is arbitrary.
 ///
 /// # Complexity
-/// * Time complexity: **O(|V| + |E|)**
-/// * Space complexity: **O(|V| + |E|)**
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -13,9 +13,21 @@ use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visi
 ///
 /// The graph must be undirected. It should not contain loops.
 /// It must implement `IntoEdges`, `IntoNodeIdentifiers` and `Visitable`
-/// Returns a tuple composed of a HashMap that associates to each `NodeId` its color and the number of used colors.
+/// Returns a tuple composed of a `HashMap` that associates to each `NodeId` its color and the number of used colors.
 ///
-/// Computes in **O((|V| + |E|)log(|V|)** time.
+///
+/// # Arguments
+/// * `graph`: undirected graph without loops
+///
+/// # Returns
+/// * `(HashMap, usize)`: [`struct@hashbrown::HashMap`] that associates to each `NodeId` its color
+///   and the `usize` number of used colors.
+///
+/// # Complexity
+/// * Time complexity: **O((|V| + |E|)log(|V|)**
+/// * Space complexity: **O(|V|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// [1]: https://en.wikipedia.org/wiki/DSatur
 ///

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -10,22 +10,18 @@ use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visi
 ///
 ///
 /// This is a heuristic. So, it does not necessarily return a minimum coloring.
-///
 /// The graph must be undirected. It should not contain loops.
-/// It must implement `IntoEdges`, `IntoNodeIdentifiers` and `Visitable`
-/// Returns a tuple composed of a `HashMap` that associates to each `NodeId` its color and the number of used colors.
-///
 ///
 /// # Arguments
-/// * `graph`: undirected graph without loops
+/// * `graph`: undirected graph without loops.
 ///
 /// # Returns
 /// * `(HashMap, usize)`: [`struct@hashbrown::HashMap`] that associates to each `NodeId` its color
 ///   and the `usize` number of used colors.
 ///
 /// # Complexity
-/// * Time complexity: **O((|V| + |E|)log(|V|)**
-/// * Space complexity: **O(|V|)**
+/// * Time complexity: **O((|V| + |E|)log(|V|)**.
+/// * Space complexity: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -16,8 +16,8 @@ use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visi
 /// * `graph`: undirected graph without loops.
 ///
 /// # Returns
-/// * `(HashMap, usize)`: [`struct@hashbrown::HashMap`] that associates to each `NodeId` its color
-///   and the `usize` number of used colors.
+/// * [`struct@hashbrown::HashMap`] that associates to each `NodeId` its color.
+/// * `usize`: the number of used colors.
 ///
 /// # Complexity
 /// * Time complexity: **O((|V| + |E|)log(|V|)**.

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -6,8 +6,8 @@ use hashbrown::{HashMap, HashSet};
 use crate::scored::MaxScored;
 use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visitable};
 
-/// \[Generic\] DStatur algorithm to properly color a non weighted undirected graph.
-/// <https://en.wikipedia.org/wiki/DSatur>
+/// \[Generic\] [DStatur algorithm][1] to properly color a non weighted undirected graph.
+///
 ///
 /// This is a heuristic. So, it does not necessarily return a minimum coloring.
 ///
@@ -15,7 +15,9 @@ use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visi
 /// It must implement `IntoEdges`, `IntoNodeIdentifiers` and `Visitable`
 /// Returns a tuple composed of a HashMap that associates to each `NodeId` its color and the number of used colors.
 ///
-/// Computes in **O((|V| + |E|)*log(|V|)** time
+/// Computes in **O((|V| + |E|)log(|V|)** time.
+///
+/// [1]: https://en.wikipedia.org/wiki/DSatur
 ///
 /// # Example
 /// ```rust

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -21,7 +21,7 @@ use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visi
 ///
 /// # Complexity
 /// * Time complexity: **O((|V| + |E|)log(|V|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Space complexity: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -21,7 +21,7 @@ use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visi
 ///
 /// # Complexity
 /// * Time complexity: **O((|V| + |E|)log(|V|)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -16,6 +16,7 @@ use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visi
 /// * `graph`: undirected graph without loops.
 ///
 /// # Returns
+/// Returns a tuple of:
 /// * [`struct@hashbrown::HashMap`] that associates to each `NodeId` its color.
 /// * `usize`: the number of used colors.
 ///

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -23,9 +23,9 @@ use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
 /// cost is calculated.
 ///
 /// # Arguments
-/// * `graph` - weighted graph
-/// * `start` - the start node  
-/// * `goal` - optional *goal* node
+/// * `graph`: weighted graph
+/// * `start`: the start node  
+/// * `goal`: optional *goal* node
 /// * `edge_cost`: closure that returns cost of a particular edge
 ///
 /// # Returns

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -15,25 +15,24 @@ use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
 /// Compute the length of the shortest path from `start` to every reachable
 /// node.
 ///
-/// The graph should be `Visitable` and implement `IntoEdges`. The function
-/// `edge_cost` should return the cost for a particular edge, which is used
+/// The function `edge_cost` should return the cost for a particular edge, which is used
 /// to compute path costs. Edge costs must be non-negative.
 ///
 /// If `goal` is not `None`, then the algorithm terminates once the `goal` node's
 /// cost is calculated.
 ///
 /// # Arguments
-/// * `graph`: weighted graph
-/// * `start`: the start node  
-/// * `goal`: optional *goal* node
-/// * `edge_cost`: closure that returns cost of a particular edge
+/// * `graph`: weighted graph.
+/// * `start`: the start node.
+/// * `goal`: optional *goal* node.
+/// * `edge_cost`: closure that returns cost of a particular edge.
 ///
 /// # Returns
 /// * `HashMap`: [`struct@hashbrown::HashMap`] that maps `NodeId` to path cost.
 ///
 /// # Complexity
-/// * Time complexity: **O((|V|+|E|)log(|V|))**
-/// * Space complexity: **O(|V|+|E|)**
+/// * Time complexity: **O((|V|+|E|)log(|V|))**.
+/// * Space complexity: **O(|V|+|E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -22,7 +22,21 @@ use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
 /// If `goal` is not `None`, then the algorithm terminates once the `goal` node's
 /// cost is calculated.
 ///
-/// Returns a `HashMap` that maps `NodeId` to path cost.
+/// # Arguments
+/// * `graph` - weighted graph
+/// * `start` - the start node  
+/// * `goal` - optional *goal* node
+/// * `edge_cost`: closure that returns cost of a particular edge
+///
+/// # Returns
+/// * `HashMap`: [`struct@hashbrown::HashMap`] that maps `NodeId` to path cost.
+///
+/// # Complexity
+/// * Time complexity: **O((|V|+|E|)log(|V|))**
+/// * Space complexity: **O(|V|+|E|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 /// # Example
 /// ```rust
 /// use petgraph::Graph;

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -32,7 +32,7 @@ use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
 ///
 /// # Complexity
 /// * Time complexity: **O((|V|+|E|)log(|V|))**.
-/// * Space complexity: **O(|V|+|E|)**.
+/// * Auxiliary space: **O(|V|+|E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -161,16 +161,16 @@ const UNDEFINED: usize = usize::MAX;
 /// to ~30,000 nodes.
 ///
 /// # Arguments
-/// * `graph`: a control-flow graph
-/// * `root`: the *root* node of the `graph`
+/// * `graph`: a control-flow graph.
+/// * `root`: the *root* node of the `graph`.
 ///
 /// # Returns
 /// * `Dominators`: the dominance relation for given `graph` and `root`
-///   represented by [`struct@Dominators`]
+///   represented by [`struct@Dominators`].
 ///
 /// # Complexity
-/// * Time complexity: **O(|V|²)**
-/// * Space complexity: **O(|V| + |E|)**
+/// * Time complexity: **O(|V|²)**.
+/// * Space complexity: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -170,7 +170,7 @@ const UNDEFINED: usize = usize::MAX;
 ///
 /// # Complexity
 /// * Time complexity: **O(|V|²)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/dominators.rs
+++ b/src/algo/dominators.rs
@@ -160,6 +160,20 @@ const UNDEFINED: usize = usize::MAX;
 /// Cooper et al found it to be faster in practice on control flow graphs of up
 /// to ~30,000 nodes.
 ///
+/// # Arguments
+/// * `graph`: a control-flow graph
+/// * `root`: the *root* node of the `graph`
+///
+/// # Returns
+/// * `Dominators`: the dominance relation for given `graph` and `root`
+///   represented by [`struct@Dominators`]
+///
+/// # Complexity
+/// * Time complexity: **O(|V|²)**
+/// * Space complexity: **O(|V| + |E|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 /// [0]: http://www.hipersoft.rice.edu/grads/publications/dom14.pdf
 pub fn simple_fast<G>(graph: G, root: G::NodeId) -> Dominators<G::NodeId>
 where

--- a/src/algo/feedback_arc_set.rs
+++ b/src/algo/feedback_arc_set.rs
@@ -25,10 +25,13 @@ use self::linked_list::{LinkedList, LinkedListEntry};
 /// * `g`: a directed graph.
 ///
 /// # Returns
-/// * `impl Iterator`:  the iterator of edge references `G::EdgeRef`.
+/// * `impl Iterator`:  the iterator of edge references `G::EdgeRef` in the feedback arc set.
 ///
 /// # Complexity
-/// * Time complexity: **O(|E|)**, where **|E|** is the number of edges in the input graph.
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V| + |E|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// # Example
 ///

--- a/src/algo/feedback_arc_set.rs
+++ b/src/algo/feedback_arc_set.rs
@@ -22,13 +22,13 @@ use self::linked_list::{LinkedList, LinkedListEntry};
 /// Loops (edges to and from the same node) are always included in the returned set.
 ///
 /// # Arguments
-/// * `g`: a directed graph
+/// * `g`: a directed graph.
 ///
 /// # Returns
-/// * `impl Iterator`:  the iterator of edge references `G::EdgeRef`
+/// * `impl Iterator`:  the iterator of edge references `G::EdgeRef`.
 ///
 /// # Complexity
-/// * Time complexity: **O(|E|)**, where |E| is the number of edges in the input graph.
+/// * Time complexity: **O(|E|)**, where **|E|** is the number of edges in the input graph.
 ///
 /// # Example
 ///

--- a/src/algo/feedback_arc_set.rs
+++ b/src/algo/feedback_arc_set.rs
@@ -15,12 +15,20 @@ use self::linked_list::{LinkedList, LinkedListEntry};
 /// removed, make the graph acyclic.
 ///
 /// Uses a [greedy heuristic algorithm] to select a small number of edges, but does not necessarily
-/// find the minimum feedback arc set. Time complexity is roughly **O(|E|)** for an input graph with
-/// edges **E**.
+/// find the minimum feedback arc set.
 ///
 /// Does not consider edge/node weights when selecting edges for the feedback arc set.
 ///
 /// Loops (edges to and from the same node) are always included in the returned set.
+///
+/// # Arguments
+/// * `g`: a directed graph
+///
+/// # Returns
+/// * `impl Iterator`:  the iterator of edge references `G::EdgeRef`
+///
+/// # Complexity
+/// * Time complexity: **O(|E|)**, where |E| is the number of edges in the input graph.
 ///
 /// # Example
 ///

--- a/src/algo/feedback_arc_set.rs
+++ b/src/algo/feedback_arc_set.rs
@@ -29,7 +29,7 @@ use self::linked_list::{LinkedList, LinkedListEntry};
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -14,16 +14,16 @@ use crate::visit::{
 /// Compute the length of each shortest path in a weighted graph with positive or negative edge weights (but with no negative cycles).
 ///
 /// # Arguments
-/// * `graph`: graph with no negative cycle
-/// * `edge_cost`: closure that returns cost of a particular edge
+/// * `graph`: graph with no negative cycle.
+/// * `edge_cost`: closure that returns cost of a particular edge.
 ///
 /// # Returns
-/// * `Ok`: (if graph contains no negative cycle) a hashmap containing all pairs shortest paths
+/// * `Ok`: (if graph contains no negative cycle) a [`struct@hashbrown::HashMap`] containing all pairs shortest paths.
 /// * `Err`: if graph contains negative cycle.
 ///
 /// # Complexity
-/// * Time complexity: **O(|V|³)**
-/// * Space complexity: **O(|V|²)**
+/// * Time complexity: **O(|V|³)**.
+/// * Space complexity: **O(|V|²)**.
 ///
 /// where **|V|** is the number of nodes.
 ///

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -21,6 +21,12 @@ use crate::visit::{
 /// * `Ok`: (if graph contains no negative cycle) a hashmap containing all pairs shortest paths
 /// * `Err`: if graph contains negative cycle.
 ///
+/// # Complexity
+/// * Time complexity: **O(|V|³)**
+/// * Space complexity: **O(|V|²)**
+///
+/// where **|V|** is the number of nodes.
+///
 /// **Note**: If the graph is sparse (the number of edges is quite small),
 /// consider using the [`johnson`](fn@crate::algo::johnson), which is likely to show better performance.
 ///
@@ -126,6 +132,10 @@ where
 /// # Returns
 /// * `Ok`: (if graph contains no negative cycle) a hashmap containing all pairs shortest path distances and a hashmap for all pairs shortest paths
 /// * `Err`: if graph contains negative cycle.
+///
+/// # Complexity
+/// * Time complexity: **O(|V|³)**
+/// * Space complexity: **O(|V|²)**
 ///
 /// # Examples
 /// ```rust

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -28,7 +28,7 @@ use crate::visit::{
 /// where **|V|** is the number of nodes.
 ///
 /// **Note**: If the graph is sparse (the number of edges is quite small),
-/// consider using the [`johnson`](fn@crate::algo::johnson), which is likely to show better performance.
+/// consider using [`johnson`](fn@crate::algo::johnson)'s algorithm, which is likely to show better performance in such cases.
 ///
 /// # Examples
 /// ```rust

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -23,7 +23,7 @@ use crate::visit::{
 ///
 /// # Complexity
 /// * Time complexity: **O(|V|³)**.
-/// * Space complexity: **O(|V|²)**.
+/// * Auxiliary space: **O(|V|²)**.
 ///
 /// where **|V|** is the number of nodes.
 ///
@@ -135,7 +135,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V|³)**
-/// * Space complexity: **O(|V|²)**
+/// * Auxiliary space: **O(|V|²)**
 ///
 /// # Examples
 /// ```rust

--- a/src/algo/ford_fulkerson.rs
+++ b/src/algo/ford_fulkerson.rs
@@ -121,8 +121,7 @@ where
 /// # Returns
 /// Returns a tuple of two values:
 /// * `N::EdgeWeight`: computed maximum flow;
-/// * `Vec<N::EdgeWeight>`: the flow of each edge.
-///   The vector is indexed by the graph's edge indices.
+/// * `Vec<N::EdgeWeight>`: the flow of each edge. The vector is indexed by the graph's edge indices.
 ///
 /// # Complexity
 /// * Time complexity: **O(|V||E|²)**.

--- a/src/algo/ford_fulkerson.rs
+++ b/src/algo/ford_fulkerson.rs
@@ -109,15 +109,30 @@ where
     }
 }
 
-/// \[Generic\] [Ford-Fulkerson][ff] algorithm.
+/// \[Generic\] [Ford-Fulkerson][ff] algorithm in the [Edmonds-Karp][ek] variation.
 ///
-/// Computes the [maximum flow] of a weighted directed graph.
+/// Computes the [maximum flow] from `source` to `destination` in a weighted directed graph.
 ///
-/// If it terminates, it returns the computed maximum flow and a vector containing the flow of
-/// each edge. The vector is indexed by the indices of the edges in the graph.
+/// # Arguments
+/// * `network`: a wieghted directed graph.
+/// * `source`: a stream *source* node.
+/// * `destination`: a stream *sink* node.
+///
+/// # Returns
+/// Returns a tuple of two values:
+/// * `N::EdgeWeight`: computed maximum flow;
+/// * `Vec<N::EdgeWeight>`: the flow of each edge.
+///   The vector is indexed by the graph's edge indices.
+///
+/// # Complexity
+/// * Time complexity: **O(|V||E|²)**.
+/// * Space complexity: **O(|V| + |E|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// [maximum flow]: https://en.wikipedia.org/wiki/Maximum_flow_problem
 /// [ff]: https://en.wikipedia.org/wiki/Ford%E2%80%93Fulkerson_algorithm
+/// [ek]: https://en.wikipedia.org/wiki/Edmonds%E2%80%93Karp_algorithm
 ///
 /// # Example
 /// ```rust

--- a/src/algo/ford_fulkerson.rs
+++ b/src/algo/ford_fulkerson.rs
@@ -126,7 +126,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V||E|²)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -17,7 +17,7 @@ use core::marker::{Send, Sync};
 /// Сompute the lengths of shortest paths in a weighted graph with
 /// positive or negative edge weights, but no negative cycles.
 ///
-/// The time complexity of this implementation is O(VElog(V) + V^2*log(V)),
+/// The time complexity of this implementation is **O(|V||E|log(|V|) + |V|²*log(|V|))**,
 /// which is faster than [`floyd_warshall`](fn@crate::algo::floyd_warshall) on sparse graphs and slower on dense ones.
 ///
 /// If you are working with a sparse graph that is guaranteed to have no negative weights,
@@ -32,6 +32,12 @@ use core::marker::{Send, Sync};
 /// ## Returns
 /// * `Err`: if graph contains negative cycle.
 /// * `Ok`: `HashMap` of shortest distances.
+///
+/// # Complexity
+/// * Time complexity: **O(|V||E|log(|V|) + |V|²log(|V|))** since the implementation is based on [`dijkstra`](fn@crate::algo::dijkstra)
+/// * Space complexity: **O(|V|² + |V||E|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// [johnson]: https://en.wikipedia.org/wiki/Johnson%27s_algorithm
 ///

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -35,7 +35,7 @@ use core::marker::{Send, Sync};
 ///
 /// # Complexity
 /// * Time complexity: **O(|V||E|log(|V|) + |V|²log(|V|))** since the implementation is based on [`dijkstra`](fn@crate::algo::dijkstra).
-/// * Space complexity: **O(|V|² + |V||E|)**.
+/// * Auxiliary space: **O(|V|² + |V||E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -34,8 +34,8 @@ use core::marker::{Send, Sync};
 /// * `Ok`: `HashMap` of shortest distances.
 ///
 /// # Complexity
-/// * Time complexity: **O(|V||E|log(|V|) + |V|²log(|V|))** since the implementation is based on [`dijkstra`](fn@crate::algo::dijkstra)
-/// * Space complexity: **O(|V|² + |V||E|)**
+/// * Time complexity: **O(|V||E|log(|V|) + |V|²log(|V|))** since the implementation is based on [`dijkstra`](fn@crate::algo::dijkstra).
+/// * Space complexity: **O(|V|² + |V||E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -10,28 +10,25 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 /// \[Generic\] k'th shortest path algorithm.
 ///
 /// Compute the length of the k'th shortest path from `start` to every reachable
-/// node.
-///
-/// The graph should be `Visitable` and implement `IntoEdges`. The function
-/// `edge_cost` should return the cost for a particular edge, which is used
-/// to compute path costs. Edge costs must be non-negative.
+/// node. Edge costs must be non-negative.
 ///
 /// If `goal` is not `None`, then the algorithm terminates once the `goal` node's
 /// cost is calculated.
 ///
 /// # Arguments
-/// * `graph`: an input graph
-/// * `start`: the *start* node
-/// * `goal`: optional *goal* node
-/// * `k`: sequence number of the required shortest paths
-/// * `edge_cost`: closure that returns cost of a particular edge
+/// * `graph`: an input graph.
+/// * `start`: the *start* node.
+/// * `goal`: optional *goal* node.
+/// * `k`: sequence number of the required shortest paths.
+/// * `edge_cost`: closure that should return the cost for a particular edge, which is used
+///   to compute path costs. Edge costs must be non-negative.
 ///
 /// # Returns
 /// * `HashMap`: [`struct@hashbrown::HashMap`] that maps `NodeId` to path cost.
 ///
 /// # Complexity
-/// * Time complexity: **O(k(|E| + |V|log(|V|)))**
-/// * Space complexity: **O(|V| + k|E|)**
+/// * Time complexity: **O(k(|E| + |V|log(|V|)))**.
+/// * Space complexity: **O(|V| + k|E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -19,9 +19,22 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 /// If `goal` is not `None`, then the algorithm terminates once the `goal` node's
 /// cost is calculated.
 ///
-/// Computes in **O(k * (|E| + |V|*log(|V|)))** time (average).
+/// # Arguments
+/// * `graph`: an input graph
+/// * `start`: the *start* node
+/// * `goal`: optional *goal* node
+/// * `k`: sequence number of the required shortest paths
+/// * `edge_cost`: closure that returns cost of a particular edge
 ///
-/// Returns a `HashMap` that maps `NodeId` to path cost.
+/// # Returns
+/// * `HashMap`: [`struct@hashbrown::HashMap`] that maps `NodeId` to path cost.
+///
+/// # Complexity
+/// * Time complexity: **O(k(|E| + |V|log(|V|)))**
+/// * Space complexity: **O(|V| + k|E|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 /// # Example
 /// ```rust
 /// use petgraph::Graph;

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -9,7 +9,7 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 
 /// \[Generic\] k'th shortest path algorithm.
 ///
-/// Compute the length of the k'th shortest path from `start` to every reachable
+/// Compute the length of the k-th shortest path from `start` to every reachable
 /// node. Edge costs must be non-negative.
 ///
 /// If `goal` is not `None`, then the algorithm terminates once the `goal` node's

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -27,10 +27,10 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 /// * `HashMap`: [`struct@hashbrown::HashMap`] that maps `NodeId` to path cost.
 ///
 /// # Complexity
-/// * Time complexity: **O(k(|E| + |V|log(|V|)))**.
+/// * Time complexity: **O(k|E| log(k|E|))**.
 /// * Auxiliary space: **O(|V| + k|E|)**.
 ///
-/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+/// where **|V|** is the number of nodes, **|E|** is the number of edges and **k** is the provided parameter.
 ///
 /// # Example
 /// ```rust

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -28,7 +28,7 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 ///
 /// # Complexity
 /// * Time complexity: **O(k(|E| + |V|log(|V|)))**.
-/// * Space complexity: **O(|V| + k|E|)**.
+/// * Auxiliary space: **O(|V| + k|E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -197,14 +197,14 @@ where
 /// instead.
 ///
 /// # Arguments
-/// * `graph`: an undirected graph
+/// * `graph`: an undirected graph.
 ///
 /// # Returns
 /// * [`struct@Matching`] calculated using greedy heuristic.
 ///
 /// # Complexity
-/// * Time complexity: **O(|V| + |E|)**
-/// * Space complexity: **O(|V|)**
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -330,14 +330,14 @@ impl<G: GraphBase> PartialEq for Label<G> {
 /// **Panics** if `g.node_bound()` is `usize::MAX`.
 ///
 /// # Arguments
-/// * `graph`: an undirected graph
+/// * `graph`: an undirected graph.
 ///
 /// # Returns
 /// * [`struct@Matching`]: computed maximum matching.
 ///
 /// # Complexity
-/// * Time complexity: **O(|V|³)**
-/// * Space complexity: **O(|V| + |E|)**
+/// * Time complexity: **O(|V|³)**.
+/// * Space complexity: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -204,7 +204,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -337,7 +337,7 @@ impl<G: GraphBase> PartialEq for Label<G> {
 ///
 /// # Complexity
 /// * Time complexity: **O(|V|³)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -189,12 +189,24 @@ where
 /// greedy heuristic.
 ///
 /// The input graph is treated as if undirected. The underlying heuristic is
-/// unspecified, but is guaranteed to be bounded by *O(|V| + |E|)*. No
+/// unspecified, but is guaranteed to be bounded by **O(|V| + |E|)**. No
 /// guarantees about the output are given other than that it is a valid
 /// matching.
 ///
 /// If you require a maximum matching, use [`maximum_matching`][1] function
 /// instead.
+///
+/// # Arguments
+/// * `graph`: an undirected graph
+///
+/// # Returns
+/// * [`struct@Matching`] calculated using greedy heuristic.
+///
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**
+/// * Space complexity: **O(|V|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// [1]: fn.maximum_matching.html
 pub fn greedy_matching<G>(graph: G) -> Matching<G>
@@ -312,10 +324,22 @@ impl<G: GraphBase> PartialEq for Label<G> {
 /// [1]: https://dl.acm.org/doi/10.1145/321941.321942
 ///
 /// The input graph is treated as if undirected. The algorithm runs in
-/// *O(|V|³)*. An algorithm with a better time complexity might be used in the
+/// **O(|V|³)**. An algorithm with a better time complexity might be used in the
 /// future.
 ///
 /// **Panics** if `g.node_bound()` is `usize::MAX`.
+///
+/// # Arguments
+/// * `graph`: an undirected graph
+///
+/// # Returns
+/// * [`struct@Matching`]: computed maximum matching.
+///
+/// # Complexity
+/// * Time complexity: **O(|V|³)**
+/// * Space complexity: **O(|V| + |E|)**
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// # Examples
 ///

--- a/src/algo/maximal_cliques.rs
+++ b/src/algo/maximal_cliques.rs
@@ -76,7 +76,7 @@ where
 /// * `g`: The graph to find maximal cliques in.
 ///
 /// # Returns
-/// * A vector of sets making up the maximal cliques in the graph.
+/// * `Vec<HashSet>`: A vector of [`struct@hashbrown::HashSet`] making up the maximal cliques in the graph.
 ///
 /// # Complexity
 /// * Time complexity: **O(3^(|V|/3))**

--- a/src/algo/maximal_cliques.rs
+++ b/src/algo/maximal_cliques.rs
@@ -80,7 +80,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(3^(|V|/3))**
-/// * Space complexity: **O(|V|²)** plus the space needed for sets R, P, and X.
+/// * Auxiliary space: **O(|V|²)**.
 ///
 /// where **|V|** is the number of nodes.
 ///

--- a/src/algo/maximal_cliques.rs
+++ b/src/algo/maximal_cliques.rs
@@ -72,11 +72,17 @@ where
 /// This method may also be called on directed graphs, but one needs to ensure that
 /// if an edge (u, v) exists, then (v, u) also exists.
 ///
-/// ## Arguments
+/// # Arguments
 /// * `g`: The graph to find maximal cliques in.
 ///
-/// ## Returns
-/// A vector of sets making up the maximal cliques in the graph.
+/// # Returns
+/// * A vector of sets making up the maximal cliques in the graph.
+///
+/// # Complexity
+/// * Time complexity: **O(3^(|V|/3))**
+/// * Space complexity: **O(|V|²)** plus the space needed for sets R, P, and X.
+///
+/// where **|V|** is the number of nodes.
 ///
 /// [1]: https://en.wikipedia.org/wiki/Bron%E2%80%93Kerbosch_algorithm
 ///

--- a/src/algo/min_spanning_tree.rs
+++ b/src/algo/min_spanning_tree.rs
@@ -22,9 +22,20 @@ use crate::visit::{IntoEdgeReferences, NodeIndexable};
 /// The resulting graph has all the vertices of the input graph (with identical node indices),
 /// and **|V| - c** edges, where **c** is the number of connected components in `g`.
 ///
-/// Use `from_elements` to create a graph from the resulting iterator.
-///
 /// See also: [`min_spanning_tree_prim`][1] for an implementation using Prim's algorithm.
+///
+/// # Arguments
+/// * `g`: an undirected graph.
+///
+/// # Returns
+/// * [`MinSpanningTree`]: an iterator producing a minimum spanning forest of a graph.
+///   Use `from_elements` to create a graph from the resulting iterator.
+///
+/// # Complexity
+/// * Time complexity: **O(|E| log |E|)**.
+/// * Space complexity: **O(|V| + |E|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// [1]: fn.min_spanning_tree_prim.html
 ///
@@ -180,14 +191,23 @@ where
 /// Graph is treated as if connected (has only 1 component). Otherwise, the resulting
 /// graph will only contain edges for an arbitrary minimum spanning tree for a single component.
 ///
-/// Using Prim's algorithm with runtime **O(|E| log |V|)**.
-///
 /// The resulting graph has all the vertices of the input graph (with identical node indices),
 /// and **|V| - 1** edges if input graph is connected, and |W| edges if disconnected, where |W| < |V| - 1.
 ///
-/// Use `from_elements` to create a graph from the resulting iterator.
-///
 /// See also: [`min_spanning_tree`][1] for an implementation using Kruskal's algorithm and support for minimum spanning forest.
+///
+/// # Arguments
+/// * `g`: an undirected graph.
+///
+/// # Returns
+/// * [`MinSpanningTreePrim`]: an iterator producing a minimum spanning tree of a graph.
+///   Use `from_elements` to create a graph from the resulting iterator.
+///
+/// # Complexity
+/// * Time complexity: **O(|E| log |V|)**.
+/// * Space complexity: **O(|V| + |E|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// [1]: fn.min_spanning_tree.html
 ///

--- a/src/algo/min_spanning_tree.rs
+++ b/src/algo/min_spanning_tree.rs
@@ -33,7 +33,7 @@ use crate::visit::{IntoEdgeReferences, NodeIndexable};
 ///
 /// # Complexity
 /// * Time complexity: **O(|E| log |E|)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -205,7 +205,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|E| log |V|)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -252,8 +252,19 @@ where
 
 /// \[Generic\] Return `true` if the input directed graph contains a cycle.
 ///
-/// This implementation is recursive; use `toposort` if an alternative is
-/// needed.
+/// This implementation is recursive; use [`toposort`] if an alternative is needed.
+///
+/// # Arguments:
+/// `g`: a directed graph.
+///
+/// # Returns
+/// `bool`: `true` if the input graph contains a cycle and `false` otherwise.
+///
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn is_cyclic_directed<G>(g: G) -> bool
 where
     G: IntoNodeIdentifiers + IntoNeighbors + Visitable,

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -79,7 +79,7 @@ pub use johnson::parallel_johnson;
 ///   or number of *weakly* connected components if `g` is directed.
 ///
 /// # Complexity
-/// * Time complexity: **O(|E| + |V|log|V|)**.
+/// * Time complexity: amortized **O(|E| + |V|log|V|)**.
 /// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -333,8 +333,23 @@ where
 ///
 /// If `from` and `to` are equal, this function returns true.
 ///
-/// If `space` is not `None`, it is used instead of creating a new workspace for
-/// graph traversal.
+/// # Arguments:
+/// * `g`: an input graph.
+/// * `from`: the first node of a desired path.
+/// * `to`: the last node of a desired path.
+/// * `space`: optional [`DfsSpace`]. If `space` is not `None`,
+///   it is used instead of creating a new workspace for graph traversal.
+///
+/// # Returns
+/// * `true`: if there exists a path starting at `from` and reaching
+///   `to` or `from` and `to` are equal.
+/// * `false`: otherwise.
+///
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V|)** or **O(1)** if `space` was provided.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn has_path_connecting<G>(
     g: G,
     from: G::NodeId,

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -145,7 +145,8 @@ where
 /// `g`: an input graph that always treated as undirected.
 ///
 /// # Returns
-/// `bool`: `true` if the input graph contains a cycle and `false` otherwise.
+/// `true`: if the input graph contains a cycle.
+/// `false`: otherwise.
 ///
 /// # Complexity
 /// * Time complexity: amortized **O(|E|)**.
@@ -258,7 +259,8 @@ where
 /// `g`: a directed graph.
 ///
 /// # Returns
-/// `bool`: `true` if the input graph contains a cycle and `false` otherwise.
+/// `true`: if the input graph contains a cycle.
+/// `false`: otherwise.
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -70,6 +70,20 @@ pub use johnson::parallel_johnson;
 /// \[Generic\] Return the number of connected components of the graph.
 ///
 /// For a directed graph, this is the *weakly* connected components.
+///
+/// # Arguments
+/// * `g`: an input graph.
+///
+/// # Returns
+/// * `usize`: the number of connected components if `g` is undirected
+///   or number of *weakly* connected components if `g` is directed.
+///
+/// # Complexity
+/// * Time complexity: **O(|E| + |V|log|V|)**.
+/// * Space complexity: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
 /// # Example
 /// ```rust
 /// use petgraph::Graph;
@@ -126,6 +140,18 @@ where
 /// \[Generic\] Return `true` if the input graph contains a cycle.
 ///
 /// Always treats the input graph as if undirected.
+///
+/// # Arguments:
+/// `g`: an input graph that always treated as undirected.
+///
+/// # Returns
+/// `bool`: `true` if the input graph contains a cycle and `false` otherwise.
+///
+/// # Complexity
+/// * Time complexity: amortized **O(|E|)**.
+/// * Space complexity: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn is_cyclic_undirected<G>(g: G) -> bool
 where
     G: NodeIndexable + IntoEdgeReferences,

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -80,7 +80,7 @@ pub use johnson::parallel_johnson;
 ///
 /// # Complexity
 /// * Time complexity: **O(|E| + |V|log|V|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -150,7 +150,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: amortized **O(|E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn is_cyclic_undirected<G>(g: G) -> bool
@@ -191,7 +191,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn toposort<G>(
@@ -264,7 +264,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn is_cyclic_directed<G>(g: G) -> bool
@@ -349,7 +349,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V|)** or **O(1)** if `space` was provided.
+/// * Auxiliary space: **O(|V|)** or **O(1)** if `space` was provided.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn has_path_connecting<G>(
@@ -393,7 +393,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -607,7 +607,7 @@ impl<N> TarjanScc<N> {
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -637,7 +637,7 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -794,7 +794,7 @@ pub struct NegativeCycle(pub ());
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn is_bipartite_undirected<G, N, VM>(g: G, start: N) -> bool

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -774,11 +774,29 @@ impl<N> Cycle<N> {
 #[derive(Clone, Debug, PartialEq)]
 pub struct NegativeCycle(pub ());
 
-/// Return `true` if the graph is bipartite. A graph is bipartite if its nodes can be divided into
-/// two disjoint and indepedent sets U and V such that every edge connects U to one in V. This
-/// algorithm implements 2-coloring algorithm based on the BFS algorithm.
+/// Return `true` if the graph\* is bipartite.
 ///
+/// A graph is bipartite if its nodes can be divided into
+/// two disjoint and indepedent sets U and V such that every edge connects U to one in V.
+///
+/// This algorithm implements 2-coloring algorithm based on the BFS algorithm.
 /// Always treats the input graph as if undirected.
+///
+/// \* The algorithm checks only the subgraph that is reachable from the `start`.
+///
+/// # Arguments
+/// * `g`: an input graph.
+/// * `start`: some node of the graph.
+///
+/// # Returns
+/// * `true`: if the subgraph accessible from the start node is bipartite.
+/// * `false`: if such a subgraph is not bipartite.
+///
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn is_bipartite_undirected<G, N, VM>(g: G, start: N) -> bool
 where
     G: GraphRef + Visitable<NodeId = N, Map = VM> + IntoNeighbors<NodeId = N>,

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -379,15 +379,25 @@ where
 
 /// \[Generic\] Compute the *strongly connected components* using [Kosaraju's algorithm][1].
 ///
-/// [1]: https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
+/// This implementation is iterative and does two passes over the nodes.
 ///
+/// # Arguments
+/// * `g`: a directed or undirected graph.
+///
+/// # Returns
 /// Return a vector where each element is a strongly connected component (scc).
 /// The order of node ids within each scc is arbitrary, but the order of
 /// the sccs is their postorder (reverse topological sort).
 ///
 /// For an undirected graph, the sccs are simply the connected components.
 ///
-/// This implementation is iterative and does two passes over the nodes.
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
+/// [1]: https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm
 pub fn kosaraju_scc<G>(g: G) -> Vec<Vec<G::NodeId>>
 where
     G: IntoNeighborsDirected + Visitable + IntoNodeIdentifiers,
@@ -581,18 +591,28 @@ impl<N> TarjanScc<N> {
 
 /// \[Generic\] Compute the *strongly connected components* using [Tarjan's algorithm][1].
 ///
-/// [1]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
-/// [2]: https://homepages.ecs.vuw.ac.nz/~djp/files/P05.pdf
+/// This implementation is recursive and does one pass over the nodes. It is based on
+/// [A Space-Efficient Algorithm for Finding Strongly Connected Components][2] by David J. Pierce,
+/// to provide a memory-efficient implementation of [Tarjan's algorithm][1].
 ///
+/// # Arguments
+/// * `g`: a directed or undirected graph.
+///
+/// # Returns
 /// Return a vector where each element is a strongly connected component (scc).
 /// The order of node ids within each scc is arbitrary, but the order of
 /// the sccs is their postorder (reverse topological sort).
 ///
 /// For an undirected graph, the sccs are simply the connected components.
 ///
-/// This implementation is recursive and does one pass over the nodes. It is based on
-/// [A Space-Efficient Algorithm for Finding Strongly Connected Components][2] by David J. Pierce,
-/// to provide a memory-efficient implementation of [Tarjan's algorithm][1].
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
+/// [1]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+/// [2]: https://www.researchgate.net/publication/283024636_A_space-efficient_algorithm_for_finding_strongly_connected_components
 pub fn tarjan_scc<G>(g: G) -> Vec<Vec<G::NodeId>>
 where
     G: IntoNodeIdentifiers + IntoNeighbors + NodeIndexable,

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -171,15 +171,28 @@ where
 
 /// \[Generic\] Perform a topological sort of a directed graph.
 ///
-/// If the graph was acyclic, return a vector of nodes in topological order:
-/// each node is ordered before its successors.
-/// Otherwise, it will return a `Cycle` error. Self loops are also cycles.
+/// `toposort` returns `Err` on graphs with cycles.
+/// To handle graphs with cycles, use the one of scc algorithms or
+/// [`DfsPostOrder`](struct@crate::visit::DfsPostOrder)
+///   instead of this function.
 ///
-/// To handle graphs with cycles, use the scc algorithms or `DfsPostOrder`
-/// instead of this function.
+/// The implementation is iterative.
 ///
-/// If `space` is not `None`, it is used instead of creating a new workspace for
-/// graph traversal. The implementation is iterative.
+/// # Arguments
+/// * `g`: an acyclic directed graph.
+/// * `space`: optional [`DfsSpace`]. If `space` is not `None`,
+///   it is used instead of creating a new workspace for graph traversal.
+///
+/// # Returns
+/// * `Ok`: a vector of nodes in topological order: each node is ordered before its successors
+///   (if the graph was acyclic).
+/// * `Err`: [`Cycle`] if the graph was not acyclic. Self loops are also cycles this case.
+///
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn toposort<G>(
     g: G,
     space: Option<&mut DfsSpace<G::NodeId, G::Map>>,

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -627,9 +627,21 @@ where
 
 /// [Graph] Condense every strongly connected component into a single node and return the result.
 ///
-/// If `make_acyclic` is true, self-loops and multi edges are ignored, guaranteeing that
-/// the output is acyclic.
-/// # Example
+/// # Arguments
+/// * `g`: an input [`Graph`].
+/// * `make_acyclic`: if `true`, self-loops and multi edges are ignored, guaranteeing that
+///   the output is acyclic.
+///
+/// # Returns
+/// Returns a `Graph` with nodes `Vec<N>` representing strongly connected components.
+///
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V| + |E|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
+/// # Examples
 /// ```rust
 /// use petgraph::Graph;
 /// use petgraph::algo::condensation;

--- a/src/algo/page_rank.rs
+++ b/src/algo/page_rank.rs
@@ -22,8 +22,8 @@ use rayon::prelude::*;
 /// The damping factor should be a measure (like `f32` or `f64`) between 0 and 1 (0 and 1 included). Otherwise, it panics.
 ///
 /// # Complexity
-/// * Time complexity is **O(n|V|²|E|)**.
-/// * Space complexity is **O(|V| + |E|)**.
+/// * Time complexity: **O(n|V|²|E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **n** is the number of iterations, **|V|** the number of vertices (i.e nodes) and **|E|** the number of edges.
 ///

--- a/src/algo/page_rank.rs
+++ b/src/algo/page_rank.rs
@@ -10,14 +10,20 @@ use rayon::prelude::*;
 ///
 /// Computes the ranks of every node in a graph using the [Page Rank algorithm][pr].
 ///
-/// Returns a `Vec` container mapping each node index to its rank.
+/// # Arguments
+/// * `graph`: a directed graph.
+/// * `damping_factor`: a value in range `0.0 <= damping_factor <= 1.0`.
+/// * `nb_iter`: number of iterations of the main loop.
+///
+/// # Returns
+/// * A `Vec` mapping each node index to its rank.
 ///
 /// # Panics
-/// The damping factor should be a number of type `f32` or `f64` between 0 and 1 (0 and 1 included). Otherwise, it panics.
+/// The damping factor should be a measure (like `f32` or `f64`) between 0 and 1 (0 and 1 included). Otherwise, it panics.
 ///
 /// # Complexity
-/// - Time complexity is **O(n|V|²|E|)**.
-/// - Space complexity is **O(|V| + |E|)**.
+/// * Time complexity is **O(n|V|²|E|)**.
+/// * Space complexity is **O(|V| + |E|)**.
 ///
 /// where **n** is the number of iterations, **|V|** the number of vertices (i.e nodes) and **|E|** the number of edges.
 ///

--- a/src/algo/page_rank.rs
+++ b/src/algo/page_rank.rs
@@ -16,8 +16,8 @@ use rayon::prelude::*;
 /// The damping factor should be a number of type `f32` or `f64` between 0 and 1 (0 and 1 included). Otherwise, it panics.
 ///
 /// # Complexity
-/// - Time complexity is **O(n|V|²|E|)**,
-/// - Space complexity is **O(|V| + |E|)**,
+/// - Time complexity is **O(n|V|²|E|)**.
+/// - Space complexity is **O(|V| + |E|)**.
 ///
 /// where **n** is the number of iterations, **|V|** the number of vertices (i.e nodes) and **|E|** the number of edges.
 ///

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -11,10 +11,31 @@ use crate::{
     Direction::Outgoing,
 };
 
-/// Returns an iterator that produces all simple paths from `from` node to `to`, which contains at least `min_intermediate_nodes` nodes
-/// and at most `max_intermediate_nodes`, if given, or limited by the graph's order otherwise. The simple path is a path without repetitions.
+/// Calculate all simple paths with specified constraints from node `from` to node `to`.
 ///
-/// This algorithm is adapted from <https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.simple_paths.all_simple_paths.html>.
+/// The simple path is a path without repetitions.
+/// The number of simple paths between a given pair of vertices almost always grows exponentially,
+/// reaching `O(V!)` on a dense graphs at `V` vertices.
+///
+/// So if you have a large enough graph, be prepared to wait for the results for years.
+/// Or consider extracting only part of the simple paths using the adapter [`Iterator::take`].
+///
+/// This algorithm is adapted from [NetworkX](https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.simple_paths.all_simple_paths.html).
+/// # Arguments
+/// * `graph`: an input graph.
+/// * `from`: an initial node of desired paths.
+/// * `to`: a target node of desired paths.
+/// * `min_intermediate_nodes`: the minimum number of nodes in the desired paths.
+/// * `max_intermediate_nodes`: the maximum number of nodes in the desired paths (optional).
+/// # Returns
+/// Returns an iterator that produces all simple paths from `from` node to `to`, which contains at least `min_intermediate_nodes` nodes
+/// and at most `max_intermediate_nodes`, if given, or limited by the graph's order otherwise.
+///
+/// # Complexity
+/// * Time complexity: for computing first **k** paths, the running time will be **O(k|V| + k|E|)**.
+/// * Auxillary space: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// # Example
 /// ```
@@ -44,14 +65,6 @@ use crate::{
 /// assert_eq!(paths.len(), 2);
 ///
 /// ```
-///
-/// # Note
-///
-/// The number of simple paths between a given pair of vertices almost always grows exponentially,
-/// reaching `O(V!)` on a dense graphs at `V` vertices.
-///
-/// So if you have a large enough graph, be prepared to wait for the results for years.
-/// Or consider extracting only part of the simple paths using the adapter [`Iterator::take`].
 pub fn all_simple_paths<TargetColl, G, S>(
     graph: G,
     from: G::NodeId,

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -13,12 +13,13 @@ use crate::{
 
 /// Calculate all simple paths with specified constraints from node `from` to node `to`.
 ///
-/// The simple path is a path without repetitions.
-/// The number of simple paths between a given pair of vertices almost always grows exponentially,
-/// reaching `O(V!)` on a dense graphs at `V` vertices.
+/// A simple path is a path without repeating nodes.
+/// The number of simple paths between a given pair of vertices can grow exponentially,
+/// reaching `O(|V|!)` on complete graphs with `|V|` vertices.
 ///
-/// So if you have a large enough graph, be prepared to wait for the results for years.
+/// So if you have a large enough graph, be prepared to wait on the results for years.
 /// Or consider extracting only part of the simple paths using the adapter [`Iterator::take`].
+/// Also note, that this algorithm does not check that a path exists between `from` and `to`. This may lead to very long running times and it may be worth it to check if a path exists before running this algorithm on large graphs.
 ///
 /// This algorithm is adapted from [NetworkX](https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.simple_paths.all_simple_paths.html).
 /// # Arguments
@@ -32,7 +33,7 @@ use crate::{
 /// and at most `max_intermediate_nodes`, if given, or limited by the graph's order otherwise.
 ///
 /// # Complexity
-/// * Time complexity: for computing first **k** paths, the running time will be **O(k|V| + k|E|)**.
+/// * Time complexity: for computing the first **k** paths, the running time will be **O(k|V| + k|E|)**.
 /// * Auxillary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -24,7 +24,7 @@ use alloc::{vec, vec::Vec};
 ///
 /// ## Complexity
 /// * Time complexity: **O(|V||E|)**, but it's generally assumed that in the average case it is **O(|E|)**.
-/// * Space complexity: **O(|V|)**.
+/// * Auxiliary space: **O(|V|)**.
 ///
 /// |V| is the number of nodes, |E| is the number of edges in the input graph.
 ///

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -15,7 +15,7 @@ use alloc::{vec, vec::Vec};
 /// ## Arguments
 /// * `graph`: weighted graph.
 /// * `source`: the source vertex, for which we calculate the lengths of the shortest paths to all the others.
-/// * `edge_cost`: closure that returns cost of a particular edge.
+/// * `edge_cost`: closure that returns the cost of a particular edge.
 ///
 /// ## Returns
 /// * `Err`: if graph contains negative cycle.
@@ -26,7 +26,7 @@ use alloc::{vec, vec::Vec};
 /// * Time complexity: **O(|V||E|)**, but it's generally assumed that in the average case it is **O(|E|)**.
 /// * Auxiliary space: **O(|V|)**.
 ///
-/// |V| is the number of nodes, |E| is the number of edges in the input graph.
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 ///
 /// [spfa]: https://www.geeksforgeeks.org/shortest-path-faster-algorithm/

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -15,7 +15,7 @@ use alloc::{vec, vec::Vec};
 /// ## Arguments
 /// * `graph`: weighted graph.
 /// * `source`: the source vertex, for which we calculate the lengths of the shortest paths to all the others.
-/// * `edge_cost`: closure that returns cost of a particular edge
+/// * `edge_cost`: closure that returns cost of a particular edge.
 ///
 /// ## Returns
 /// * `Err`: if graph contains negative cycle.
@@ -23,8 +23,8 @@ use alloc::{vec, vec::Vec};
 ///   of predecessors of each vertex along the shortest path.
 ///
 /// ## Complexity
-/// * Time complexity: **O(|V||E|)**, but it's generally assumed that in the average case it is **O(|E|)**
-/// * Space complexity: **O(|V|)**
+/// * Time complexity: **O(|V||E|)**, but it's generally assumed that in the average case it is **O(|E|)**.
+/// * Space complexity: **O(|V|)**.
 ///
 /// |V| is the number of nodes, |E| is the number of edges in the input graph.
 ///

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -22,6 +22,13 @@ use alloc::{vec, vec::Vec};
 /// * `Ok`: a pair of a vector of shortest distances and a vector
 ///   of predecessors of each vertex along the shortest path.
 ///
+/// ## Complexity
+/// * Time complexity: **O(|V||E|)**, but it's generally assumed that in the average case it is **O(|E|)**
+/// * Space complexity: **O(|V|)**
+///
+/// |V| is the number of nodes, |E| is the number of edges in the input graph.
+///
+///
 /// [spfa]: https://www.geeksforgeeks.org/shortest-path-faster-algorithm/
 ///
 /// # Example

--- a/src/algo/steiner_tree.rs
+++ b/src/algo/steiner_tree.rs
@@ -140,7 +140,7 @@ where
 /// A `StableGraph` containing the nodes and edges of the Steiner tree.
 ///
 /// ## Complexity
-/// Time complexity is **O(|S| |V|²)**,
+/// Time complexity: **O(|S| |V|²)**.
 /// where **|V|** the number of vertices (i.e nodes) and **|S|** the number of provided terminals.
 ///
 /// [1]: https://en.wikipedia.org/wiki/Steiner_tree_problem

--- a/src/algo/steiner_tree.rs
+++ b/src/algo/steiner_tree.rs
@@ -140,7 +140,7 @@ where
 /// A `StableGraph` containing the nodes and edges of the Steiner tree.
 ///
 /// ## Complexity
-/// Time complexity is **O(|S| |V|²)**.
+/// Time complexity is **O(|S| |V|²)**,
 /// where **|V|** the number of vertices (i.e nodes) and **|S|** the number of provided terminals.
 ///
 /// [1]: https://en.wikipedia.org/wiki/Steiner_tree_problem

--- a/src/algo/tred.rs
+++ b/src/algo/tred.rs
@@ -37,7 +37,7 @@ use crate::Direction;
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + |E|)**.
-/// * Space complexity: **O(|V| + |E|)**.
+/// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
@@ -111,7 +111,7 @@ where
 ///   denotes the outgoing degree of **y** in the transitive closure of **G**.
 ///   This is still **O(|V|³)** in the worst case like the naive algorithm but
 ///   should perform better for some classes of graphs.
-/// * Space complexity: **O(|E|)**.
+/// * Auxiliary space: **O(|E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn dag_transitive_reduction_closure<E, Ix: IndexType>(

--- a/src/algo/tred.rs
+++ b/src/algo/tred.rs
@@ -21,12 +21,12 @@ use crate::Direction;
 
 /// Creates a representation of the same graph respecting topological order for use in `tred::dag_transitive_reduction_closure`.
 ///
-/// `toposort` must be a topological order on the node indices of `g` (for example obtained
-/// from [`toposort`]).
+/// # Arguments
+/// * `g`: a directed acyclic graph.
+/// * `toposort`: a topological order on the node indices of `g` (for example obtained from [`toposort`](fn@crate::algo::toposort)).
 ///
-/// [`toposort`]: ../fn.toposort.html
-///
-/// Returns a pair of a graph `res` and the reciprocal of the topological sort `revmap`.
+/// # Returns
+/// Returns a pair of a graph `res` represented with [`UnweightedList`](type@crate::adj::UnweightedList) and the reciprocal of the topological sort `revmap`:
 ///
 /// `res` is the same graph as `g` with the following differences:
 /// * Node and edge weights are stripped,
@@ -34,7 +34,16 @@ use crate::Direction;
 /// * Iterating on the neighbors of a node respects topological order.
 ///
 /// `revmap` is handy to get back to map indices in `g` to indices in `res`.
-/// ```
+///
+/// # Complexity
+/// * Time complexity: **O(|V| + |E|)**.
+/// * Space complexity: **O(|V| + |E|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
+///
+/// # Example
+///
+/// ```rust
 /// use petgraph::prelude::*;
 /// use petgraph::graph::DefaultIx;
 /// use petgraph::visit::IntoNeighbors;
@@ -57,10 +66,6 @@ use crate::Direction;
 ///     .collect();
 /// assert_eq!(children, vec![first, second])
 /// ```
-///
-/// Runtime: **O(|V| + |E|)**.
-///
-/// Space complexity: **O(|V| + |E|)**.
 pub fn dag_to_toposorted_adjacency_list<G, Ix: IndexType>(
     g: G,
     toposort: &[G::NodeId],
@@ -93,23 +98,22 @@ where
 /// orders](https://www.sciencedirect.com/science/article/pii/0012365X9390164O) by Habib, Morvan
 /// and Rampon.
 ///
-/// The input graph must be in a very specific format: an adjacency
-/// list such that:
-/// * Node indices are a toposort, and
-/// * The neighbors of all nodes are stored in topological order.
+/// # Arguments
+/// * `g`: an input graph in a very specific format: an adjacency
+///   list such that node indices are a toposort, and the neighbors of all nodes are stored in topological order.
+///   To get such a representation, use the function [`dag_to_toposorted_adjacency_list`].
 ///
-/// To get such a representation, use the function [`dag_to_toposorted_adjacency_list`].
-///
-/// [`dag_to_toposorted_adjacency_list`]: ./fn.dag_to_toposorted_adjacency_list.html
-///
+/// # Returns
 /// The output is the pair of the transitive reduction and the transitive closure.
 ///
-/// Runtime complexity: **O(|V| + \sum_{(x, y) \in Er} d(y))** where **d(y)**
-/// denotes the outgoing degree of **y** in the transitive closure of **G**.
-/// This is still **O(|V|³)** in the worst case like the naive algorithm but
-/// should perform better for some classes of graphs.
+/// # Complexity
+/// * Time complexity: **O(|V| + \sum_{(x, y) \in Er} d(y))** where **d(y)**
+///   denotes the outgoing degree of **y** in the transitive closure of **G**.
+///   This is still **O(|V|³)** in the worst case like the naive algorithm but
+///   should perform better for some classes of graphs.
+/// * Space complexity: **O(|E|)**.
 ///
-/// Space complexity: **O(|E|)**.
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 pub fn dag_transitive_reduction_closure<E, Ix: IndexType>(
     g: &List<E, Ix>,
 ) -> (UnweightedList<Ix>, UnweightedList<Ix>) {

--- a/src/algo/tred.rs
+++ b/src/algo/tred.rs
@@ -26,7 +26,9 @@ use crate::Direction;
 /// * `toposort`: a topological order on the node indices of `g` (for example obtained from [`toposort`](fn@crate::algo::toposort)).
 ///
 /// # Returns
-/// Returns a pair of a graph `res` represented with [`UnweightedList`](type@crate::adj::UnweightedList) and the reciprocal of the topological sort `revmap`:
+/// Returns a tuple of:
+/// * [`UnweightedList`](type@crate::adj::UnweightedList) `res` graph.
+/// * `Vec`: reciprocal of the topological sort `revmap`.
 ///
 /// `res` is the same graph as `g` with the following differences:
 /// * Node and edge weights are stripped,
@@ -108,7 +110,8 @@ where
 ///
 /// # Complexity
 /// * Time complexity: **O(|V| + \sum_{(x, y) \in Er} d(y))** where **d(y)**
-///   denotes the outgoing degree of **y** in the transitive closure of **G**.
+///   denotes the outgoing degree of **y** in the transitive closure of **G**
+///   and **Er** the edge set of the transitive reduction.
 ///   This is still **O(|V|³)** in the worst case like the naive algorithm but
 ///   should perform better for some classes of graphs.
 /// * Auxiliary space: **O(|E|)**.


### PR DESCRIPTION
This PR aims to bring uniformity to the documentation of algorithms.

Now the doc comments will have the following structure:

```markdown
Main description...
...
...

# Arguments
...

# Returns
...

# Complexity
* Time complexity: ...
* Space complexity: ...

# Examples

```

For example, the `spfa` doc comment might look like:
```markdown
/// \[Generic\] Compute shortest paths from node `source` to all other.
///
/// Using the [Shortest Path Faster Algorithm][spfa].
/// Compute shortest distances from node `source` to all other.
///
/// Compute shortest paths lengths in a weighted graph with positive or negative edge weights,
/// but with no negative cycles.
///
/// ## Arguments
/// * `graph`: weighted graph.
/// * `source`: the source vertex, for which we calculate the lengths of the shortest paths to all the others.
/// * `edge_cost`: closure that returns cost of a particular edge
///
/// ## Returns
/// * `Err`: if graph contains negative cycle.
/// * `Ok`: a pair of a vector of shortest distances and a vector
///   of predecessors of each vertex along the shortest path.
///
/// ## Complexity
/// * Time complexity: **O(|V||E|)**, but it's generally assumed that in the average case it is **O(|E|)**
/// * Space complexity: **O(|V|)**
///
/// |V| is the number of nodes, |E| is the number of edges in the input graph.
///
///
/// [spfa]: https://www.geeksforgeeks.org/shortest-path-faster-algorithm/
///
/// # Example
```