### PR TITLE
feat: Implemented new largest maximal clique algorithm and function

### DIFF
--- a/benches/maximal_cliques.rs
+++ b/benches/maximal_cliques.rs
@@ -5,7 +5,7 @@ extern crate test;
 
 use test::Bencher;
 
-use petgraph::algo::maximal_cliques;
+use petgraph::algo::maximal_cliques::{maximal_cliques, largest_maximal_clique};
 
 #[allow(dead_code)]
 mod common;
@@ -34,4 +34,28 @@ fn maximal_cliques_fan_100_bench(bench: &mut Bencher) {
 fn maximal_cliques_fan_200_bench(bench: &mut Bencher) {
     let g = directed_fan(200);
     bench.iter(|| maximal_cliques(&g));
+}
+
+#[bench]
+fn largest_maximal_clique_fan_010_bench(bench: &mut Bencher) {
+    let g = directed_fan(10);
+    bench.iter(|| largest_maximal_clique(&g));
+}
+
+#[bench]
+fn largest_maximal_clique_fan_050_bench(bench: &mut Bencher) {
+    let g = directed_fan(50);
+    bench.iter(|| largest_maximal_clique(&g));
+}
+
+#[bench]
+fn largest_maximal_clique_fan_100_bench(bench: &mut Bencher) {
+    let g = directed_fan(100);
+    bench.iter(|| largest_maximal_clique(&g));
+}
+
+#[bench]
+fn largest_maximal_clique_fan_200_bench(bench: &mut Bencher) {
+    let g = directed_fan(200);
+    bench.iter(|| largest_maximal_clique(&g));
 }

--- a/src/algo/maximal_cliques.rs
+++ b/src/algo/maximal_cliques.rs
@@ -1,8 +1,11 @@
-use crate::visit::{GetAdjacencyMatrix, IntoNeighbors, IntoNodeIdentifiers};
+use crate::visit::{
+    EdgeRef, GetAdjacencyMatrix, IntoEdges, IntoNeighbors, IntoNodeIdentifiers, NodeIndexable,
+    Visitable,
+};
 use alloc::vec::Vec;
 use core::hash::Hash;
 use core::iter::FromIterator;
-use hashbrown::HashSet;
+use hashbrown::{HashMap, HashSet};
 
 /// Finds maximal cliques containing all the vertices in r, some of the
 /// vertices in p, and none of the vertices in x.
@@ -122,4 +125,163 @@ where
     let p = g.node_identifiers().collect::<HashSet<G::NodeId>>();
     let x = HashSet::new();
     bron_kerbosch_pivot(g, &adj_mat, r, p, x)
+}
+
+/// Finds the largest maximal clique in an undirected graph using the algorithm outlined in McCreesh and Prosser's paper [1].
+/// Much faster than the standard Bron-Kerbosch technique, but only will get the largest maximal clique 
+/// instead of all maximal cliques 
+///  
+/// Uses a graph coloring algorithm to narrow the search space and start from the nodes most likely to be in a large clique, 
+/// and ignores any cliques that are not capable of reaching the max size to further reduce the time taken. This implementation
+/// can be dramatically improved through parallelization, as was originally outlined in the aforementioned paper [1]
+///
+/// This method may also be called on directed graphs, but one needs to ensure that
+/// if an edge (u, v) exists, then (v, u) also exists.
+///
+/// # Arguments
+/// * `g`: The graph to find maximal cliques in.
+///
+/// # Returns
+/// * `Vec<HashSet>`: A vector of [`struct@hashbrown::HashSet`] making up the maximal cliques in the graph.
+///
+/// # Complexity
+/// * Time complexity: **O((n+m) * 3^(n/3))**
+/// * Auxiliary space: **O(n^2)**
+///
+/// where `n` is the number of nodes and `m` is the of edges
+///
+/// [1]: https://doi.org/10.3390/a6040618
+///
+/// # Example
+///
+/// ```
+/// use petgraph::algo::maximal_cliques::largest_maximal_clique;
+/// use petgraph::graph::UnGraph;
+///
+/// let mut g = UnGraph::<i32, ()>::from_edges([(0, 1), (0, 2), (1, 2), (2, 3)]);
+/// g.add_node(4);
+/// // The example graph:
+/// //
+/// // 0 --- 2 -- 3
+/// //  \   /
+/// //   \ /
+/// //    1       4
+/// //
+/// // maximal cliques: {4}, {2, 3}, {0, 1, 2}
+/// // Output the result
+/// let cliques = largest_maximal_clique(&g);
+/// println!("{:?}", cliques);
+/// //   {NodeIndex(0), NodeIndex(1), NodeIndex(2)}
+/// ```
+pub fn largest_maximal_clique<G>(g: G) -> HashSet<G::NodeId>
+where
+    G: IntoEdges + IntoNodeIdentifiers + Visitable + NodeIndexable,
+    G::NodeId: Eq + Hash + Ord,
+{
+    mccreesh_prosser(g)
+}
+
+fn mccreesh_prosser<G>(g: G) -> HashSet<G::NodeId>
+where
+    G: IntoEdges + IntoNodeIdentifiers + Visitable + NodeIndexable,
+    G::NodeId: Eq + Hash + Clone + Ord,
+{
+    let mut c_max = HashSet::new();
+    let mut nodes: Vec<_> = g.node_identifiers().collect();
+
+    // sort nodes by degree as high edge nodes are more likely to be in a larger clique
+    nodes.sort_by_key(|&n| std::cmp::Reverse(g.edges(n).count()));
+    let mut clique = HashSet::new();
+    let candidate_vertices: HashSet<_> = nodes.into_iter().collect();
+
+    expand(&g, &mut clique, candidate_vertices, &mut c_max);
+    c_max
+}
+
+/// A recursive Function as described in the [McCreesh-Prosser paper](https://doi.org/10.3390/a6040618)
+/// Which takes in a clique and attempts to expand it using the candidate vertices
+fn expand<G>(
+    graph: &G,
+    clique: &mut HashSet<G::NodeId>,
+    mut candidate_vertices: HashSet<G::NodeId>,
+    largest_clique: &mut HashSet<G::NodeId>,
+) where
+    G: IntoEdges + Visitable,
+    G::NodeId: Eq + Hash + Clone + Ord,
+{
+    // color the candidate vertices to get an upper bound for pruning and roughly rank the nodes most -> least connections
+    let (order, colors) = color_order(graph, &candidate_vertices);
+
+    // iterate through candidates from rarest color to most common color
+    for node in order.into_iter().rev() {
+        let v_color = colors.get(&node).copied().unwrap_or(0);
+
+        // if the best potential size is worse than the largest we've found, ignore it
+        if clique.len() + v_color <= largest_clique.len() {
+            return;
+        }
+        // test how the clique changes when we add the new node (if it's worse we will remove it)
+        clique.insert(node.clone());
+        let neighbors: HashSet<_> = graph.neighbors(node.clone()).collect();
+        let new_candidate_vertices: HashSet<G::NodeId> = candidate_vertices.intersection(&neighbors).cloned().collect();
+
+        // this fires when we have a maximal clique
+        if new_candidate_vertices.is_empty() {
+            // update largest_clique if applicable
+            if clique.len() > largest_clique.len() {
+                *largest_clique = clique.clone();
+            }
+        } else {
+            // still have more nodes to add, recurse
+            expand(graph, clique, new_candidate_vertices, largest_clique);
+        }
+
+        // backtrack: remove the node from the clique so we can explore other possibilities.
+        clique.remove(&node);
+        candidate_vertices.remove(&node);
+    }
+}
+
+/// Colors the given set of nodes using a greedy algorithm and returns an ordering.
+/// Simple and fast, but will produce results much worse than most other colorings
+///
+/// This algorithm specifically is extremely useful for use in `mccreesh_prosser` clique finding as speed is
+/// very important and using a good coloring can be detrimental for that task.
+/// 
+/// # Returns
+/// A tuple containing:
+/// * `order`: A vector of the nodes in `p`, sorted by their assigned color number.
+/// * `colors`: A map from each node to its color number (a `usize`).
+fn color_order<G>(graph: &G, p: &HashSet<G::NodeId>) -> (Vec<G::NodeId>, HashMap<G::NodeId, usize>)
+where
+    G: IntoEdges + Visitable,
+    G::NodeId: Eq + Hash + Clone + Ord,
+{
+    // A simple greedy coloring implementation.
+    let mut colors = HashMap::new();
+    let mut ordered_nodes: Vec<_> = p.iter().cloned().collect();
+
+    // sort nodes first so we have deterministic coloring
+    ordered_nodes.sort();
+
+    for node in ordered_nodes {
+        let mut neighboring_colors = HashSet::new();
+        for neighbor in graph.neighbors(node.clone()) {
+            if let Some(color) = colors.get(&neighbor) {
+                neighboring_colors.insert(*color);
+            }
+        }
+
+        let mut color = 1;
+        while neighboring_colors.contains(&color) {
+            color += 1;
+        }
+        colors.insert(node, color);
+    }
+
+    // Now create the final `order` vector, sorted by color.
+    let mut final_order: Vec<_> = p.iter().cloned().collect();
+    final_order.sort_by_key(|n| colors.get(n).copied().unwrap_or(0));
+
+    (final_order, colors)
 }

--- a/tests/mccreesh_prosser.rs
+++ b/tests/mccreesh_prosser.rs
@@ -1,0 +1,160 @@
+extern crate petgraph;
+use hashbrown::HashSet;
+use petgraph::graph::{DiGraph, UnGraph};
+use petgraph::{algo::maximal_cliques::largest_maximal_clique, graph::Graph, Undirected};
+
+#[test]
+fn test_largest_maximal_clique_empty_graph() {
+    // empty graph should return empty set
+    let g = Graph::<i32, ()>::new();
+    let largest_clique = largest_maximal_clique(&g);
+    let expected_clique = HashSet::new();
+    assert_eq!(expected_clique, largest_clique);
+}
+
+#[test]
+fn test_largest_maximal_clique_undirected_sparse_graph() {
+    // c     d
+    //
+    // b --- a
+    let mut g = UnGraph::<i32, ()>::new_undirected();
+
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+
+    g.extend_with_edges([(a, b), (b, a)]);
+
+    let largest_clique = largest_maximal_clique(&g);
+
+    // The largest clique should be {a, b} with size 2
+    let expected_clique: HashSet<_> = vec![a, b].into_iter().collect();
+    assert_eq!(expected_clique, largest_clique);
+}
+
+#[test]
+fn test_largest_maximal_clique_directed_sparse_graph() {
+    // c     d
+    //
+    // b <-> a
+    let mut g = DiGraph::<i32, ()>::new();
+
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+
+    g.extend_with_edges([(a, b), (b, a)]);
+
+    let largest_clique = largest_maximal_clique(&g);
+
+    // The largest clique should be {a, b} with size 2
+    let expected_clique: HashSet<_> = vec![a, b].into_iter().collect();
+    assert_eq!(expected_clique, largest_clique);
+}
+
+#[test]
+fn test_largest_maximal_clique_undirected() {
+    // f - d - e - a
+    //     |   | /
+    //     c - b
+    let mut g = Graph::<i32, (), Undirected>::new_undirected();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    let e = g.add_node(4);
+    let f = g.add_node(5);
+    g.extend_with_edges([(a, b), (a, e), (b, e), (b, c), (c, d), (d, e), (e, f)]);
+
+    let largest_clique = largest_maximal_clique(&g);
+    println!("Largest clique: {:?}", &largest_clique);
+
+    // The largest clique should be {a, b, e} with size 3
+    let expected_clique: HashSet<_> = vec![a, b, e].into_iter().collect();
+    assert_eq!(expected_clique, largest_clique);
+}
+
+#[test]
+fn test_largest_maximal_clique_directed() {
+    // f <-> d <-> e <-> a
+    //       ^     ^     ^
+    //       |     |     |
+    //       v     v     |
+    //       c <-> b <---|
+    let mut g = Graph::<i32, ()>::new();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    let e = g.add_node(4);
+    let f = g.add_node(5);
+    g.extend_with_edges([
+        (a, b),
+        (b, a),
+        (a, e),
+        (e, a),
+        (b, e),
+        (e, b),
+        (b, c),
+        (c, b),
+        (c, d),
+        (d, c),
+        (d, e),
+        (e, d),
+        (d, f),
+        (f, d),
+    ]);
+
+    let largest_clique = largest_maximal_clique(&g);
+    println!("Largest clique: {:?}", &largest_clique);
+
+    // The largest clique should be {a, b, e} with size 3
+    let expected_clique: HashSet<_> = vec![a, b, e].into_iter().collect();
+    assert_eq!(expected_clique, largest_clique);
+}
+
+#[test]
+fn test_largest_maximal_clique_single_node() {
+    // Test with a single isolated node
+    let mut g = Graph::<i32, (), Undirected>::new_undirected();
+    let a = g.add_node(0);
+
+    let largest_clique = largest_maximal_clique(&g);
+
+    // The largest (and only) clique should be {a}
+    let expected_clique: HashSet<_> = vec![a].into_iter().collect();
+    assert_eq!(expected_clique, largest_clique);
+}
+
+#[test]
+fn test_largest_maximal_clique_multiple_isolated_nodes() {
+    // Test with multiple isolated nodes
+    let mut g = Graph::<i32, (), Undirected>::new_undirected();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+
+    let largest_clique = largest_maximal_clique(&g);
+
+    // All isolated nodes form cliques of size 1, so any one of them is valid
+    // The function should return one of {a}, {b}, or {c}
+    assert_eq!(1, largest_clique.len());
+    assert!(
+        largest_clique.contains(&a) || largest_clique.contains(&b) || largest_clique.contains(&c)
+    );
+}
+
+#[test]
+fn test_largest_maximal_clique_complete_graph() {
+    // Test with a complete graph (triangle)
+    let mut g = Graph::<i32, (), Undirected>::new_undirected();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+
+    g.extend_with_edges([(a, b), (b, c), (c, a)]);
+
+    let largest_clique = largest_maximal_clique(&g);
+
+    // The largest clique should be {a, b, c} with size 3
+    let expected_clique: HashSet<_> = vec![a, b, c].into_iter().collect();
+    assert_eq!(expected_clique, largest_clique);
+}


### PR DESCRIPTION
Implemented the maximal clique algorithm as described in [this paper](https://doi.org/10.3390/a6040618) and added a new public function `largest_maximal_clique`. This works significantly faster if you are only interested in the largest maximal clique, and there is still room for parallelization which is currently not implemented in the algorithm. I needed to implement it for my current project which uses ~1M nodes and ~10M edges, and the time to compute went from ~6 hours to ~2.5 minutes.

This code is likely organized poorly, the code and tests are all fully functional AFAIK, but I would like some help regarding layout of the different functions.