### PR TITLE
fix: `StableGraph::reverse` breaks free lists

### DIFF
--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -2440,3 +2440,42 @@ fn test_reverse() {
         itertools::assert_equal(gr.edges_directed(i, Incoming), reversed_gr.edges(i));
     }
 }
+
+#[test]
+fn test_reverse_after_remove_nodes() {
+    let mut gr = StableGraph::<_, _>::default();
+    let a = gr.add_node("a");
+    let b = gr.add_node("b");
+    let c = gr.add_node("c");
+
+    gr.add_edge(a, a, 0);
+
+    gr.remove_node(b);
+    gr.remove_node(c);
+
+    gr.check_free_lists();
+
+    gr.reverse();
+
+    gr.check_free_lists();
+}
+
+#[test]
+fn test_reverse_after_remove_edges() {
+    let mut gr = StableGraph::<_, _>::default();
+    let a = gr.add_node("a");
+    let b = gr.add_node("b");
+    let c = gr.add_node("c");
+
+    let e_ab = gr.add_edge(a, b, 0);
+    let e_bc = gr.add_edge(b, c, 0);
+
+    gr.remove_edge(e_ab);
+    gr.remove_edge(e_bc);
+
+    gr.check_free_lists();
+
+    gr.reverse();
+
+    gr.check_free_lists();
+}

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -246,11 +246,15 @@ where
         // edge incoming / outgoing lists,
         // node incoming / outgoing lists
         for edge in &mut self.g.edges {
-            edge.node.swap(0, 1);
-            edge.next.swap(0, 1);
+            if edge.weight.is_some() {
+                edge.node.swap(0, 1);
+                edge.next.swap(0, 1);
+            }
         }
         for node in &mut self.g.nodes {
-            node.next.swap(0, 1);
+            if node.weight.is_some() {
+                node.next.swap(0, 1);
+            }
         }
     }
 


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->
  
StableGraph is implicitly using the outgoing lists as a free list, but `reverse` is also reversing those.