### PR TITLE
test: Add dependency list for 'quickcheck' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0", default-features = false, optional = true }
 rayon = { version = "1.5.3", optional = true }
-dot-parser = { version = "0.5.1", optional = true}
+dot-parser = { version = "0.5.1", optional = true }
 dot-parser-macros = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
@@ -80,6 +80,7 @@ generate = [] # For unstable features
 
 graphmap = []
 matrix_graph = []
+quickcheck = ["std", "dep:quickcheck", "graphmap", "stable_graph"]
 serde-1 = ["serde", "serde_derive"]
 stable_graph = ["serde?/alloc"]
 unstable = ["generate"]


### PR DESCRIPTION
Currently it seems to be impossible to run the following test setup due to missing dependency declarations:
```
cargo test --no-default-features --features 'quickcheck'
```
This was first observed in #331.

Running the above fails due to multiple reasons which boil down to other features being disabled which are actually necessary.

This PR aims to fix that by declaring a dependency list for the quickcheck feature and is a revamp of #372. Thus, this resolves #331.

I am not 100% certain about the `std` dependency in the quickcheck dependency list, but without that dependency there seem to be some issues with missing RandomStates (std) to initialize certain structs in quickchecks. Since furthermore Quickcheck does not have `no-std`, it would - according to my understanding - include std anyways.  
