### PR TITLE
docs: Update `GraphMap` link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ use petgraph::dot::{Dot, Config};
 use petgraph::visit::NodeIndexable;
 
 fn main() {
-    // Create an undirected graph with associated data 
+    // Create an undirected graph with associated data
     // of type `i32` for the nodes and `()` for the edges.
     let g = UnGraph::<i32, ()>::from_edges(&[
         (0, 1), (1, 2), (2, 3), (0, 3)
@@ -161,7 +161,7 @@ terms.
 
 [docsrs-examples]: https://docs.rs/petgraph/latest/petgraph/index.html#examples
 
-[docsrs-graph-map]: https://docs.rs/petgraph/latest/petgraph/stable_graph/struct.StableGraph.html
+[docsrs-graph-map]: https://docs.rs/petgraph/latest/petgraph/graphmap/struct.GraphMap.html
 
 [docsrs-matrix-graph]: https://docs.rs/petgraph/latest/petgraph/matrix_graph/struct.MatrixGraph.html
 


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->
Making a small change here as I noticed that the link to `GraphMap` points to `StableGraph` instead, while reading through the docs.