### PR TITLE
refactor: Remove unnecessary trait bounds from impls/methods

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -407,10 +407,11 @@ pub type DiGraph<N, E, Ix = DefaultIx> = Graph<N, E, Directed, Ix>;
 pub type UnGraph<N, E, Ix = DefaultIx> = Graph<N, E, Undirected, Ix>;
 
 /// The resulting cloned graph has the same graph indices as `self`.
-impl<N, E, Ty, Ix: IndexType> Clone for Graph<N, E, Ty, Ix>
+impl<N, E, Ty, Ix> Clone for Graph<N, E, Ty, Ix>
 where
     N: Clone,
     E: Clone,
+    Ix: Copy,
 {
     fn clone(&self) -> Self {
         Graph {
@@ -524,11 +525,7 @@ impl<N, E> Graph<N, E, Undirected> {
     }
 }
 
-impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
+impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix> {
     /// Create a new `Graph` with estimated capacity.
     pub fn with_capacity(nodes: usize, edges: usize) -> Self {
         Graph {
@@ -537,7 +534,13 @@ where
             ty: PhantomData,
         }
     }
+}
 
+impl<N, E, Ty, Ix> Graph<N, E, Ty, Ix>
+where
+    Ty: EdgeType,
+    Ix: IndexType,
+{
     /// Return the number of nodes (also called vertices) in the graph.
     ///
     /// Computes in **O(1)** time.
@@ -2020,11 +2023,7 @@ where
 }
 
 /// Create a new empty `Graph`.
-impl<N, E, Ty, Ix> Default for Graph<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
+impl<N, E, Ty, Ix> Default for Graph<N, E, Ty, Ix> {
     fn default() -> Self {
         Self::with_capacity(0, 0)
     }

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -218,7 +218,6 @@ impl<N, E> StableGraph<N, E, Directed> {
 
 impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
 where
-    Ty: EdgeType,
     Ix: IndexType,
 {
     /// Create a new `StableGraph` with estimated capacity.
@@ -231,7 +230,13 @@ where
             free_edge: EdgeIndex::end(),
         }
     }
+}
 
+impl<N, E, Ty, Ix> StableGraph<N, E, Ty, Ix>
+where
+    Ty: EdgeType,
+    Ix: IndexType,
+{
     /// Return the current node and edge capacity of the graph.
     pub fn capacity(&self) -> (usize, usize) {
         self.g.capacity()
@@ -1327,10 +1332,11 @@ where
 }
 
 /// The resulting cloned graph has the same graph indices as `self`.
-impl<N, E, Ty, Ix: IndexType> Clone for StableGraph<N, E, Ty, Ix>
+impl<N, E, Ty, Ix> Clone for StableGraph<N, E, Ty, Ix>
 where
     N: Clone,
     E: Clone,
+    Ix: Copy,
 {
     fn clone(&self) -> Self {
         StableGraph {
@@ -1408,7 +1414,6 @@ where
 /// Create a new empty `StableGraph`.
 impl<N, E, Ty, Ix> Default for StableGraph<N, E, Ty, Ix>
 where
-    Ty: EdgeType,
     Ix: IndexType,
 {
     fn default() -> Self {

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -190,8 +190,6 @@ where
 
 impl<N, E, Ty, S> GraphMap<N, E, Ty, S>
 where
-    N: NodeTrait,
-    Ty: EdgeType,
     S: BuildHasher,
 {
     /// Create a new `GraphMap`
@@ -225,7 +223,14 @@ where
             ty: PhantomData,
         }
     }
+}
 
+impl<N, E, Ty, S> GraphMap<N, E, Ty, S>
+where
+    N: NodeTrait,
+    Ty: EdgeType,
+    S: BuildHasher,
+{
     /// Return the current node and edge capacity of the graph.
     pub fn capacity(&self) -> (usize, usize) {
         (self.nodes.capacity(), self.edges.capacity())
@@ -1009,8 +1014,6 @@ where
 /// Create a new empty `GraphMap`.
 impl<N, E, Ty, S> Default for GraphMap<N, E, Ty, S>
 where
-    N: NodeTrait,
-    Ty: EdgeType,
     S: BuildHasher + Default,
 {
     fn default() -> Self {


### PR DESCRIPTION
The goal of this PR is to make the following scenario possible:

```rust
#[derive(Default, Clone)]
struct DummyWrapper<Node, Edge, Ix> {
    graph: StableDiGraph<Node, Edge, Ix>,
}
```

… which currently requires a manual implementation of both, `Default` and `Clone`:

```rust
struct DummyWrapper<Node, Edge, Ix> {
    graph: StableDiGraph<Node, Edge, Ix>,
}

impl<Node, Edge, Ix> Clone for DummyWrapper<Node, Edge, Ix>
where
    Node: Clone,
    Edge: Clone,
    Ix: Clone,
{
    fn clone(&self) -> Self {
        Self {
            graph: self.graph.clone(),
        }
    }
}

impl<Node, Edge, Ix> Default for DummyWrapper<Node, Edge, Ix>
where
    Node: Default,
    Edge: Default,
    Ix: Default,
{
    fn default() -> Self {
        Self {
            graph: Default::default(),
        }
    }
}
```

… due to the following trait bounds getting in the way of the derives:

```
error[E0277]: the trait bound `Ix: petgraph::adj::IndexType` is not satisfied
 --> web-api/crates/interactive-graph/src/lib.rs:3:5
  |
1 | #[derive(Default, Clone)]
  |          ------- in this derive macro expansion
2 | struct DummyWrapper<Node, Edge, Ix> {
3 |     graph: StableDiGraph<Node, Edge, Ix>,
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `petgraph::adj::IndexType` is not implemented for `Ix`

error[E0277]: the trait bound `Ix: petgraph::adj::IndexType` is not satisfied
 --> web-api/crates/interactive-graph/src/lib.rs:3:5
  |
1 | #[derive(Default, Clone)]
  |                   ----- in this derive macro expansion
2 | struct DummyWrapper<Node, Edge, Ix> {
3 |     graph: StableDiGraph<Node, Edge, Ix>,
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `petgraph::adj::IndexType` is not implemented for `Ix`
```

With this PR's changes the initial scenario compiles as is, using derives.