### PR TITLE
docs: Add link to multigraph definition to isomorphism algos

### DIFF
--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -808,12 +808,14 @@ mod matching {
 /// Using the VF2 algorithm, only matching graph syntactically (graph
 /// structure).
 ///
-/// The graphs should not be multigraphs.
+/// The graphs should not be [multigraphs].
 ///
 /// **Reference**
 ///
 /// * Luigi P. Cordella, Pasquale Foggia, Carlo Sansone, Mario Vento;
 ///   *A (Sub)Graph Isomorphism Algorithm for Matching Large Graphs*
+///
+/// [multigraphs]: https://en.wikipedia.org/wiki/Multigraph
 pub fn is_isomorphic<G0, G1>(g0: G0, g1: G1) -> bool
 where
     G0: NodeCompactIndexable + EdgeCount + GetAdjacencyMatrix + GraphProp + IntoNeighborsDirected,
@@ -837,7 +839,9 @@ where
 /// Using the VF2 algorithm, examining both syntactic and semantic
 /// graph isomorphism (graph structure and matching node and edge weights).
 ///
-/// The graphs should not be multigraphs.
+/// The graphs should not be [multigraphs].
+///
+/// [multigraphs]: https://en.wikipedia.org/wiki/Multigraph
 pub fn is_isomorphic_matching<G0, G1, NM, EM>(
     g0: G0,
     g1: G1,
@@ -873,11 +877,11 @@ where
 /// Using the VF2 algorithm, only matching graph syntactically (graph
 /// structure).
 ///
-/// The graphs should not be multigraphs.
+/// The graphs should not be [multigraphs].
 ///
 /// # Subgraph isomorphism
 ///
-/// (adapted from [`networkx` documentation](https://networkx.github.io/documentation/stable/reference/algorithms/isomorphism.vf2.html))
+/// (adapted from [`networkx` documentation][networkx_vf2])
 ///
 /// Graph theory literature can be ambiguous about the meaning of the above statement,
 /// and we seek to clarify it now.
@@ -901,6 +905,9 @@ where
 ///
 /// * Luigi P. Cordella, Pasquale Foggia, Carlo Sansone, Mario Vento;
 ///   *A (Sub)Graph Isomorphism Algorithm for Matching Large Graphs*
+///
+/// [networkx_vf2]: https://networkx.github.io/documentation/stable/reference/algorithms/isomorphism.vf2.html
+/// [multigraphs]: https://en.wikipedia.org/wiki/Multigraph
 pub fn is_isomorphic_subgraph<G0, G1>(g0: G0, g1: G1) -> bool
 where
     G0: NodeCompactIndexable + EdgeCount + GetAdjacencyMatrix + GraphProp + IntoNeighborsDirected,
@@ -924,7 +931,9 @@ where
 /// Using the VF2 algorithm, examining both syntactic and semantic
 /// graph isomorphism (graph structure and matching node and edge weights).
 ///
-/// The graphs should not be multigraphs.
+/// The graphs should not be [multigraphs].
+///
+/// [multigraphs]: https://en.wikipedia.org/wiki/Multigraph
 pub fn is_isomorphic_subgraph_matching<G0, G1, NM, EM>(
     g0: G0,
     g1: G1,
@@ -960,7 +969,9 @@ where
 /// if `g0` is isomorphic to a subgraph of `g1`, return the mappings between
 /// them.
 ///
-/// The graphs should not be multigraphs.
+/// The graphs should not be [multigraphs].
+///
+/// [multigraphs]: https://en.wikipedia.org/wiki/Multigraph
 pub fn subgraph_isomorphisms_iter<'a, G0, G1, NM, EM>(
     g0: &'a G0,
     g1: &'a G1,


### PR DESCRIPTION
This resolves #600.

There seems to have been some confusion on what the term Multigraph refers to. This should clear up the issue. The further discussion in the issue seems to be somewhat chaotic due to the missing definition of multigraph and possibly mixing it up with disconnected graphs.

To address this issue, I added links to definitions of multigraphs to the respective docstrings.

Once new PR / Issue templates are in place (#811), I will create an issue that isomorphism functionality should support multigraphs.