### PR TITLE
perf!: Maximal cliques with bitmaps

### DIFF
--- a/tests/maximal_cliques.rs
+++ b/tests/maximal_cliques.rs
@@ -163,7 +163,6 @@ fn test_maximal_cliques_directed_sparse_graph() {
     let cliques = maximal_cliques(&g);
 
     let expected_cliques = vec![vec![a, b], vec![c], vec![d]];
-    println!("{:?}", &cliques);
     assert_eq!(expected_cliques.len(), cliques.len());
 
     for v in expected_cliques {


### PR DESCRIPTION
This PR addresses the performance improvement suggestion from #755. In particular, `FixedBitSet`s are used (when it makes sense) instead of `HashMap`s to speed up performance. The performance increase seems to be significant enough in my opinion.

BREAKING CHANGE:

We introduce the additonal bound `NodeIndexable` on provided graphs for the `maximal_cliques` algo. This is implemented by all graphs types provided by petgraph and simply allows to convert between `NodeId` and `usize` indexes to be able to use `FixedBitMap` as a performance optimization.

## Performance Comparison

Old:
```bash
running 4 tests
test maximal_cliques_fan_100_bench ... bench:      76,259.80 ns/iter (+/- 4,042.91)
test maximal_cliques_fan_10_bench  ... bench:       5,349.75 ns/iter (+/- 201.43)
test maximal_cliques_fan_200_bench ... bench:     197,757.93 ns/iter (+/- 23,968.19)
test maximal_cliques_fan_50_bench  ... bench:      32,230.14 ns/iter (+/- 2,523.89)
```

New:
```bash
running 4 tests
test maximal_cliques_fan_100_bench ... bench:      52,831.39 ns/iter (+/- 2,484.60)
test maximal_cliques_fan_10_bench  ... bench:       3,525.59 ns/iter (+/- 273.42)
test maximal_cliques_fan_200_bench ... bench:     139,948.69 ns/iter (+/- 12,517.60)
test maximal_cliques_fan_50_bench  ... bench:      20,918.74 ns/iter (+/- 1,263.94)
```

Ran on Intel Core i7-4770.