### PR TITLE
refactor: Fix clippy (and other) lints

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -997,7 +997,7 @@ where
         &self,
         a: NodeIndex<Ix>,
         b: NodeIndex<Ix>,
-    ) -> EdgesConnecting<E, Ty, Ix> {
+    ) -> EdgesConnecting<'_, E, Ty, Ix> {
         EdgesConnecting {
             target_node: b,
             edges: self.edges_directed(a, Direction::Outgoing),
@@ -1090,7 +1090,7 @@ where
     /// just the nodes without edges.
     ///
     /// The whole iteration computes in **O(|V|)** time where V is the set of nodes.
-    pub fn externals(&self, dir: Direction) -> Externals<N, Ty, Ix> {
+    pub fn externals(&self, dir: Direction) -> Externals<'_, N, Ty, Ix> {
         Externals {
             iter: self.nodes.iter().enumerate(),
             dir,
@@ -1121,7 +1121,7 @@ where
     ///
     /// The order in which weights are yielded matches the order of their
     /// node indices.
-    pub fn node_weights_mut(&mut self) -> NodeWeightsMut<N, Ix> {
+    pub fn node_weights_mut(&mut self) -> NodeWeightsMut<'_, N, Ix> {
         NodeWeightsMut {
             nodes: self.nodes.iter_mut(),
         }
@@ -1131,7 +1131,7 @@ where
     ///
     /// The order in which weights are yielded matches the order of their
     /// node indices.
-    pub fn node_weights(&self) -> NodeWeights<N, Ix> {
+    pub fn node_weights(&self) -> NodeWeights<'_, N, Ix> {
         NodeWeights {
             nodes: self.nodes.iter(),
         }
@@ -1148,7 +1148,7 @@ where
     /// Create an iterator over all edges, in indexed order.
     ///
     /// Iterator element type is `EdgeReference<E, Ix>`.
-    pub fn edge_references(&self) -> EdgeReferences<E, Ix> {
+    pub fn edge_references(&self) -> EdgeReferences<'_, E, Ix> {
         EdgeReferences {
             iter: self.edges.iter().enumerate(),
         }
@@ -1158,7 +1158,7 @@ where
     ///
     /// The order in which weights are yielded matches the order of their
     /// edge indices.
-    pub fn edge_weights(&self) -> EdgeWeights<E, Ix> {
+    pub fn edge_weights(&self) -> EdgeWeights<'_, E, Ix> {
         EdgeWeights {
             edges: self.edges.iter(),
         }
@@ -1167,7 +1167,7 @@ where
     ///
     /// The order in which weights are yielded matches the order of their
     /// edge indices.
-    pub fn edge_weights_mut(&mut self) -> EdgeWeightsMut<E, Ix> {
+    pub fn edge_weights_mut(&mut self) -> EdgeWeightsMut<'_, E, Ix> {
         EdgeWeightsMut {
             edges: self.edges.iter_mut(),
         }
@@ -1701,7 +1701,7 @@ fn edges_walker_mut<E, Ix>(
     edges: &mut [Edge<E, Ix>],
     next: EdgeIndex<Ix>,
     dir: Direction,
-) -> EdgesWalkerMut<E, Ix>
+) -> EdgesWalkerMut<'_, E, Ix>
 where
     Ix: IndexType,
 {

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -680,7 +680,7 @@ where
     }
 
     /// Return an iterator over the node indices of the graph
-    pub fn node_indices(&self) -> NodeIndices<N, Ix> {
+    pub fn node_indices(&self) -> NodeIndices<'_, N, Ix> {
         NodeIndices {
             iter: enumerate(self.raw_nodes()),
         }
@@ -737,7 +737,7 @@ where
     ///
     /// Note: the iterator borrows a graph in contrast to the behavior of
     /// [`Graph::edge_indices`](fn@crate::Graph::edge_indices).
-    pub fn edge_indices(&self) -> EdgeIndices<E, Ix> {
+    pub fn edge_indices(&self) -> EdgeIndices<'_, E, Ix> {
         EdgeIndices {
             iter: enumerate(self.raw_edges()),
         }
@@ -753,10 +753,10 @@ where
         &self,
         a: NodeIndex<Ix>,
         b: NodeIndex<Ix>,
-    ) -> EdgesConnecting<E, Ty, Ix> {
+    ) -> EdgesConnecting<'_, E, Ty, Ix> {
         EdgesConnecting {
             target_node: b,
-            edges: self.edges_directed(a, Direction::Outgoing),
+            edges: self.edges_directed(a, Outgoing),
             ty: PhantomData,
         }
     }
@@ -814,7 +814,7 @@ where
     /// not borrow from the graph.
     ///
     /// [1]: struct.Neighbors.html#method.detach
-    pub fn neighbors(&self, a: NodeIndex<Ix>) -> Neighbors<E, Ix> {
+    pub fn neighbors(&self, a: NodeIndex<Ix>) -> Neighbors<'_, E, Ix> {
         self.neighbors_directed(a, Outgoing)
     }
 
@@ -833,7 +833,7 @@ where
     /// not borrow from the graph.
     ///
     /// [1]: struct.Neighbors.html#method.detach
-    pub fn neighbors_directed(&self, a: NodeIndex<Ix>, dir: Direction) -> Neighbors<E, Ix> {
+    pub fn neighbors_directed(&self, a: NodeIndex<Ix>, dir: Direction) -> Neighbors<'_, E, Ix> {
         let mut iter = self.neighbors_undirected(a);
         if self.is_directed() {
             let k = dir.index();
@@ -856,7 +856,7 @@ where
     /// not borrow from the graph.
     ///
     /// [1]: struct.Neighbors.html#method.detach
-    pub fn neighbors_undirected(&self, a: NodeIndex<Ix>) -> Neighbors<E, Ix> {
+    pub fn neighbors_undirected(&self, a: NodeIndex<Ix>) -> Neighbors<'_, E, Ix> {
         Neighbors {
             skip_start: a,
             edges: &self.g.edges,
@@ -874,7 +874,7 @@ where
     ///
     /// Produces an empty iterator if the node doesn't exist.<br>
     /// Iterator element type is `EdgeReference<E, Ix>`.
-    pub fn edges(&self, a: NodeIndex<Ix>) -> Edges<E, Ty, Ix> {
+    pub fn edges(&self, a: NodeIndex<Ix>) -> Edges<'_, E, Ty, Ix> {
         self.edges_directed(a, Outgoing)
     }
 
@@ -889,7 +889,7 @@ where
     ///
     /// Produces an empty iterator if the node `a` doesn't exist.<br>
     /// Iterator element type is `EdgeReference<E, Ix>`.
-    pub fn edges_directed(&self, a: NodeIndex<Ix>, dir: Direction) -> Edges<E, Ty, Ix> {
+    pub fn edges_directed(&self, a: NodeIndex<Ix>, dir: Direction) -> Edges<'_, E, Ty, Ix> {
         Edges {
             skip_start: a,
             edges: &self.g.edges,
@@ -913,7 +913,7 @@ where
     /// just the nodes without edges.
     ///
     /// The whole iteration computes in **O(|V|)** time where V is the set of nodes.
-    pub fn externals(&self, dir: Direction) -> Externals<N, Ty, Ix> {
+    pub fn externals(&self, dir: Direction) -> Externals<'_, N, Ty, Ix> {
         Externals {
             iter: self.raw_nodes().iter().enumerate(),
             dir,

--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -460,7 +460,7 @@ where
     ///
     /// Produces an empty iterator if the node doesn't exist.<br>
     /// Iterator element type is `N`.
-    pub fn neighbors(&self, a: N) -> Neighbors<N, Ty> {
+    pub fn neighbors(&self, a: N) -> Neighbors<'_, N, Ty> {
         Neighbors {
             iter: match self.nodes.get(&a) {
                 Some(neigh) => neigh.iter(),
@@ -480,7 +480,7 @@ where
     ///
     /// Produces an empty iterator if the node doesn't exist.<br>
     /// Iterator element type is `N`.
-    pub fn neighbors_directed(&self, a: N, dir: Direction) -> NeighborsDirected<N, Ty> {
+    pub fn neighbors_directed(&self, a: N, dir: Direction) -> NeighborsDirected<'_, N, Ty> {
         NeighborsDirected {
             iter: match self.nodes.get(&a) {
                 Some(neigh) => neigh.iter(),
@@ -500,7 +500,7 @@ where
     ///
     /// Produces an empty iterator if the node doesn't exist.<br>
     /// Iterator element type is `(N, N, &E)`.
-    pub fn edges(&self, a: N) -> Edges<N, E, Ty, S> {
+    pub fn edges(&self, a: N) -> Edges<'_, N, E, Ty, S> {
         Edges {
             from: a,
             iter: self.neighbors(a),
@@ -520,7 +520,7 @@ where
     ///
     /// Produces an empty iterator if the node doesn't exist.<br>
     /// Iterator element type is `(N, N, &E)`.
-    pub fn edges_directed(&self, a: N, dir: Direction) -> EdgesDirected<N, E, Ty, S> {
+    pub fn edges_directed(&self, a: N, dir: Direction) -> EdgesDirected<'_, N, E, Ty, S> {
         EdgesDirected {
             from: a,
             iter: self.neighbors_directed(a, dir),
@@ -544,7 +544,7 @@ where
     /// Return an iterator over all edges of the graph with their weight in arbitrary order.
     ///
     /// Iterator element type is `(N, N, &E)`
-    pub fn all_edges(&self) -> AllEdges<N, E, Ty> {
+    pub fn all_edges(&self) -> AllEdges<'_, N, E, Ty> {
         AllEdges {
             inner: self.edges.iter(),
             ty: self.ty,
@@ -555,7 +555,7 @@ where
     /// to their weight.
     ///
     /// Iterator element type is `(N, N, &mut E)`
-    pub fn all_edges_mut(&mut self) -> AllEdgesMut<N, E, Ty> {
+    pub fn all_edges_mut(&mut self) -> AllEdgesMut<'_, N, E, Ty> {
         AllEdgesMut {
             inner: self.edges.iter_mut(),
             ty: self.ty,
@@ -567,7 +567,7 @@ where
     ///
     /// Iterator element type is `(N, N, &E)`
     #[cfg(feature = "rayon")]
-    pub fn par_all_edges(&self) -> ParAllEdges<N, E, Ty>
+    pub fn par_all_edges(&self) -> ParAllEdges<'_, N, E, Ty>
     where
         N: Send + Sync,
         E: Sync,
@@ -583,7 +583,7 @@ where
     ///
     /// Iterator element type is `(N, N, &mut E)`
     #[cfg(feature = "rayon")]
-    pub fn par_all_edges_mut(&mut self) -> ParAllEdgesMut<N, E, Ty>
+    pub fn par_all_edges_mut(&mut self) -> ParAllEdgesMut<'_, N, E, Ty>
     where
         N: Send + Sync,
         E: Send,

--- a/src/iter_format.rs
+++ b/src/iter_format.rs
@@ -44,7 +44,7 @@ pub struct Format<'a, I> {
 }
 
 pub trait IterFormatExt: Iterator {
-    fn format(self, separator: &str) -> Format<Self>
+    fn format(self, separator: &str) -> Format<'_, Self>
     where
         Self: Sized,
     {

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -243,8 +243,8 @@ impl fmt::Display for MatrixError {
 pub struct MatrixGraph<
     N,
     E,
-    #[cfg(feature = "std")] S = RandomState,
     #[cfg(not(feature = "std"))] S,
+    #[cfg(feature = "std")] S = RandomState,
     Ty = Directed,
     Null: Nullable<Wrapped = E> = Option<E>,
     Ix = DefaultIx,
@@ -627,7 +627,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     ///
     /// Produces an empty iterator if the node doesn't exist.<br>
     /// Iterator element type is [`NodeIndex<Ix>`](../graph/struct.NodeIndex.html).
-    pub fn neighbors(&self, a: NodeIndex<Ix>) -> Neighbors<Ty, Null, Ix> {
+    pub fn neighbors(&self, a: NodeIndex<Ix>) -> Neighbors<'_, Ty, Null, Ix> {
         Neighbors(Edges::on_columns(
             a.index(),
             &self.node_adjacencies,
@@ -642,7 +642,7 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
     ///
     /// Produces an empty iterator if the node doesn't exist.<br>
     /// Iterator element type is `(NodeIndex<Ix>, NodeIndex<Ix>, &E)`.
-    pub fn edges(&self, a: NodeIndex<Ix>) -> Edges<Ty, Null, Ix> {
+    pub fn edges(&self, a: NodeIndex<Ix>) -> Edges<'_, Ty, Null, Ix> {
         Edges::on_columns(a.index(), &self.node_adjacencies, self.node_capacity)
     }
 
@@ -728,7 +728,7 @@ impl<N, E, S: BuildHasher, Null: Nullable<Wrapped = E>, Ix: IndexType>
         &self,
         a: NodeIndex<Ix>,
         d: Direction,
-    ) -> Neighbors<Directed, Null, Ix> {
+    ) -> Neighbors<'_, Directed, Null, Ix> {
         if d == Outgoing {
             self.neighbors(a)
         } else {
@@ -747,7 +747,7 @@ impl<N, E, S: BuildHasher, Null: Nullable<Wrapped = E>, Ix: IndexType>
     ///
     /// Produces an empty iterator if the node `a` doesn't exist.<br>
     /// Iterator element type is `(NodeIndex<Ix>, NodeIndex<Ix>, &E)`.
-    pub fn edges_directed(&self, a: NodeIndex<Ix>, d: Direction) -> Edges<Directed, Null, Ix> {
+    pub fn edges_directed(&self, a: NodeIndex<Ix>, d: Direction) -> Edges<'_, Directed, Null, Ix> {
         if d == Outgoing {
             self.edges(a)
         } else {
@@ -1155,7 +1155,7 @@ impl<T, S: BuildHasher> IdStorage<T, S> {
         self.upper_bound - self.removed_ids.len()
     }
 
-    fn iter_ids(&self) -> IdIterator<S> {
+    fn iter_ids(&self) -> IdIterator<'_, S> {
         IdIterator {
             upper_bound: self.upper_bound,
             removed_ids: &self.removed_ids,

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -261,8 +261,8 @@ pub struct MatrixGraph<
 pub type DiMatrix<
     N,
     E,
-    #[cfg(feature = "std")] S = RandomState,
     #[cfg(not(feature = "std"))] S,
+    #[cfg(feature = "std")] S = RandomState,
     Null = Option<E>,
     Ix = DefaultIx,
 > = MatrixGraph<N, E, S, Directed, Null, Ix>;
@@ -271,8 +271,8 @@ pub type DiMatrix<
 pub type UnMatrix<
     N,
     E,
-    #[cfg(feature = "std")] S = RandomState,
     #[cfg(not(feature = "std"))] S,
+    #[cfg(feature = "std")] S = RandomState,
     Null = Option<E>,
     Ix = DefaultIx,
 > = MatrixGraph<N, E, S, Undirected, Null, Ix>;
@@ -766,8 +766,8 @@ impl<N, E, S: BuildHasher, Null: Nullable<Wrapped = E>, Ix: IndexType>
 pub struct NodeIdentifiers<
     'a,
     Ix,
-    #[cfg(feature = "std")] S = RandomState,
     #[cfg(not(feature = "std"))] S,
+    #[cfg(feature = "std")] S = RandomState,
 > {
     iter: IdIterator<'a, S>,
     ix: PhantomData<Ix>,
@@ -804,8 +804,8 @@ pub struct NodeReferences<
     'a,
     N: 'a,
     Ix,
-    #[cfg(feature = "std")] S = RandomState,
     #[cfg(not(feature = "std"))] S,
+    #[cfg(feature = "std")] S = RandomState,
 > {
     nodes: &'a IdStorage<N, S>,
     iter: IdIterator<'a, S>,
@@ -1102,7 +1102,7 @@ fn ensure_len<T: Default>(v: &mut Vec<T>, size: usize) {
 }
 
 #[derive(Debug, Clone)]
-struct IdStorage<T, #[cfg(feature = "std")] S = RandomState, #[cfg(not(feature = "std"))] S> {
+struct IdStorage<T, #[cfg(not(feature = "std"))] S, #[cfg(feature = "std")] S = RandomState> {
     elements: Vec<Option<T>>,
     upper_bound: usize,
     removed_ids: IndexSet<usize, S>,


### PR DESCRIPTION
This PR fixes some clippy lints about lifetime annotations which occur when running clippy like it is run in CI using the nightly toolchain.

More precisely, when running:
```bash
cargo clippy --all-features --lib --bins --examples --tests -- -D warnings
```
or alternatively `just clippy` when #845 is merged, one gets multiple warnings (Errors because of `-D warnings`) of the following sort:
```bash
error: lifetime flowing from input to output with different syntax can be confusing
   --> src/adj.rs:314:25
    |
314 |     pub fn edge_indices(&self) -> EdgeIndices<E, Ix> {
    |                         ^^^^^     ------------------ the lifetime gets resolved as '_
    |                         |
    |                         this lifetime flows to the output
    |
    = note: -D mismatched-lifetime-syntaxes implied by -D warnings
    = help: to override -D warnings add #[allow(mismatched_lifetime_syntaxes)]
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
314 |     pub fn edge_indices(&self) -> EdgeIndices<'_, E, Ix> {
    |                                               +++
```

This PR fixes these lints by exactly adding an anonymous lifetime to the return types and thus making the lifetime flow more explicit. Furthermore, a tiny change in the order of `std` and `no-std` generic parameters in `matrix_graph.rs` is made to make RustRover lints happy.