### PR TITLE
refactor: New Dijkstra/General Algorithm API

### DIFF
--- a/src/algo/dijkstra.rs
+++ b/src/algo/dijkstra.rs
@@ -132,9 +132,9 @@ where
     ///     (e, 1),
     ///     (f, 2),
     /// ].iter().cloned().collect();
-    /// let res = dijkstra::with_dynamic_goal(&graph, b, |&node| node == d || node == f, |_| 1);
-    /// assert_eq!(res.scores, expected_res);
-    /// assert!(res.goal_node == Some(d) || res.goal_node == Some(f));
+    /// let mut dijkstra = dijkstra::Dijkstra::new(&graph, b, |_| 1).with_goal(|&node| node == d || node == f);
+    /// let res = dijkstra.run();
+    /// assert_eq!(res.distances(), &expected_res);
     /// ```
     pub fn run(&mut self) -> DijkstraOutput<'_, G::NodeId, K> {
         let mut visit_next = BinaryHeap::new();


### PR DESCRIPTION
This PR suggests a revamp to the Dijkstra API. This revamp could (and should) similarly be applied to most of the other algorithms in `petgraph` as well.

A struct to store the state of the Dijkstra computation is introduced. This struct can be constructed and edited using the builder pattern. Furthermore, one can call `.run()` to run the actual algorithm, which returns a `DijkstraOutput`. This structure has three main benefits:

1) Storing the state of the Dijkstra computation: This way, one can reuse previous computations. Using `with_goal()` one can change the goal function after one computation and start a new one with a new goal reusing the results from the previous run of Dijkstra.

2) Having a custom return type: Because the custom return type does not expose its fields, we are more flexible to change internal functionality without having a breaking change.

3) The new API allows for Dijkstra to return Paths as well. We could decide on how we want to implement this specifically and possibly introduce different run functions which only compute distances or paths as well (for performance reasons). But this is only possible due to the new API.

Usage would now look something like this:
```rust
    let mut dijkstra = Dijkstra::new(&graph, start, edge_cost_fn).with_goal(goal_fn);
    let result = dijkstra.run().distance_to_node(&goal_node);

    let mut dijkstra = dijkstra.with_goal(new_goal_fn);
    // Previously computed distances are reused. I.e. if new_goal_node is already explored, no computation is necessary.
    let result_two = dijkstra.run().distance_to_node(&new_goal_node);
```

Of course, this is compatible with the new `with_dynamic_goal` (https://github.com/petgraph/petgraph/pull/855) or rather integrates it natively. This could be applied similarly to `bidirectional_dijkstra` (https://github.com/petgraph/petgraph/pull/782).

If we would accept / agree on these or similar changes before the new version, these would not be considered breaking and we would not have to re-do APIs again right after introducing them (referring to `with_dynamic_goal` and `bidirectional_dijkstra`).

Note that the actual docstrings and tests etc for this API are not done yet, as this is just a draft and suggestion for how it could look like.

Tagging you @starovoid.