### PR TITLE
feat: Add `into_nodes_edges_iters` to `StableGraph`

### DIFF
--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -817,6 +817,15 @@ where
         }
     }
 
+    pub fn into_nodes_edges(self) -> (impl Iterator<Item = (NodeIndex<Ix>, N)>, impl Iterator<Item = (EdgeIndex<Ix>, NodeIndex<Ix>, NodeIndex<Ix>, E)>) {
+        let (inner_nodes, inner_edges) = self.g.into_nodes_edges();
+
+        (
+            inner_nodes.into_iter().enumerate().filter_map(|(i, node)| node.weight.map(|node| (i, node))).map(|(index, node)| (NodeIndex::new(index), node)), 
+            inner_edges.into_iter().enumerate().filter(|(_, edge)| edge.weight.is_some()).map(|(index, edge)| (EdgeIndex::new(index), edge.source(), edge.target(), edge.weight.unwrap()))
+        )
+    }
+
     /// Index the `StableGraph` by two indices, any combination of
     /// node or edge indices is fine.
     ///

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -817,11 +817,12 @@ where
         }
     }
 
-    pub fn into_nodes_edges(self) -> (impl Iterator<Item = (NodeIndex<Ix>, N)>, impl Iterator<Item = (EdgeIndex<Ix>, NodeIndex<Ix>, NodeIndex<Ix>, E)>) {
+    /// Convert the `StableGraph` into iterators of Nodes and Edges
+    pub fn into_nodes_edges_iters(self) -> (impl Iterator<Item = (NodeIndex<Ix>, N)>, impl Iterator<Item = (EdgeIndex<Ix>, NodeIndex<Ix>, NodeIndex<Ix>, E)>) {
         let (inner_nodes, inner_edges) = self.g.into_nodes_edges();
 
         (
-            inner_nodes.into_iter().enumerate().filter_map(|(i, node)| node.weight.map(|node| (i, node))).map(|(index, node)| (NodeIndex::new(index), node)), 
+            inner_nodes.into_iter().enumerate().filter(|(_, node)| node.weight.is_some()).map(|(index, node)| (NodeIndex::new(index), node.weight.unwrap())), 
             inner_edges.into_iter().enumerate().filter(|(_, edge)| edge.weight.is_some()).map(|(index, edge)| (EdgeIndex::new(index), edge.source(), edge.target(), edge.weight.unwrap()))
         )
     }


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->


  As discussed in #840.  

  This allows transforming a `StableGraph` into its components, without allocations (via `Graph::from::<StableGraph>`) and without losing the `NodeIndex` or `EdgeIndex`.
  