### PR TITLE
ci: Use just and adapt CONTRIBUTING.md and ci.yml accordingly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,21 +74,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.8
+      - uses: extractions/setup-just@v3
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
       - name: Check formatting
-        run: cargo fmt -- --check
+        run: just fmt
 
       - name: Run clippy
         # The benchmarks target require nightly,
         # so we cannot use --all-targets here.
-        run: |
-          cargo clippy --all-features \
-            --lib --bins --examples --tests \
-            -- -D warnings
+        run: just clippy
 
       - name: Build docs
         run: cargo doc --no-deps --all-features
@@ -101,6 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.8
+      - uses: extractions/setup-just@v3
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -108,7 +107,7 @@ jobs:
           targets: wasm32v1-none
 
       - name: Check
-        run: cargo check --no-default-features -p petgraph --target wasm32v1-none --features graphmap,serde-1,stable_graph,matrix_graph,generate,unstable
+        run: just check-no-std
 
   fast-miri:
     # This job runs on pull_request without the `S-run-thorough-ci-tests` label.
@@ -118,6 +117,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.8
+      - uses: extractions/setup-just@v3
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
@@ -125,16 +125,7 @@ jobs:
         with:
           tool: nextest
       # Exclude some tests from fast-miri, as they take very long to run. thorough-miri includes all tests without nextest.
-      - run: |
-          cargo miri nextest run -- \
-            --skip b01_vienna_test \
-            --skip b07_vienna_test \
-            --skip generic_graph6_encoder_test_cases \
-            --skip graph6_for_csr_test_cases \
-            --skip graph6_for_graph_map_test_cases \
-            --skip graph6_for_graph_test_cases \
-            --skip graph6_for_matrix_graph_test_case \
-            --skip graph6_for_stable_graph_test_cases
+      - run: just miri-fast
 
   thorough-miri:
     # This job runs on push and pull_request with the `S-run-thorough-ci-tests` label.
@@ -144,7 +135,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.8
+      - uses: extractions/setup-just@v3
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
-      - run: cargo miri test
+      - run: just miri

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ For running the benchmarks, you will need to switch to the `nightly`
 toolchain, as features are used which are only available in the
 nightly toolchain. You can do this by running:
 
-```bash
+```commandline
 rustup default nightly
 ```
 
@@ -142,7 +142,7 @@ Which will install the nightly toolchain if it is not already
 installed, and set it as the default toolchain. You can switch back
 to the stable toolchain by running:
 
-```bash
+```commandline
 rustup default stable
 ```
 
@@ -150,7 +150,7 @@ rustup default stable
 
 Building petgraph is as simple as running:
 
-```bash
+```commandline
 cargo build
 ```
 
@@ -158,7 +158,7 @@ cargo build
 
 Testing petgraph is also simple, and can be done by running:
 
-```bash
+```commandline
 cargo test --features all
 ```
 
@@ -166,11 +166,47 @@ Note the `--features all` flag, which enables all features of
 petgraph. This makes sure that quickcheck tests are also
 run.
 
+In CI, we run the tests on different rust versions and toolchains,
+including nightly, as well as our current minimum supported Rust
+version (MSRV). You can see which versions are tested exactly in 
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+
+Similarly, we also run [cargo miri][miri-url] in CI, which is a tool for
+detecting undefined behavior in Rust code. This will however
+again require the nightly toolchain:
+
+```commandline
+cargo miri test
+```
+
+This might, however, take a long time to run, so it is probably worth it 
+specifying individual tests to run, as follows:
+
+```commandline
+cargo miri test --test min_spanning_tree
+```
+
+### 🧹 Lints
+
+We use [clippy][clippy-url] and [rustfmt][rustfmt-url] to ensure that 
+the code is formatted and linted correctly. You can run these tools 
+yourself by running:
+
+```commandline
+cargo fmt
+```
+
+and
+
+```commandline
+cargo clippy --all-features --lib --bins --examples --tests -- -D warnings
+```
+
 ### ⏱️ Benchmarks
 
 Benchmarks can be run by running:
 
-```bash
+```commandline
 cargo bench
 ```
 
@@ -193,9 +229,16 @@ you are interested in helping out on a more long-term basis, feel free
 to introduce yourself on [discord][discord-url] or start
 a [discussion][github-discussions-url].
 
+
+[algo-docs-template]: https://github.com/petgraph/petgraph/blob/master/assets/guide/algodocs.md
+
 [code-of-conduct-url]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
 
+[clippy-url]: https://github.com/rust-lang/rust-clippy
+
 [discord-url]: https://discord.gg/n2tc79tJ4e
+
+[rustfmt-url]: https://github.com/rust-lang/rustfmt
 
 [github-discussions-url]: https://github.com/petgraph/petgraph/discussions
 
@@ -209,7 +252,7 @@ a [discussion][github-discussions-url].
 
 [github-new-issue]: https://github.com/petgraph/petgraph/issues/new
 
-[algo-docs-template]: https://github.com/petgraph/petgraph/blob/master/assets/guide/algodocs.md
+[miri-url]: https://github.com/rust-lang/miri
 
 ## 🏛️ Old Section on Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,9 +130,9 @@ petgraph does not have any special setup requirements, other than
 having a working Rust toolchain. The project is built using
 [Cargo](https://doc.rust-lang.org/cargo/).
 
-For running the benchmarks, you will need to switch to the `nightly`
-toolchain, as features are used which are only available in the
-nightly toolchain. You can do this by running:
+For running the benchmarks, as well as [miri][miri-url], you will
+need to switch to the `nightly`
+toolchain. You can do this by running:
 
 ```commandline
 rustup default nightly
@@ -163,6 +163,16 @@ just
 
 or have a look at the [`justfile`](justfile).
 
+To run a basic test suite, as it is run in CI (using the stable
+toolchain), you can run:
+
+```commandline
+just ci
+```
+
+Which will run the (cargo) tests and lints. More detailed commands
+will be explained in the following sections.
+
 ### 🏗️ Building
 
 Building petgraph is as simple as running:
@@ -192,9 +202,8 @@ again require the nightly toolchain:
 just miri
 ```
 
-This might, however, take a long time to run, so it is to run
-`miri-fast` instead, which
-uses [nextest][nextest-url]
+This might, however, take a long time to run, so consider running
+`miri-fast` instead, which uses [nextest][nextest-url],
 a faster test runner, and skips some tests which take very long:
 
 ```commandline

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,60 +146,87 @@ to the stable toolchain by running:
 rustup default stable
 ```
 
+We use [just][just-url] as a command runner
+to simplify the commands you need to run. You can install it using
+cargo:
+
+```commandline
+cargo install just
+```
+
+To understand which commands are available, and what they do, you can
+run:
+
+```commandline
+just
+```
+
+or have a look at the [`justfile`](justfile).
+
 ### 🏗️ Building
 
 Building petgraph is as simple as running:
 
 ```commandline
-cargo build
+just build
 ```
 
 ### 🧪 Testing
 
-Testing petgraph is also simple, and can be done by running:
+Testing petgraph is similarly simple:
 
 ```commandline
-cargo test --features all
+just test
 ```
-
-Note the `--features all` flag, which enables all features of
-petgraph. This makes sure that quickcheck tests are also
-run.
 
 In CI, we run the tests on different rust versions and toolchains,
 including nightly, as well as our current minimum supported Rust
-version (MSRV). You can see which versions are tested exactly in 
+version (MSRV). You can see which versions are tested exactly in
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
-Similarly, we also run [cargo miri][miri-url] in CI, which is a tool for
-detecting undefined behavior in Rust code. This will however
+Similarly, we also run [cargo miri][miri-url] in CI, which is a tool
+for detecting undefined behavior in Rust code. This will however
 again require the nightly toolchain:
 
 ```commandline
-cargo miri test
+just miri
 ```
 
-This might, however, take a long time to run, so it is probably worth it 
-specifying individual tests to run, as follows:
+This might, however, take a long time to run, so it is to run
+`miri-fast` instead, which
+uses [nextest][nextest-url]
+a faster test runner, and skips some tests which take very long:
 
 ```commandline
-cargo miri test --test min_spanning_tree
+just miri-fast
+```
+
+Nextest can again be installed using cargo:
+
+```commandline
+cargo install cargo-nextest --locked
 ```
 
 ### 🧹 Lints
 
-We use [clippy][clippy-url] and [rustfmt][rustfmt-url] to ensure that 
-the code is formatted and linted correctly. You can run these tools 
-yourself by running:
+We use [clippy][clippy-url] and [rustfmt][rustfmt-url] to ensure that
+the code is formatted and linted correctly. You can run all linting
+at once by running:
 
 ```commandline
-cargo fmt
+just lint
+```
+
+Or individually, by running:
+
+```commandline
+just fmt
 ```
 
 and
 
 ```commandline
-cargo clippy --all-features --lib --bins --examples --tests -- -D warnings
+just clippy
 ```
 
 ### ⏱️ Benchmarks
@@ -238,6 +265,8 @@ a [discussion][github-discussions-url].
 
 [discord-url]: https://discord.gg/n2tc79tJ4e
 
+[just-url]: https://github.com/casey/just
+
 [rustfmt-url]: https://github.com/rust-lang/rustfmt
 
 [github-discussions-url]: https://github.com/petgraph/petgraph/discussions
@@ -253,6 +282,8 @@ a [discussion][github-discussions-url].
 [github-new-issue]: https://github.com/petgraph/petgraph/issues/new
 
 [miri-url]: https://github.com/rust-lang/miri
+
+[nextest-url]: https://github.com/nextest-rs/nextest
 
 ## 🏛️ Old Section on Pull Requests
 

--- a/justfile
+++ b/justfile
@@ -34,6 +34,9 @@ fmt:
 clippy:
     cargo clippy --all-features --lib --bins --examples --tests -- -D warnings
 
+# Runs all linting checks that are run in CI
+lint: fmt clippy
+
 # Checks if no-std is working same as in CI. Requires the wasm32v1-none target to be installed
 check-no-std:
     cargo check --no-default-features -p petgraph --target wasm32v1-none --features graphmap,serde-1,stable_graph,matrix_graph,generate,unstable

--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ clippy:
 # Runs all linting checks that are run in CI
 lint: fmt clippy
 
+# Runs all tests and linting that are run in CI
 ci: fmt clippy test
 
 # Checks if no-std is working same as in CI. Requires the wasm32v1-none target to be installed

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 
 # Builds the project in development mode
 build:
-    cargo build $args
+    cargo build
 
 # Tests with all features enabled
 test:
@@ -36,6 +36,8 @@ clippy:
 
 # Runs all linting checks that are run in CI
 lint: fmt clippy
+
+ci: fmt clippy test
 
 # Checks if no-std is working same as in CI. Requires the wasm32v1-none target to be installed
 check-no-std:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,39 @@
+# Lists all available recipes
+default:
+    just --list
+
+# Builds the project in development mode
+build:
+    cargo build $args
+
+# Tests with all features enabled
+test:
+    cargo test --features all
+
+# Miri with all tests (this might take very long). Consider the fast-miri recipe instead or specify individual tests
+miri:
+    cargo miri test
+
+# Miri with the same configuration as in (non-thorough) CI. Uses nextest and excludes some tests that are known to be very slow
+miri-fast:
+    cargo miri nextest run -- \
+                --skip b01_vienna_test \
+                --skip b07_vienna_test \
+                --skip generic_graph6_encoder_test_cases \
+                --skip graph6_for_csr_test_cases \
+                --skip graph6_for_graph_map_test_cases \
+                --skip graph6_for_graph_test_cases \
+                --skip graph6_for_matrix_graph_test_case \
+                --skip graph6_for_stable_graph_test_cases
+
+# Fmt with the same configuration as in CI
+fmt:
+    cargo fmt --all -- --check
+
+# Clippy with the same configuration as in CI
+clippy:
+    cargo clippy --all-features --lib --bins --examples --tests -- -D warnings
+
+# Checks if no-std is working same as in CI. Requires the wasm32v1-none target to be installed
+check-no-std:
+    cargo check --no-default-features -p petgraph --target wasm32v1-none --features graphmap,serde-1,stable_graph,matrix_graph,generate,unstable


### PR DESCRIPTION
This addresses the problem with CONTRIBUTING.md found in #844. 

Additionally, further details about CI actions which might be interesting to contributors were added such as miri, as well as running tests on different toolchains / rust versions.

Resolves #844