### PR TITLE
feat: Fix self-loop bug in all_simple_paths and enable multiple targets

### DIFF
--- a/benches/simple_paths.rs
+++ b/benches/simple_paths.rs
@@ -3,59 +3,18 @@
 extern crate petgraph;
 extern crate test;
 
+mod common;
+
 use std::collections::hash_map::RandomState;
 
+use common::ungraph;
 use hashbrown::HashSet;
 use petgraph::algo::{all_simple_paths, all_simple_paths_multi};
 use petgraph::prelude::*;
 use test::Bencher;
 
 #[bench]
-fn simple_paths_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 5;
-    let mut g = Graph::new_undirected();
-    let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
-
-    // Create a complete undirected graph - every pair of nodes has an edge
-    for i in 0..NODE_COUNT {
-        for j in i + 1..NODE_COUNT {
-            g.add_edge(nodes[i], nodes[j], ());
-        }
-    }
-
-    let from = nodes[0];
-    let to = nodes[NODE_COUNT - 1];
-
-    bench.iter(|| {
-        let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
-        paths.count()
-    });
-}
-
-#[bench]
-fn simple_paths_multi_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 5;
-    let mut g = Graph::new_undirected();
-    let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
-
-    // Create a complete undirected graph - every pair of nodes has an edge
-    for i in 0..NODE_COUNT {
-        for j in i + 1..NODE_COUNT {
-            g.add_edge(nodes[i], nodes[j], ());
-        }
-    }
-
-    let from = nodes[0];
-    let to: HashSet<_, RandomState> = (1..NODE_COUNT).map(|i| nodes[i]).collect();
-
-    bench.iter(|| {
-        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
-        paths.count()
-    });
-}
-
-#[bench]
-fn simple_paths_single_target_equivalent_bench(bench: &mut Bencher) {
+fn complete_graph_single_bench(bench: &mut Bencher) {
     static NODE_COUNT: usize = 5;
     let mut g = Graph::new_undirected();
     let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
@@ -77,5 +36,111 @@ fn simple_paths_single_target_equivalent_bench(bench: &mut Bencher) {
             total_paths += paths.count();
         }
         total_paths
+    });
+}
+
+#[bench]
+fn complete_graph_multi_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 5;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
+
+    // Create a complete undirected graph - every pair of nodes has an edge
+    for i in 0..NODE_COUNT {
+        for j in i + 1..NODE_COUNT {
+            g.add_edge(nodes[i], nodes[j], ());
+        }
+    }
+
+    let from = nodes[0];
+    let to: HashSet<_, RandomState> = (1..NODE_COUNT).map(|i| nodes[i]).collect();
+
+    bench.iter(|| {
+        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        paths.count()
+    });
+}
+
+#[bench]
+fn petersen_single_bench(bench: &mut Bencher) {
+    let g = ungraph().petersen_a();
+    let from = NodeIndex::new(0);
+    let targets: Vec<_> = (1..g.node_count()).map(NodeIndex::new).collect();
+
+    bench.iter(|| {
+        let mut total_paths = 0;
+        for &to in &targets {
+            let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+            total_paths += paths.count();
+        }
+        total_paths
+    });
+}
+
+#[bench]
+fn petersen_multi_bench(bench: &mut Bencher) {
+    let g = ungraph().petersen_a();
+    let from = NodeIndex::new(0);
+    let to: HashSet<_, RandomState> = (1..g.node_count()).map(NodeIndex::new).collect();
+
+    bench.iter(|| {
+        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        paths.count()
+    });
+}
+
+#[bench]
+fn bipartite_single_bench(bench: &mut Bencher) {
+    let g = ungraph().bipartite();
+    let from = NodeIndex::new(0);
+    let targets: Vec<_> = (1..g.node_count()).map(NodeIndex::new).collect();
+
+    bench.iter(|| {
+        let mut total_paths = 0;
+        for &to in &targets {
+            let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+            total_paths += paths.count();
+        }
+        total_paths
+    });
+}
+
+#[bench]
+fn bipartite_multi_bench(bench: &mut Bencher) {
+    let g = ungraph().bipartite();
+    let from = NodeIndex::new(0);
+    let to: HashSet<_, RandomState> = (1..g.node_count()).map(NodeIndex::new).collect();
+
+    bench.iter(|| {
+        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        paths.count()
+    });
+}
+
+#[bench]
+fn full_single_bench(bench: &mut Bencher) {
+    let g = ungraph().full_a();
+    let from = NodeIndex::new(0);
+    let targets: Vec<_> = (1..g.node_count()).map(NodeIndex::new).collect();
+
+    bench.iter(|| {
+        let mut total_paths = 0;
+        for &to in &targets {
+            let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+            total_paths += paths.count();
+        }
+        total_paths
+    });
+}
+
+#[bench]
+fn full_multi_bench(bench: &mut Bencher) {
+    let g = ungraph().full_a();
+    let from = NodeIndex::new(0);
+    let to: HashSet<_, RandomState> = (1..g.node_count()).map(NodeIndex::new).collect();
+
+    bench.iter(|| {
+        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        paths.count()
     });
 }

--- a/benches/simple_paths.rs
+++ b/benches/simple_paths.rs
@@ -1,0 +1,81 @@
+#![feature(test)]
+
+extern crate petgraph;
+extern crate test;
+
+use std::collections::hash_map::RandomState;
+
+use hashbrown::HashSet;
+use petgraph::algo::{all_simple_paths, all_simple_paths_multi};
+use petgraph::prelude::*;
+use test::Bencher;
+
+#[bench]
+fn simple_paths_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 5;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
+
+    // Create a complete undirected graph - every pair of nodes has an edge
+    for i in 0..NODE_COUNT {
+        for j in i + 1..NODE_COUNT {
+            g.add_edge(nodes[i], nodes[j], ());
+        }
+    }
+
+    let from = nodes[0];
+    let to = nodes[NODE_COUNT - 1];
+
+    bench.iter(|| {
+        let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+        paths.count()
+    });
+}
+
+#[bench]
+fn simple_paths_multi_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 5;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
+
+    // Create a complete undirected graph - every pair of nodes has an edge
+    for i in 0..NODE_COUNT {
+        for j in i + 1..NODE_COUNT {
+            g.add_edge(nodes[i], nodes[j], ());
+        }
+    }
+
+    let from = nodes[0];
+    let to: HashSet<_, RandomState> = (1..NODE_COUNT).map(|i| nodes[i]).collect();
+
+    bench.iter(|| {
+        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        paths.count()
+    });
+}
+
+#[bench]
+fn simple_paths_single_target_equivalent_bench(bench: &mut Bencher) {
+    static NODE_COUNT: usize = 5;
+    let mut g = Graph::new_undirected();
+    let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
+
+    // Create a complete undirected graph - every pair of nodes has an edge
+    for i in 0..NODE_COUNT {
+        for j in i + 1..NODE_COUNT {
+            g.add_edge(nodes[i], nodes[j], ());
+        }
+    }
+
+    let from = nodes[0];
+    let targets: Vec<_> = (1..NODE_COUNT).map(|i| nodes[i]).collect();
+
+    bench.iter(|| {
+        let mut total_paths = 0;
+        for &to in &targets {
+            let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+            total_paths += paths.count();
+        }
+        total_paths
+    });
+}

--- a/benches/simple_paths.rs
+++ b/benches/simple_paths.rs
@@ -5,8 +5,6 @@ extern crate test;
 
 mod common;
 
-use std::collections::hash_map::RandomState;
-
 use common::ungraph;
 use hashbrown::HashSet;
 use petgraph::algo::{all_simple_paths, all_simple_paths_multi};
@@ -15,7 +13,7 @@ use test::Bencher;
 
 #[bench]
 fn complete_graph_single_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 5;
+    static NODE_COUNT: usize = 6;
     let mut g = Graph::new_undirected();
     let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
 
@@ -32,7 +30,7 @@ fn complete_graph_single_bench(bench: &mut Bencher) {
     bench.iter(|| {
         let mut total_paths = 0;
         for &to in &targets {
-            let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+            let paths = all_simple_paths::<Vec<_>, _, fxhash::FxBuildHasher>(&g, from, to, 0, None);
             total_paths += paths.count();
         }
         total_paths
@@ -41,7 +39,7 @@ fn complete_graph_single_bench(bench: &mut Bencher) {
 
 #[bench]
 fn complete_graph_multi_bench(bench: &mut Bencher) {
-    static NODE_COUNT: usize = 5;
+    static NODE_COUNT: usize = 6;
     let mut g = Graph::new_undirected();
     let nodes: Vec<NodeIndex> = (0..NODE_COUNT).map(|_| g.add_node(())).collect();
 
@@ -53,10 +51,11 @@ fn complete_graph_multi_bench(bench: &mut Bencher) {
     }
 
     let from = nodes[0];
-    let to: HashSet<_, RandomState> = (1..NODE_COUNT).map(|i| nodes[i]).collect();
+    let to: HashSet<_, fxhash::FxBuildHasher> = (1..NODE_COUNT).map(|i| nodes[i]).collect();
 
     bench.iter(|| {
-        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        let paths =
+            all_simple_paths_multi::<Vec<_>, _, fxhash::FxBuildHasher>(&g, from, &to, 0, None);
         paths.count()
     });
 }
@@ -70,7 +69,7 @@ fn petersen_single_bench(bench: &mut Bencher) {
     bench.iter(|| {
         let mut total_paths = 0;
         for &to in &targets {
-            let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+            let paths = all_simple_paths::<Vec<_>, _, fxhash::FxBuildHasher>(&g, from, to, 0, None);
             total_paths += paths.count();
         }
         total_paths
@@ -81,10 +80,11 @@ fn petersen_single_bench(bench: &mut Bencher) {
 fn petersen_multi_bench(bench: &mut Bencher) {
     let g = ungraph().petersen_a();
     let from = NodeIndex::new(0);
-    let to: HashSet<_, RandomState> = (1..g.node_count()).map(NodeIndex::new).collect();
+    let to: HashSet<_, fxhash::FxBuildHasher> = (1..g.node_count()).map(NodeIndex::new).collect();
 
     bench.iter(|| {
-        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        let paths =
+            all_simple_paths_multi::<Vec<_>, _, fxhash::FxBuildHasher>(&g, from, &to, 0, None);
         paths.count()
     });
 }
@@ -98,7 +98,7 @@ fn bipartite_single_bench(bench: &mut Bencher) {
     bench.iter(|| {
         let mut total_paths = 0;
         for &to in &targets {
-            let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+            let paths = all_simple_paths::<Vec<_>, _, fxhash::FxBuildHasher>(&g, from, to, 0, None);
             total_paths += paths.count();
         }
         total_paths
@@ -109,10 +109,11 @@ fn bipartite_single_bench(bench: &mut Bencher) {
 fn bipartite_multi_bench(bench: &mut Bencher) {
     let g = ungraph().bipartite();
     let from = NodeIndex::new(0);
-    let to: HashSet<_, RandomState> = (1..g.node_count()).map(NodeIndex::new).collect();
+    let to: HashSet<_, fxhash::FxBuildHasher> = (1..g.node_count()).map(NodeIndex::new).collect();
 
     bench.iter(|| {
-        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        let paths =
+            all_simple_paths_multi::<Vec<_>, _, fxhash::FxBuildHasher>(&g, from, &to, 0, None);
         paths.count()
     });
 }
@@ -126,7 +127,7 @@ fn full_single_bench(bench: &mut Bencher) {
     bench.iter(|| {
         let mut total_paths = 0;
         for &to in &targets {
-            let paths = all_simple_paths::<Vec<_>, _, RandomState>(&g, from, to, 0, None);
+            let paths = all_simple_paths::<Vec<_>, _, fxhash::FxBuildHasher>(&g, from, to, 0, None);
             total_paths += paths.count();
         }
         total_paths
@@ -137,10 +138,11 @@ fn full_single_bench(bench: &mut Bencher) {
 fn full_multi_bench(bench: &mut Bencher) {
     let g = ungraph().full_a();
     let from = NodeIndex::new(0);
-    let to: HashSet<_, RandomState> = (1..g.node_count()).map(NodeIndex::new).collect();
+    let to: HashSet<_, fxhash::FxBuildHasher> = (1..g.node_count()).map(NodeIndex::new).collect();
 
     bench.iter(|| {
-        let paths = all_simple_paths_multi::<Vec<_>, _, RandomState>(&g, from, &to, 0, None);
+        let paths =
+            all_simple_paths_multi::<Vec<_>, _, fxhash::FxBuildHasher>(&g, from, &to, 0, None);
         paths.count()
     });
 }

--- a/src/algo/mod.rs
+++ b/src/algo/mod.rs
@@ -66,7 +66,7 @@ pub use scc::{
     kosaraju_scc::kosaraju_scc,
     tarjan_scc::{tarjan_scc, TarjanScc},
 };
-pub use simple_paths::all_simple_paths;
+pub use simple_paths::{all_simple_paths, all_simple_paths_multi};
 pub use spfa::spfa;
 #[cfg(feature = "stable_graph")]
 pub use steiner_tree::steiner_tree;

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -157,6 +157,9 @@ where
 /// to the source, the lookup overhead can make repeated calls to [`all_simple_paths`]
 /// a faster alternative.
 ///
+/// **Note**: If security is not a concern, you can use a faster hasher (e.g., `FxBuildHasher`)
+/// to minimize the `HashSet` lookup overhead.
+///
 /// Path constraints (`min_intermediate_nodes`, `max_intermediate_nodes`) and complexity
 /// are otherwise identical to [`all_simple_paths`].
 ///

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -141,6 +141,53 @@ where
     })
 }
 
+/// Calculate all simple paths from a source node to any of several target nodes.
+///
+/// This function is a variant of [`all_simple_paths`] that accepts a `HashSet` of
+/// target nodes instead of a single one. A path is yielded as soon as it reaches any
+/// node in the `to` set.
+///
+/// # Performance Considerations
+///
+/// The efficiency of this function hinges on the graph's structure. It provides significant
+/// performance gains on graphs where paths share long initial segments (e.g., trees and DAGs),
+/// as the benefit of a single traversal outweighs the `HashSet` lookup overhead.
+///
+/// Conversely, in dense graphs where paths diverge quickly or for targets very close
+/// to the source, the lookup overhead can make repeated calls to [`all_simple_paths`]
+/// a faster alternative.
+///
+/// Path constraints (`min_intermediate_nodes`, `max_intermediate_nodes`) and complexity
+/// are otherwise identical to [`all_simple_paths`].
+///
+/// # Example
+/// ```
+/// use petgraph::{algo, prelude::*};
+/// use hashbrown::HashSet;
+/// use std::collections::hash_map::RandomState;
+///
+/// let mut graph = DiGraph::<&str, i32>::new();
+///
+/// let a = graph.add_node("a");
+/// let b = graph.add_node("b");
+/// let c = graph.add_node("c");
+/// let d = graph.add_node("d");
+/// graph.extend_with_edges(&[(a, b, 1), (b, c, 1), (b, d, 1)]);
+///
+/// // Find paths from "a" to either "c" or "d".
+/// let targets = HashSet::from_iter([c, d]);
+/// let mut paths = algo::all_simple_paths_multi::<Vec<_>, _, RandomState>(&graph, a, &targets, 0, None)
+///     .collect::<Vec<_>>();
+///
+/// paths.sort_by_key(|p| p.clone());
+/// let expected_paths = vec![
+///     vec![a, b, c],
+///     vec![a, b, d],
+/// ];
+///
+/// assert_eq!(paths, expected_paths);
+///
+/// ```
 pub fn all_simple_paths_multi<'a, TargetColl, G, S>(
     graph: G,
     from: G::NodeId,

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -395,7 +395,7 @@ mod test {
             all_simple_paths::<_, _, RandomState>(&graph, 1.into(), 1.into(), 0, None)
                 .map(|v: Vec<_>| v.into_iter().map(|i| i.index()).collect())
                 .collect();
-        assert_eq!(paths, vec![vec![1]]);
+        assert!(paths.is_empty());
     }
 
     #[test]
@@ -424,7 +424,7 @@ mod test {
             all_simple_paths_multi::<_, _, RandomState>(&graph, 0.into(), targets, 0, None)
                 .map(|v: Vec<_>| v.into_iter().map(|i| i.index()).collect())
                 .collect();
-        let expected = HashSet::from_iter([vec![0], vec![0, 1], vec![0, 1, 2]]);
+        let expected = HashSet::from_iter([vec![0, 1], vec![0, 1, 2]]);
         assert_eq!(paths, expected);
     }
 
@@ -490,7 +490,7 @@ mod test {
             all_simple_paths::<_, _, RandomState>(&graph, 0.into(), 0.into(), 0, None)
                 .map(|v: Vec<_>| v.into_iter().map(|i| i.index()).collect())
                 .collect();
-        assert_eq!(paths, vec![vec![0]]);
+        assert!(paths.is_empty());
 
         let paths: Vec<Vec<_>> =
             all_simple_paths::<_, _, RandomState>(&graph, 0.into(), 1.into(), 0, None)
@@ -551,7 +551,6 @@ mod test {
             all_simple_paths::<Vec<_>, _, RandomState>(&graph, a, a, 0, None).collect();
 
         // The only simple path from a node to itself is a path of length 1 (just the node itself).
-        let expected_paths: Vec<Vec<_>> = vec![vec![a]];
-        assert_eq!(paths, expected_paths);
+        assert!(paths.is_empty());
     }
 }

--- a/src/algo/simple_paths.rs
+++ b/src/algo/simple_paths.rs
@@ -30,8 +30,8 @@ use crate::{
 /// * `min_intermediate_nodes`: the minimum number of nodes in the desired paths.
 /// * `max_intermediate_nodes`: the maximum number of nodes in the desired paths (optional).
 /// # Returns
-/// Returns an iterator that produces all simple paths from `from` node to `to`, which contains at least `min_intermediate_nodes` nodes
-/// and at most `max_intermediate_nodes`, if given, or limited by the graph's order otherwise.
+/// Returns an iterator that produces all simple paths from `from` node to `to`, which contains at least `min_intermediate_nodes`
+/// and at most `max_intermediate_nodes` intermediate nodes, if given, or limited by the graph's order otherwise.
 ///
 /// # Complexity
 /// * Time complexity: for computing the first **k** paths, the running time will be **O(k|V| + k|E|)**.
@@ -154,14 +154,27 @@ where
 /// as the benefit of a single traversal outweighs the `HashSet` lookup overhead.
 ///
 /// Conversely, in dense graphs where paths diverge quickly or for targets very close
-/// to the source, the lookup overhead can make repeated calls to [`all_simple_paths`]
+/// to the source, the lookup overhead could make repeated calls to [`all_simple_paths`]
 /// a faster alternative.
 ///
-/// **Note**: If security is not a concern, you can use a faster hasher (e.g., `FxBuildHasher`)
-/// to minimize the `HashSet` lookup overhead.
+/// **Note**: If security is not a concern, a faster hasher (e.g., `FxBuildHasher`)
+/// can be specified to minimize the `HashSet` lookup overhead.
 ///
-/// Path constraints (`min_intermediate_nodes`, `max_intermediate_nodes`) and complexity
-/// are otherwise identical to [`all_simple_paths`].
+/// # Arguments
+/// * `graph`: an input graph.
+/// * `from`: an initial node of desired paths.
+/// * `to`: a `HashSet` of target nodes. A path is yielded as soon as it reaches any node in this set.
+/// * `min_intermediate_nodes`: the minimum number of nodes in the desired paths.
+/// * `max_intermediate_nodes`: the maximum number of nodes in the desired paths (optional).
+/// # Returns
+/// Returns an iterator that produces all simple paths from `from` node to any node in the `to` set, which contains at least `min_intermediate_nodes`
+/// and at most `max_intermediate_nodes` intermediate nodes, if given, or limited by the graph's order otherwise.
+///
+/// # Complexity
+/// * Time complexity: for computing the first **k** paths, the running time will be **O(k|V| + k|E|)**.
+/// * Auxillary space: **O(|V|)**.
+///
+/// where **|V|** is the number of nodes and **|E|** is the number of edges.
 ///
 /// # Example
 /// ```


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->

### Description

This pull request resolves #864.

1.  **Fixes a bug in `all_simple_paths`**: The original implementation could return a self-looping path when `from`=`to`, as described in the issue.

2.  **Adds `all_simple_paths_multi` for multiple targets**: A new function, [`all_simple_paths_multi`](src/algo/simple_paths.rs:144), has been implemented. This function finds all simple paths from a single source node to a `HashSet` of possible target nodes, in a single DFS traversal.

Unit tests have been added to validate the fix and to ensure the correctness of the new multi-target pathfinding functionality across various graph types and edge cases.

TODOs:
- [x] Add benchmarks to the functions in `src/algo/simple_paths.rs`
- [x] Add docstrings for the new `all_simple_path_multi` function.

Help needed: Finalise the design choice to exclude the single node path when `source = target`