### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/src/algo/scc/tarjan_scc.rs
+++ b/src/algo/scc/tarjan_scc.rs
@@ -44,7 +44,7 @@ impl<N> TarjanScc<N> {
     /// [1]: https://homepages.ecs.vuw.ac.nz/~djp/files/P05.pdf
     /// [2]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
     ///
-    /// Calls `f` for each strongly strongly connected component (scc).
+    /// Calls `f` for each strongly connected component (scc).
     /// The order of node ids within each scc is arbitrary, but the order of
     /// the sccs is their postorder (reverse topological sort).
     ///


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->

remove redundant word in comment