### PR TITLE
feat: Add `map_owned` and `filter_map_owned` for `Graph` and `StableGraph`

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1506,7 +1506,11 @@ where
     /// as `self`.
     ///
     /// If you want a non-consuming version of this function, see [`map`](struct.Graph.html#method.map).
-    pub fn map_owned<F, G, N2, E2>(self, mut node_map: F, mut edge_map: G) -> Graph<N2, E2, Ty, Ix>
+    pub fn map_owned<F, G, N2, E2>(
+        mut self,
+        mut node_map: F,
+        mut edge_map: G,
+    ) -> Graph<N2, E2, Ty, Ix>
     where
         F: FnMut(NodeIndex<Ix>, N) -> N2,
         G: FnMut(EdgeIndex<Ix>, E) -> E2,

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1475,6 +1475,8 @@ where
     ///
     /// The resulting graph has the same structure and the same
     /// graph indices as `self`.
+    ///
+    /// If you want a consuming version of this function, see [`map_owned`](struct.Graph.html#method.map_owned).
     pub fn map<'a, F, G, N2, E2>(
         &'a self,
         mut node_map: F,
@@ -1503,7 +1505,7 @@ where
     /// The resulting graph has the same structure and the same graph indices
     /// as `self`.
     ///
-    /// If you want a non-destructive version of this function, see `map`.
+    /// If you want a non-consuming version of this function, see [`map`](struct.Graph.html#method.map).
     pub fn map_owned<F, G, N2, E2>(self, mut node_map: F, mut edge_map: G) -> Graph<N2, E2, Ty, Ix>
     where
         F: FnMut(NodeIndex<Ix>, N) -> N2,
@@ -1534,6 +1536,8 @@ where
     /// If no nodes are removed, the resulting graph has compatible node
     /// indices; if neither nodes nor edges are removed, the result has
     /// the same graph indices as `self`.
+    ///
+    /// If you want a consuming version of this function, see [`filter_map_owned`](struct.Graph.html#method.filter_map_owned).
     pub fn filter_map<'a, F, G, N2, E2>(
         &'a self,
         mut node_map: F,
@@ -1557,6 +1561,51 @@ where
             let target = node_index_map[edge.target().index()];
             if source != NodeIndex::end() && target != NodeIndex::end() {
                 if let Some(ew) = edge_map(EdgeIndex::new(i), &edge.weight) {
+                    g.add_edge(source, target, ew);
+                }
+            }
+        }
+        g
+    }
+
+    /// Create a new `Graph` by mapping nodes and edges,
+    /// consuming the current graph.
+    /// A node or edge may be mapped to `None` to exclude it from
+    /// the resulting graph.
+    ///
+    /// Nodes are mapped first with the `node_map` closure, then
+    /// `edge_map` is called for the edges that have not had any endpoint
+    /// removed.
+    ///
+    /// The resulting graph has the structure of a subgraph of the original graph.
+    /// If no nodes are removed, the resulting graph has compatible node
+    /// indices; if neither nodes nor edges are removed, the result has
+    /// the same graph indices as `self`.
+    ///
+    /// If you want a non-consuming version of this function, see [`filter_map`](struct.Graph.html#method.filter_map).
+    pub fn filter_map_owned<F, G, N2, E2>(
+        self,
+        mut node_map: F,
+        mut edge_map: G,
+    ) -> Graph<N2, E2, Ty, Ix>
+    where
+        F: FnMut(NodeIndex<Ix>, N) -> Option<N2>,
+        G: FnMut(EdgeIndex<Ix>, E) -> Option<E2>,
+    {
+        let mut g = Graph::with_capacity(0, 0);
+        // mapping from old node index to new node index, end represents removed.
+        let mut node_index_map = vec![NodeIndex::end(); self.node_count()];
+        for (i, node) in enumerate(self.nodes) {
+            if let Some(nw) = node_map(NodeIndex::new(i), node.weight) {
+                node_index_map[i] = g.add_node(nw);
+            }
+        }
+        for (i, edge) in enumerate(self.edges) {
+            // skip edge if any endpoint was removed
+            let source = node_index_map[edge.source().index()];
+            let target = node_index_map[edge.target().index()];
+            if source != NodeIndex::end() && target != NodeIndex::end() {
+                if let Some(ew) = edge_map(EdgeIndex::new(i), edge.weight) {
                     g.add_edge(source, target, ew);
                 }
             }

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1497,6 +1497,31 @@ where
         g
     }
 
+    /// Create a new `Graph` by mapping node and edge weights to new values,
+    /// consuming the current graph.
+    ///
+    /// The resulting graph has the same structure and the same graph indices
+    /// as `self`.
+    ///
+    /// If you want a non-destructive version of this function, see `map`.
+    pub fn map_owned<F, G, N2, E2>(self, mut node_map: F, mut edge_map: G) -> Graph<N2, E2, Ty, Ix>
+    where
+        F: FnMut(NodeIndex<Ix>, N) -> N2,
+        G: FnMut(EdgeIndex<Ix>, E) -> E2,
+    {
+        let mut g = Graph::with_capacity(self.node_count(), self.edge_count());
+        g.nodes.extend(enumerate(self.nodes).map(|(i, node)| Node {
+            weight: node_map(NodeIndex::new(i), node.weight),
+            next: node.next,
+        }));
+        g.edges.extend(enumerate(self.edges).map(|(i, edge)| Edge {
+            weight: edge_map(EdgeIndex::new(i), edge.weight),
+            next: edge.next,
+            node: edge.node,
+        }));
+        g
+    }
+
     /// Create a new `Graph` by mapping nodes and edges.
     /// A node or edge may be mapped to `None` to exclude it from
     /// the resulting graph.

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1506,11 +1506,7 @@ where
     /// as `self`.
     ///
     /// If you want a non-consuming version of this function, see [`map`](struct.Graph.html#method.map).
-    pub fn map_owned<F, G, N2, E2>(
-        mut self,
-        mut node_map: F,
-        mut edge_map: G,
-    ) -> Graph<N2, E2, Ty, Ix>
+    pub fn map_owned<F, G, N2, E2>(self, mut node_map: F, mut edge_map: G) -> Graph<N2, E2, Ty, Ix>
     where
         F: FnMut(NodeIndex<Ix>, N) -> N2,
         G: FnMut(EdgeIndex<Ix>, E) -> E2,

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -1069,6 +1069,8 @@ where
     ///
     /// The resulting graph has the same structure and the same
     /// graph indices as `self`.
+    ///
+    /// If you want a consuming version of this function, see [`map_owned`](struct.StableGraph.html#method.map_owned).
     pub fn map<'a, F, G, N2, E2>(
         &'a self,
         mut node_map: F,
@@ -1091,6 +1093,35 @@ where
         }
     }
 
+    /// Create a new `StableGraph` by mapping node and
+    /// edge weights to new values, consuming the current graph.
+    ///
+    /// The resulting graph has the same structure and the same
+    /// graph indices as `self`.
+    ///
+    /// If you want a non-consuming version of this function, see [`map`](struct.StableGraph.html#method.map).
+    pub fn map_owned<F, G, N2, E2>(
+        self,
+        mut node_map: F,
+        mut edge_map: G,
+    ) -> StableGraph<N2, E2, Ty, Ix>
+    where
+        F: FnMut(NodeIndex<Ix>, N) -> N2,
+        G: FnMut(EdgeIndex<Ix>, E) -> E2,
+    {
+        let g = self.g.map_owned(
+            move |i, w| w.map(|w| node_map(i, w)),
+            move |i, w| w.map(|w| edge_map(i, w)),
+        );
+        StableGraph {
+            g,
+            node_count: self.node_count,
+            edge_count: self.edge_count,
+            free_node: self.free_node,
+            free_edge: self.free_edge,
+        }
+    }
+
     /// Create a new `StableGraph` by mapping nodes and edges.
     /// A node or edge may be mapped to `None` to exclude it from
     /// the resulting graph.
@@ -1102,6 +1133,8 @@ where
     /// The resulting graph has the structure of a subgraph of the original graph.
     /// Nodes and edges that are not removed maintain their old node or edge
     /// indices.
+    ///
+    /// If you want a consuming version of this function, see [`filter_map_owned`](struct.StableGraph.html#method.filter_map_owned).
     pub fn filter_map<'a, F, G, N2, E2>(
         &'a self,
         mut node_map: F,
@@ -1140,6 +1173,74 @@ where
             let source = edge.source();
             let target = edge.target();
             if let Some(edge_weight) = edge.weight.as_ref() {
+                if result_g.contains_node(source) && result_g.contains_node(target) {
+                    if let Some(new_weight) = edge_map(EdgeIndex::new(i), edge_weight) {
+                        result_g.add_edge(source, target, new_weight);
+                        continue;
+                    }
+                }
+            }
+            result_g.add_vacant_edge(&mut free_edge);
+        }
+        result_g.free_node = free_node;
+        result_g.free_edge = free_edge;
+        result_g.check_free_lists();
+        result_g
+    }
+
+    /// Create a new `StableGraph` by mapping nodes and edges, consuming the current graph.
+    /// A node or edge may be mapped to `None` to exclude it from
+    /// the resulting graph.
+    ///
+    /// Nodes are mapped first with the `node_map` closure, then
+    /// `edge_map` is called for the edges that have not had any endpoint
+    /// removed.
+    ///
+    /// The resulting graph has the structure of a subgraph of the original graph.
+    /// Nodes and edges that are not removed maintain their old node or edge
+    /// indices.
+    ///
+    /// If you want a non-consuming version of this function, see [`filter_map`](struct.StableGraph.html#method.filter_map).
+    pub fn filter_map_owned<F, G, N2, E2>(
+        self,
+        mut node_map: F,
+        mut edge_map: G,
+    ) -> StableGraph<N2, E2, Ty, Ix>
+    where
+        F: FnMut(NodeIndex<Ix>, N) -> Option<N2>,
+        G: FnMut(EdgeIndex<Ix>, E) -> Option<E2>,
+    {
+        let node_bound = self.node_bound();
+        let edge_bound = self.edge_bound();
+        let mut result_g = StableGraph::with_capacity(node_bound, edge_bound);
+        // use separate free lists so that
+        // add_node / add_edge below do not reuse the tombstones
+        let mut free_node = NodeIndex::end();
+        let mut free_edge = EdgeIndex::end();
+
+        // the stable graph keeps the node map itself
+
+        let (nodes, edges) = self.g.into_nodes_edges();
+
+        for (i, node) in enumerate(nodes) {
+            if i >= node_bound {
+                break;
+            }
+            if let Some(node_weight) = node.weight {
+                if let Some(new_weight) = node_map(NodeIndex::new(i), node_weight) {
+                    result_g.add_node(new_weight);
+                    continue;
+                }
+            }
+            result_g.add_vacant_node(&mut free_node);
+        }
+        for (i, edge) in enumerate(edges) {
+            if i >= edge_bound {
+                break;
+            }
+            let source = edge.source();
+            let target = edge.target();
+            if let Some(edge_weight) = edge.weight {
                 if result_g.contains_node(source) && result_g.contains_node(target) {
                     if let Some(new_weight) = edge_map(EdgeIndex::new(i), edge_weight) {
                         result_g.add_edge(source, target, new_weight);

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1598,31 +1598,19 @@ fn map_map_owned() {
     let a = g.add_node("A");
     let b = g.add_node("B");
     let c = g.add_node("C");
-    let d = g.add_node("D");
-    let e = g.add_node("E");
-    let f = g.add_node("F");
     let ab = g.add_edge(a, b, 7);
+    let bc = g.add_edge(b, c, 14);
     let ca = g.add_edge(c, a, 9);
-    let ad = g.add_edge(a, d, 14);
-    let bc = g.add_edge(b, c, 10);
-    let dc = g.add_edge(d, c, 2);
-    let de = g.add_edge(d, e, 9);
-    let bf = g.add_edge(b, f, 15);
-    let cf = g.add_edge(c, f, 11);
-    let ef = g.add_edge(e, f, 6);
-    println!("{:?}", g);
 
     let g2 = g.map_owned(|_, name| format!("map-{name}"), |_, weight| weight * 2);
-    assert_eq!(g2.edge_count(), 9);
+    assert_eq!(g2.node_count(), 3);
+    assert_eq!(g2.node_weight(a).map(|s| &**s), Some("map-A"));
+    assert_eq!(g2.node_weight(b).map(|s| &**s), Some("map-B"));
+    assert_eq!(g2.node_weight(c).map(|s| &**s), Some("map-C"));
+    assert_eq!(g2.edge_count(), 3);
     assert_eq!(g2.edge_weight(ab), Some(&14));
+    assert_eq!(g2.edge_weight(bc), Some(&28));
     assert_eq!(g2.edge_weight(ca), Some(&18));
-    assert_eq!(g2.edge_weight(ad), Some(&28));
-    assert_eq!(g2.edge_weight(bc), Some(&20));
-    assert_eq!(g2.edge_weight(dc), Some(&4));
-    assert_eq!(g2.edge_weight(de), Some(&18));
-    assert_eq!(g2.edge_weight(bf), Some(&30));
-    assert_eq!(g2.edge_weight(cf), Some(&22));
-    assert_eq!(g2.edge_weight(ef), Some(&12));
 }
 
 #[test]

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1593,7 +1593,28 @@ fn test_has_path() {
 }
 
 #[test]
-fn map_map_owned() {
+fn test_map() {
+    let mut g = Graph::new_undirected();
+    let a = g.add_node("A");
+    let b = g.add_node("B");
+    let c = g.add_node("C");
+    let ab = g.add_edge(a, b, 7);
+    let bc = g.add_edge(b, c, 14);
+    let ca = g.add_edge(c, a, 9);
+
+    let g2 = g.map(|_, name| format!("map-{name}"), |_, weight| weight * 2);
+    assert_eq!(g2.node_count(), 3);
+    assert_eq!(g2.node_weight(a).map(|s| &**s), Some("map-A"));
+    assert_eq!(g2.node_weight(b).map(|s| &**s), Some("map-B"));
+    assert_eq!(g2.node_weight(c).map(|s| &**s), Some("map-C"));
+    assert_eq!(g2.edge_count(), 3);
+    assert_eq!(g2.edge_weight(ab), Some(&14));
+    assert_eq!(g2.edge_weight(bc), Some(&28));
+    assert_eq!(g2.edge_weight(ca), Some(&18));
+}
+
+#[test]
+fn test_map_owned() {
     let mut g = Graph::new_undirected();
     let a = g.add_node("A");
     let b = g.add_node("B");
@@ -1614,7 +1635,7 @@ fn map_map_owned() {
 }
 
 #[test]
-fn map_filter_map() {
+fn test_filter_map() {
     let mut g = Graph::new_undirected();
     let a = g.add_node("A");
     let b = g.add_node("B");
@@ -1645,6 +1666,60 @@ fn map_filter_map() {
     let g3 = g.filter_map(
         |i, &name| if i == a || i == e { None } else { Some(name) },
         |i, &weight| {
+            let (source, target) = g.edge_endpoints(i).unwrap();
+            // don't map edges from a removed node
+            assert!(source != a);
+            assert!(target != a);
+            assert!(source != e);
+            assert!(target != e);
+            Some(weight)
+        },
+    );
+    assert_eq!(g3.node_count(), g.node_count() - 2);
+    assert_eq!(g3.edge_count(), g.edge_count() - 5);
+    assert_graph_consistent(&g3);
+
+    let mut g4 = g.clone();
+    g4.retain_edges(|gr, i| {
+        let (s, t) = gr.edge_endpoints(i).unwrap();
+        !(s == a || s == e || t == a || t == e)
+    });
+    assert_eq!(g4.edge_count(), g.edge_count() - 5);
+    assert_graph_consistent(&g4);
+}
+
+#[test]
+fn test_filter_map_owned() {
+    let mut g = Graph::new_undirected();
+    let a = g.add_node("A".to_owned());
+    let b = g.add_node("B".to_owned());
+    let c = g.add_node("C".to_owned());
+    let d = g.add_node("D".to_owned());
+    let e = g.add_node("E".to_owned());
+    let f = g.add_node("F".to_owned());
+    g.add_edge(a, b, 7);
+    g.add_edge(c, a, 9);
+    g.add_edge(a, d, 14);
+    g.add_edge(b, c, 10);
+    g.add_edge(d, c, 2);
+    g.add_edge(d, e, 9);
+    g.add_edge(b, f, 15);
+    g.add_edge(c, f, 11);
+    g.add_edge(e, f, 6);
+    println!("{g:?}");
+
+    let g2 = g.clone().filter_map_owned(
+        |_, name| Some(name),
+        |_, weight| if weight >= 10 { Some(weight) } else { None },
+    );
+    assert_eq!(g2.edge_count(), 4);
+    for edge in g2.raw_edges() {
+        assert!(edge.weight >= 10);
+    }
+
+    let g3 = g.clone().filter_map_owned(
+        |i, name| if i == a || i == e { None } else { Some(name) },
+        |i, weight| {
             let (source, target) = g.edge_endpoints(i).unwrap();
             // don't map edges from a removed node
             assert!(source != a);

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1593,6 +1593,39 @@ fn test_has_path() {
 }
 
 #[test]
+fn map_map_owned() {
+    let mut g = Graph::new_undirected();
+    let a = g.add_node("A");
+    let b = g.add_node("B");
+    let c = g.add_node("C");
+    let d = g.add_node("D");
+    let e = g.add_node("E");
+    let f = g.add_node("F");
+    let ab = g.add_edge(a, b, 7);
+    let ca = g.add_edge(c, a, 9);
+    let ad = g.add_edge(a, d, 14);
+    let bc = g.add_edge(b, c, 10);
+    let dc = g.add_edge(d, c, 2);
+    let de = g.add_edge(d, e, 9);
+    let bf = g.add_edge(b, f, 15);
+    let cf = g.add_edge(c, f, 11);
+    let ef = g.add_edge(e, f, 6);
+    println!("{:?}", g);
+
+    let g2 = g.map_owned(|_, name| format!("map-{name}"), |_, weight| weight * 2);
+    assert_eq!(g2.edge_count(), 9);
+    assert_eq!(g2.edge_weight(ab), Some(&14));
+    assert_eq!(g2.edge_weight(ca), Some(&18));
+    assert_eq!(g2.edge_weight(ad), Some(&28));
+    assert_eq!(g2.edge_weight(bc), Some(&20));
+    assert_eq!(g2.edge_weight(dc), Some(&4));
+    assert_eq!(g2.edge_weight(de), Some(&18));
+    assert_eq!(g2.edge_weight(bf), Some(&30));
+    assert_eq!(g2.edge_weight(cf), Some(&22));
+    assert_eq!(g2.edge_weight(ef), Some(&12));
+}
+
+#[test]
 fn map_filter_map() {
     let mut g = Graph::new_undirected();
     let a = g.add_node("A");

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1662,6 +1662,11 @@ fn test_filter_map() {
     for edge in g2.raw_edges() {
         assert!(edge.weight >= 10);
     }
+    assert_eq!(g2.node_count(), g.node_count());
+    // Check if node indices are compatible
+    for i in g.node_indices() {
+        assert_eq!(g2.node_weight(i), g.node_weight(i));
+    }
 
     let g3 = g.filter_map(
         |i, &name| if i == a || i == e { None } else { Some(name) },
@@ -1715,6 +1720,11 @@ fn test_filter_map_owned() {
     assert_eq!(g2.edge_count(), 4);
     for edge in g2.raw_edges() {
         assert!(edge.weight >= 10);
+    }
+    assert_eq!(g2.node_count(), g.node_count());
+    // Check if node indices are compatible
+    for i in g.node_indices() {
+        assert_eq!(g2.node_weight(i), g.node_weight(i));
     }
 
     let g3 = g.clone().filter_map_owned(

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -1722,10 +1722,10 @@ fn test_filter_map_owned() {
         |i, weight| {
             let (source, target) = g.edge_endpoints(i).unwrap();
             // don't map edges from a removed node
-            assert!(source != a);
-            assert!(target != a);
-            assert!(source != e);
-            assert!(target != e);
+            assert_ne!(source, a);
+            assert_ne!(target, a);
+            assert_ne!(source, e);
+            assert_ne!(target, e);
             Some(weight)
         },
     );

--- a/tests/stable_graph.rs
+++ b/tests/stable_graph.rs
@@ -195,6 +195,7 @@ defmac!(edges ref gr, x => gr.edges(x).map(|r| (r.target(), *r.weight())));
 
 #[test]
 fn test_edges_directed() {
+    let gr = make_graph::<Directed>();
     let x = n(9);
     assert_equal(edges!(&gr, x), vec![(x, 16), (x, 14), (n(1), 13)]);
     assert_equal(edges!(&gr, n(0)), vec![(n(3), 1)]);
@@ -209,6 +210,7 @@ fn test_edge_references() {
 
 #[test]
 fn test_edges_undirected() {
+    let gr = make_graph::<Undirected>();
     let x = n(9);
     assert_equal(
         edges!(&gr, x),
@@ -440,6 +442,9 @@ fn from() {
     assert!(edges_eq!(&gr1, &gr3));
 
     gr1.remove_node(b);
+
+    let gr4 = Graph::from(gr1);
+    let gr5 = StableGraph::from(gr4.clone());
 
     let mut ans = StableGraph::new();
     let a = ans.add_node(1);


### PR DESCRIPTION
This PR continues the work done in PR #794. Thus, it resolves #542.

It adds `map_owned` and `filter_map_owned` methods for both `Graph` and `StableGraph` which take ownership of the respective graphs and their respective associated data in comparison to the `map` and `filter_map` counterparts which only take `&` references.

Appropriate tests for this have been added. If desired, I can also add quickchecks, but this did not seem necessary.