### PR TITLE
docs: Fix Typo in Operator Module Documentation

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1,4 +1,4 @@
-//! Operators for creating new graphs from existings ones.
+//! Operators for creating new graphs from existing ones.
 use super::graph::{Graph, IndexType};
 use super::EdgeType;
 use crate::visit::IntoNodeReferences;


### PR DESCRIPTION


**Description:**  
Corrected a minor typo in the documentation comment of `operator.rs`, changing "existings" to "existing" for improved clarity and professionalism.