### PR TITLE
perf: Reuse queue allocation in `maximum_matching` main loop

### DIFF
--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -373,6 +373,10 @@ where
     let mut first_inner = vec![usize::MAX; len];
     let visited = &mut graph.visit_map();
 
+    // Queue will contain outer vertices that should be processed next.
+    // The queue is cleared after each iteration of the main loop.
+    let mut queue = VecDeque::new();
+
     for start in 0..graph.node_bound() {
         if mate[start].is_some() {
             // The vertex is already matched. A start must be a free vertex.
@@ -387,9 +391,7 @@ where
         // start is never a dummy index
         let start = graph.from_index(start);
 
-        // Queue will contain outer vertices that should be processed next. The
-        // start vertex is considered an outer vertex.
-        let mut queue = VecDeque::new();
+        // The start vertex is considered a first outer vertex on each iteration.
         queue.push_back(start);
         // Mark the start vertex so it is not processed repeatedly.
         visited.visit(start);
@@ -465,6 +467,8 @@ where
         for lbl in label.iter_mut() {
             *lbl = Label::None;
         }
+
+        queue.clear();
     }
 
     // Discard the dummy node.


### PR DESCRIPTION
A minor change that reduces the number of allocations in `maximum_matching` main loop and slightly improves performance.

Before:
```
test maximum_matching_bigger    ... bench:       1,044.74 ns/iter (+/- 8.21)
test maximum_matching_bipartite ... bench:         250.49 ns/iter (+/- 4.48)
test maximum_matching_full      ... bench:         129.69 ns/iter (+/- 1.10)
test maximum_matching_huge      ... bench:     847,857.70 ns/iter (+/- 25,993.22)
```

After:
```
test maximum_matching_bigger    ... bench:         984.27 ns/iter (+/- 31.05)
test maximum_matching_bipartite ... bench:         235.41 ns/iter (+/- 4.40)
test maximum_matching_full      ... bench:         130.42 ns/iter (+/- 1.04)
test maximum_matching_huge      ... bench:     798,815.20 ns/iter (+/- 12,723.48)
```