### PR TITLE
docs: Remove all \[Generic\] tags from algo docstrings

### DIFF
--- a/src/algo/articulation_points.rs
+++ b/src/algo/articulation_points.rs
@@ -7,7 +7,7 @@ use hashbrown::{HashMap, HashSet};
 use crate::visit;
 use crate::visit::{EdgeRef, IntoEdges, IntoNodeReferences, NodeIndexable, NodeRef};
 
-/// \[Generic\] Find articulation points in a graph using [Tarjan's algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm).
+/// Find articulation points in a graph using [Tarjan's algorithm](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm).
 ///
 /// Compute the articulation points of a graph (Nodes, which would increase the number of connected components in the graph.
 ///

--- a/src/algo/astar.rs
+++ b/src/algo/astar.rs
@@ -10,7 +10,7 @@ use crate::algo::Measure;
 use crate::scored::MinScored;
 use crate::visit::{EdgeRef, GraphBase, IntoEdges, Visitable};
 
-/// \[Generic\] A* shortest path algorithm.
+/// A* shortest path algorithm.
 ///
 /// Computes the shortest path from `start` to `finish`, including the total path cost.
 ///

--- a/src/algo/bellman_ford.rs
+++ b/src/algo/bellman_ford.rs
@@ -14,7 +14,7 @@ pub struct Paths<NodeId, EdgeWeight> {
     pub predecessors: Vec<Option<NodeId>>,
 }
 
-/// \[Generic\] Compute shortest paths from node `source` to all other.
+/// Compute shortest paths from node `source` to all other.
 ///
 /// Using the [Bellman–Ford algorithm][bf]; negative edge costs are
 /// permitted, but the graph must not have a cycle of negative weights
@@ -121,7 +121,7 @@ where
     })
 }
 
-/// \[Generic\] Find the path of a negative cycle reachable from node `source`.
+/// Find the path of a negative cycle reachable from node `source`.
 ///
 /// Using the [find_negative_cycle][nc]; will search the graph for negative cycles using
 /// [Bellman–Ford algorithm][bf]. If no negative cycle is found the function will return `None`.

--- a/src/algo/coloring.rs
+++ b/src/algo/coloring.rs
@@ -6,7 +6,7 @@ use hashbrown::{HashMap, HashSet};
 use crate::scored::MaxScored;
 use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable, VisitMap, Visitable};
 
-/// \[Generic\] [DStatur algorithm][1] to properly color a non weighted undirected graph.
+/// [DStatur algorithm][1] to properly color a non weighted undirected graph.
 ///
 ///
 /// This is a heuristic. So, it does not necessarily return a minimum coloring.

--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -10,7 +10,7 @@ use crate::algo::Measure;
 use crate::scored::MinScored;
 use crate::visit::{EdgeRef, IntoEdges, VisitMap, Visitable};
 
-/// \[Generic\] Dijkstra's shortest path algorithm.
+/// Dijkstra's shortest path algorithm.
 ///
 /// Compute the length of the shortest path from `start` to every reachable
 /// node.

--- a/src/algo/feedback_arc_set.rs
+++ b/src/algo/feedback_arc_set.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use self::linked_list::{LinkedList, LinkedListEntry};
 
-/// \[Generic\] Finds a [feedback arc set]: a set of edges in the given directed graph, which when
+/// Finds a [feedback arc set]: a set of edges in the given directed graph, which when
 /// removed, make the graph acyclic.
 ///
 /// Uses a [greedy heuristic algorithm] to select a small number of edges, but does not necessarily

--- a/src/algo/floyd_warshall.rs
+++ b/src/algo/floyd_warshall.rs
@@ -9,7 +9,7 @@ use crate::visit::{
 };
 
 #[allow(clippy::type_complexity, clippy::needless_range_loop)]
-/// \[Generic\] [Floyd–Warshall algorithm](https://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm) is an algorithm for all pairs shortest path problem
+/// [Floyd–Warshall algorithm](https://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm) is an algorithm for all pairs shortest path problem
 ///
 /// Compute the length of each shortest path in a weighted graph with positive or negative edge weights (but with no negative cycles).
 ///
@@ -120,7 +120,7 @@ where
 }
 
 #[allow(clippy::type_complexity, clippy::needless_range_loop)]
-/// \[Generic\] [Floyd–Warshall algorithm](https://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm) is an algorithm for all pairs shortest path problem
+/// [Floyd–Warshall algorithm](https://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm) is an algorithm for all pairs shortest path problem
 ///
 /// Compute all pairs shortest paths in a weighted graph with positive or negative edge weights (but with no negative cycles).
 /// Returns HashMap of shortest path lengths. Additionally, returns HashMap of intermediate nodes along shortest path for indicated edges.

--- a/src/algo/ford_fulkerson.rs
+++ b/src/algo/ford_fulkerson.rs
@@ -109,7 +109,7 @@ where
     }
 }
 
-/// \[Generic\] [Ford-Fulkerson][ff] algorithm in the [Edmonds-Karp][ek] variation.
+/// [Ford-Fulkerson][ff] algorithm in the [Edmonds-Karp][ek] variation.
 ///
 /// Computes the [maximum flow] from `source` to `destination` in a weighted directed graph.
 ///

--- a/src/algo/isomorphism.rs
+++ b/src/algo/isomorphism.rs
@@ -803,7 +803,7 @@ mod matching {
     }
 }
 
-/// \[Generic\] Return `true` if the graphs `g0` and `g1` are isomorphic.
+/// Return `true` if the graphs `g0` and `g1` are isomorphic.
 ///
 /// Using the VF2 algorithm, only matching graph syntactically (graph
 /// structure).
@@ -834,7 +834,7 @@ where
         .unwrap_or(false)
 }
 
-/// \[Generic\] Return `true` if the graphs `g0` and `g1` are isomorphic.
+/// Return `true` if the graphs `g0` and `g1` are isomorphic.
 ///
 /// Using the VF2 algorithm, examining both syntactic and semantic
 /// graph isomorphism (graph structure and matching node and edge weights).
@@ -872,7 +872,7 @@ where
     self::matching::try_match(&mut st, &mut node_match, &mut edge_match, false).unwrap_or(false)
 }
 
-/// \[Generic\] Return `true` if `g0` is isomorphic to a subgraph of `g1`.
+/// Return `true` if `g0` is isomorphic to a subgraph of `g1`.
 ///
 /// Using the VF2 algorithm, only matching graph syntactically (graph
 /// structure).
@@ -926,7 +926,7 @@ where
         .unwrap_or(false)
 }
 
-/// \[Generic\] Return `true` if `g0` is isomorphic to a subgraph of `g1`.
+/// Return `true` if `g0` is isomorphic to a subgraph of `g1`.
 ///
 /// Using the VF2 algorithm, examining both syntactic and semantic
 /// graph isomorphism (graph structure and matching node and edge weights).

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -12,7 +12,7 @@ use crate::visit::{EdgeRef, IntoEdges, IntoNodeIdentifiers, NodeIndexable, Visit
 #[cfg(feature = "rayon")]
 use core::marker::{Send, Sync};
 
-/// \[Generic\] [Johnson algorithm][johnson] for all pairs shortest path problem.
+/// [Johnson algorithm][johnson] for all pairs shortest path problem.
 ///
 /// Сompute the lengths of shortest paths in a weighted graph with
 /// positive or negative edge weights, but no negative cycles.
@@ -130,7 +130,7 @@ where
     Ok(distance_map)
 }
 
-/// \[Generic\] [Johnson algorithm][johnson]
+/// [Johnson algorithm][johnson]
 /// implementation for all pairs shortest path problem,
 /// parallelizing the [`dijkstra`](fn@crate::algo::dijkstra) calls with `rayon`.
 ///

--- a/src/algo/k_shortest_path.rs
+++ b/src/algo/k_shortest_path.rs
@@ -7,7 +7,7 @@ use crate::algo::Measure;
 use crate::scored::MinScored;
 use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable, Visitable};
 
-/// \[Generic\] k'th shortest path algorithm.
+/// k'th shortest path algorithm.
 ///
 /// Compute the length of the k-th shortest path from `start` to every reachable
 /// node. Edge costs must be non-negative.

--- a/src/algo/matching.rs
+++ b/src/algo/matching.rs
@@ -184,8 +184,7 @@ where
     }
 }
 
-/// \[Generic\] Compute a
-/// [*matching*](https://en.wikipedia.org/wiki/Matching_(graph_theory)) using a
+/// Compute a [*matching*](https://en.wikipedia.org/wiki/Matching_(graph_theory)) using a
 /// greedy heuristic.
 ///
 /// The input graph is treated as if undirected. The underlying heuristic is
@@ -317,8 +316,7 @@ impl<G: GraphBase> PartialEq for Label<G> {
     }
 }
 
-/// \[Generic\] Compute the [*maximum
-/// matching*](https://en.wikipedia.org/wiki/Matching_(graph_theory)) using
+/// Compute the [*maximum matching*](https://en.wikipedia.org/wiki/Matching_(graph_theory)) using
 /// [Gabow's algorithm][1].
 ///
 /// [1]: https://dl.acm.org/doi/10.1145/321941.321942

--- a/src/algo/min_spanning_tree.rs
+++ b/src/algo/min_spanning_tree.rs
@@ -11,7 +11,7 @@ use crate::unionfind::UnionFind;
 use crate::visit::{Data, IntoEdges, IntoNodeReferences, NodeRef};
 use crate::visit::{IntoEdgeReferences, NodeIndexable};
 
-/// \[Generic\] Compute a *minimum spanning tree* of a graph.
+/// Compute a *minimum spanning tree* of a graph.
 ///
 /// The input graph is treated as if undirected.
 ///
@@ -183,7 +183,7 @@ where
     }
 }
 
-/// \[Generic\] Compute a *minimum spanning tree* of a graph using Prim's algorithm.
+/// Compute a *minimum spanning tree* of a graph using Prim's algorithm.
 ///
 /// Graph is treated as if undirected. The computed minimum spanning tree can be wrong
 /// if this is not true.

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -73,7 +73,7 @@ pub use steiner_tree::steiner_tree;
 #[cfg(feature = "rayon")]
 pub use johnson::parallel_johnson;
 
-/// \[Generic\] Return the number of connected components of the graph.
+/// Return the number of connected components of the graph.
 ///
 /// For a directed graph, this is the *weakly* connected components.
 ///
@@ -143,7 +143,7 @@ where
     labels.len()
 }
 
-/// \[Generic\] Return `true` if the input graph contains a cycle.
+/// Return `true` if the input graph contains a cycle.
 ///
 /// Always treats the input graph as if undirected.
 ///
@@ -176,7 +176,7 @@ where
     false
 }
 
-/// \[Generic\] Perform a topological sort of a directed graph.
+/// Perform a topological sort of a directed graph.
 ///
 /// `toposort` returns `Err` on graphs with cycles.
 /// To handle graphs with cycles, use the one of scc algorithms or
@@ -257,7 +257,7 @@ where
     })
 }
 
-/// \[Generic\] Return `true` if the input directed graph contains a cycle.
+/// Return `true` if the input directed graph contains a cycle.
 ///
 /// This implementation is recursive; use [`toposort`] if an alternative is needed.
 ///
@@ -337,7 +337,7 @@ where
     f(dfs)
 }
 
-/// \[Generic\] Check if there exists a path starting at `from` and reaching `to`.
+/// Check if there exists a path starting at `from` and reaching `to`.
 ///
 /// If `from` and `to` are equal, this function returns true.
 ///

--- a/src/algo/page_rank.rs
+++ b/src/algo/page_rank.rs
@@ -6,7 +6,7 @@ use crate::visit::{EdgeRef, IntoEdges, NodeCount, NodeIndexable};
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
-/// \[Generic\] Page Rank algorithm.
+/// Page Rank algorithm.
 ///
 /// Computes the ranks of every node in a graph using the [Page Rank algorithm][pr].
 ///
@@ -127,7 +127,7 @@ where
     }
     (out_degree, flag_points_to)
 }
-/// \[Generic\] Parallel Page Rank algorithm.
+/// Parallel Page Rank algorithm.
 ///
 /// See [`page_rank`].
 #[cfg(feature = "rayon")]

--- a/src/algo/scc/kosaraju_scc.rs
+++ b/src/algo/scc/kosaraju_scc.rs
@@ -14,7 +14,7 @@ where
     kosaraju_scc(g)
 }
 
-/// \[Generic\] Compute the *strongly connected components* using [Kosaraju's algorithm][1].
+/// Compute the *strongly connected components* using [Kosaraju's algorithm][1].
 ///
 /// This implementation is iterative and does two passes over the nodes.
 ///

--- a/src/algo/scc/tarjan_scc.rs
+++ b/src/algo/scc/tarjan_scc.rs
@@ -36,7 +36,7 @@ impl<N> TarjanScc<N> {
         }
     }
 
-    /// \[Generic\] Compute the *strongly connected components* using Algorithm 3 in
+    /// Compute the *strongly connected components* using Algorithm 3 in
     /// [A Space-Efficient Algorithm for Finding Strongly Connected Components][1] by David J. Pierce,
     /// which is a memory-efficient variation of [Tarjan's algorithm][2].
     ///
@@ -153,7 +153,7 @@ impl<N> TarjanScc<N> {
     }
 }
 
-/// \[Generic\] Compute the *strongly connected components* using [Tarjan's algorithm][1].
+/// Compute the *strongly connected components* using [Tarjan's algorithm][1].
 ///
 /// This implementation is recursive and does one pass over the nodes. It is based on
 /// [A Space-Efficient Algorithm for Finding Strongly Connected Components][2] by David J. Pierce,

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable};
 use alloc::{vec, vec::Vec};
 
-/// \[Generic\] Compute shortest paths from node `source` to all other.
+/// Compute shortest paths from node `source` to all other.
 ///
 /// Using the [Shortest Path Faster Algorithm][spfa].
 /// Compute shortest distances from node `source` to all other.

--- a/src/algo/steiner_tree.rs
+++ b/src/algo/steiner_tree.rs
@@ -127,7 +127,7 @@ where
     removed_leaves
 }
 
-/// \[Generic\] [Steiner Tree][1] algorithm.
+/// [Steiner Tree][1] algorithm.
 ///
 /// Computes the Steiner tree of an undirected connected graph given a set of terminal nodes via
 /// [Kou's algorithm][2]. Implementation details are the same as in the [NetworkX implementation][3].


### PR DESCRIPTION
This PR removes the \[Generic\] tag from the docstrings of algorithms as discussed [here](https://github.com/petgraph/petgraph/pull/834#discussion_r2160087013).