### PR TITLE
ci: Compare `spfa` with `bellman_ford` in quickchecks

### DIFF
--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1632,7 +1632,9 @@ quickcheck! {
             let bf_res = bellman_ford(&gr, start);
             // We only compare the predecessors, since the algorithms use different actual values
             // to represent inf weights.
-            return spfa_res.map(|p| p.predecessors) == bf_res.map(|p| p.predecessors);
+            if spfa_res.map(|p| p.predecessors) != bf_res.map(|p| p.predecessors) {
+                return false;
+            }
         }
         true
     }
@@ -1653,7 +1655,9 @@ quickcheck! {
             let bf_res = bellman_ford(&gr, start);
             // We only compare the predecessors, since the algorithms use different actual values
             // to represent inf weight.
-            return spfa_res.map(|p| p.predecessors) == bf_res.map(|p| p.predecessors);
+            if spfa_res.map(|p| p.predecessors) != bf_res.map(|p| p.predecessors) {
+                return false;
+            }
         }
         true
     }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -933,7 +933,7 @@ quickcheck! {
         }
         for (i, start) in gr.node_indices().enumerate() {
             if i >= 10 { break; } // testing all is too slow
-            bellman_ford(&gr, start).unwrap();
+            return bellman_ford(&gr, start).is_ok();
         }
         true
     }
@@ -965,7 +965,7 @@ quickcheck! {
         }
         for (i, start) in gr.node_indices().enumerate() {
             if i >= 10 { break; } // testing all is too slow
-            bellman_ford(&gr, start).unwrap();
+            return bellman_ford(&gr, start).is_ok();
         }
         true
     }
@@ -1628,7 +1628,11 @@ quickcheck! {
         }
         for (i, start) in gr.node_indices().enumerate() {
             if i >= 10 { break; } // testing all is too slow
-            spfa(&gr, start, |edge| *edge.weight()).unwrap();
+            let spfa_res = spfa(&gr, start, |edge| *edge.weight());
+            let bf_res = bellman_ford(&gr, start);
+            // We only compare the predecessors, since the algorithms use different actual values
+            // to represent inf weights.
+            return spfa_res.map(|p| p.predecessors) == bf_res.map(|p| p.predecessors);
         }
         true
     }
@@ -1645,7 +1649,11 @@ quickcheck! {
         }
         for (i, start) in gr.node_indices().enumerate() {
             if i >= 10 { break; } // testing all is too slow
-            spfa(&gr, start, |edge| *edge.weight()).unwrap();
+            let spfa_res = spfa(&gr, start, |edge| *edge.weight());
+            let bf_res = bellman_ford(&gr, start);
+            // We only compare the predecessors, since the algorithms use different actual values
+            // to represent inf weight.
+            return spfa_res.map(|p| p.predecessors) == bf_res.map(|p| p.predecessors);
         }
         true
     }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -933,7 +933,9 @@ quickcheck! {
         }
         for (i, start) in gr.node_indices().enumerate() {
             if i >= 10 { break; } // testing all is too slow
-            return bellman_ford(&gr, start).is_ok();
+            if bellman_ford(&gr, start).is_err() {
+                return false;
+            }
         }
         true
     }
@@ -965,7 +967,9 @@ quickcheck! {
         }
         for (i, start) in gr.node_indices().enumerate() {
             if i >= 10 { break; } // testing all is too slow
-            return bellman_ford(&gr, start).is_ok();
+            if bellman_ford(&gr, start).is_err() {
+                return false;
+            }
         }
         true
     }


### PR DESCRIPTION
A slight improvement of the `spfa` and `bellman_ford` quickcheck tests:
1. Avoid `unwrap`s;
2. Compare `spfa` results with `bellman_ford`.