### PR TITLE
docs: Sync the crate feature flags in the README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,22 +84,29 @@ fn main() {
 
 petgraph is built with these features enabled by default:
 
-- `graphmap` enable [`GraphMap`][docsrs-graph-map].
-- `stable_graph` enable [`StableGraph`][docsrs-stable-graph].
-- `matrix_graph` enable [`MatrixGraph`][docsrs-matrix-graph].
+- `graphmap` - Enables [`GraphMap`][docsrs-graph-map].
+- `stable_graph` - Enables [`StableGraph`][docsrs-stable-graph].
+- `matrix_graph` - Enables [`MatrixGraph`][docsrs-matrix-graph].
+- `std` - Enables the Rust Standard Library.
+  Disabling the `std` feature makes it possible to use `petgraph`
+  in `no_std` contexts.
 
 Optionally, the following features can be enabled:
 
-- `serde-1` enable serialization for
+- `serde-1` - Enables serialization for
   `Graph, StableGraph, GraphMap`
   using [serde 1.0][docsrs-serde]. Requires Rust version as required
   by serde.
-- `rayon` enable parallel iterators for the underlying data
+- `rayon` - Enables parallel iterators for the underlying data
   in `GraphMap`. Requires Rust version as required
   by [rayon][docsrs-rayon].
-- `dot_parser` enable parsing graph
+- `dot_parser` - Enables parsing graph
   from [DOT/Graphviz][dot-url]
   strings and files.
+- `generate` - Enables graph generators.
+- `unstable` - Enables unstable crate features (currently only
+  `generate`). The API of functionality behind this flag is subject to
+  change at any time.
 
 ## Getting Help
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,27 +436,32 @@ println!("Enhanced DOT format:\n{:?}", fancy_dot);
 
 # Crate features
 
+`petgraph` is built with these features enabled by default:
+
+* **graphmap** -
+  Enables [`GraphMap`](./graphmap/struct.GraphMap.html).
+* **stable_graph** -
+  Enables [`StableGraph`](./stable_graph/struct.StableGraph.html).
+* **matrix_graph** -
+  Enables [`MatrixGraph`](./matrix_graph/struct.MatrixGraph.html).
+* **std** -
+  Enables the Rust Standard Library. Disabling the `std` feature makes it possible to use `petgraph` in `no_std` contexts.
+
+Optionally, the following features can be enabled:
+
 * **serde-1** -
-  Defaults off. Enables serialization for ``Graph, StableGraph, GraphMap`` using
+  Enables serialization for ``Graph, StableGraph, GraphMap`` using
   [`serde 1.0`](https://crates.io/crates/serde). May require a more recent version
   of Rust than petgraph alone.
-* **graphmap** -
-  Defaults on. Enables [`GraphMap`](./graphmap/struct.GraphMap.html).
-* **stable_graph** -
-  Defaults on. Enables [`StableGraph`](./stable_graph/struct.StableGraph.html).
-* **matrix_graph** -
-  Defaults on. Enables [`MatrixGraph`](./matrix_graph/struct.MatrixGraph.html).
 * **rayon** -
-  Defaults off. Enables parallel versions of iterators and algorithms using
+  Enables parallel versions of iterators and algorithms using
   [`rayon`](https://docs.rs/rayon/latest/rayon/) crate. Requires the `std` feature.
-* **std** -
-  Defaults on. Enables the Rust Standard Library. Disabling the `std` feature makes it possible to use `petgraph` in `no_std` contexts.
-* **generate** -
-  Defaults off. Enables graph generators.
-* **unstable** -
-  Defaults off. Enables unstable crate features (currently only `generate`).
 * **dot_parser** -
-  Defaults off. Enables building [`Graph`](./graph/struct.Graph.html) and [`StableGraph`](./stable_graph/struct.StableGraph.html) from [DOT/Graphviz](https://www.graphviz.org/doc/info/lang.html) descriptions. Imports can be made statically or dynamically (i.e. at compile time or at runtime).
+  Enables building [`Graph`](./graph/struct.Graph.html) and [`StableGraph`](./stable_graph/struct.StableGraph.html) from [DOT/Graphviz](https://www.graphviz.org/doc/info/lang.html) descriptions. Imports can be made statically or dynamically (i.e. at compile time or at runtime).
+* **unstable** -
+  Enables unstable crate features (currently only [`generate`](./)).
+* **generate** -
+  Enables graph generators. The API of functionality behind this flag is subject to change at any time.
 */
 #![doc(html_root_url = "https://docs.rs/petgraph/0.4/")]
 #![no_std]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,7 @@ Optionally, the following features can be enabled:
 * **dot_parser** -
   Enables building [`Graph`](./graph/struct.Graph.html) and [`StableGraph`](./stable_graph/struct.StableGraph.html) from [DOT/Graphviz](https://www.graphviz.org/doc/info/lang.html) descriptions. Imports can be made statically or dynamically (i.e. at compile time or at runtime).
 * **unstable** -
-  Enables unstable crate features (currently only [`generate`](./)).
+  Enables unstable crate features (currently only `generate`).
 * **generate** -
   Enables graph generators. The API of functionality behind this flag is subject to change at any time.
 */


### PR DESCRIPTION
This PR resolves https://github.com/petgraph/petgraph/issues/766.

With the [new docs and README](https://github.com/petgraph/petgraph/pull/807), using cargo readme as suggested in the issue seems unsuited, since the templating does not support including parts of the lib docs in the README.