### PR TITLE
refactor: replace uses of 'crate::util::zip' with 'core::iter::zip'

### DIFF
--- a/src/csr.rs
+++ b/src/csr.rs
@@ -4,6 +4,7 @@ use alloc::{vec, vec::Vec};
 use core::{
     cmp::{max, Ordering},
     fmt,
+    iter::zip,
     iter::{Enumerate, Zip},
     marker::PhantomData,
     ops::{Index, IndexMut, Range},
@@ -15,8 +16,6 @@ use crate::visit::{
     IntoEdges, IntoNeighbors, IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable,
     NodeCount, NodeIndexable, Visitable,
 };
-
-use crate::util::zip;
 
 #[doc(no_inline)]
 pub use crate::graph::{DefaultIx, IndexType};

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,11 +6,3 @@ where
 {
     iterable.into_iter().enumerate()
 }
-
-pub fn zip<I, J>(i: I, j: J) -> iter::Zip<I::IntoIter, J::IntoIter>
-where
-    I: IntoIterator,
-    J: IntoIterator,
-{
-    i.into_iter().zip(j)
-}


### PR DESCRIPTION
The function 'zip' was introduced in #747 as a part of adding `no_std` support. However, there is already such a function in `core::iter`. The MSRV stated in the description of #747 was 1.64 at minimum, but the function in `core` is stable since Rust 1.59. Thus, it is an unnecessary duplication and can be removed without consequences.

<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->