### PR TITLE
feat: make Csr::from_sorted_edges generic over edge type and properly increase edge_count in Csr::from_sorted_edges

### DIFF
--- a/src/csr.rs
+++ b/src/csr.rs
@@ -263,13 +263,7 @@ where
 
         Ok(self_)
     }
-}
 
-impl<N, E, Ty, Ix> Csr<N, E, Ty, Ix>
-where
-    Ty: EdgeType,
-    Ix: IndexType,
-{
     pub fn node_count(&self) -> usize {
         self.row.len() - 1
     }


### PR DESCRIPTION
This PR continues the work done in #783. Thus, this resolves #588.

The trait bound on the `Csr` to be `Directed` for `from_sorted_edges` was lifted. Thus, it was noticed that at no point in `from_sorted_edges`, the `edge_count` is increased. This is only relevant for `Undirected` graphs, as `Directed` graphs use their `self.column.len()` as the `edge_count()` under the hood.