### PR TITLE
fix: use a queue for SPFA 

### DIFF
--- a/benches/bellman_ford.rs
+++ b/benches/bellman_ford.rs
@@ -24,7 +24,7 @@ fn bellman_ford_bench(bench: &mut Bencher) {
             let n2 = nodes[j];
             let mut distance: f64 = ((i + 3) % 10) as f64;
             if n1 != n2 {
-                distance -= 1.0
+                distance -= 0.5
             }
             g.add_edge(n1, n2, distance);
         }

--- a/benches/spfa.rs
+++ b/benches/spfa.rs
@@ -23,7 +23,7 @@ fn spfa_bench(bench: &mut Bencher) {
             let n2 = nodes[j];
             let mut distance: f64 = ((i + 3) % 10) as f64;
             if n1 != n2 {
-                distance -= 1.0
+                distance -= 0.5
             }
             g.add_edge(n1, n2, distance);
         }

--- a/src/algo/johnson.rs
+++ b/src/algo/johnson.rs
@@ -1,4 +1,5 @@
 //! Johnson's algorithm implementation.
+use alloc::collections::VecDeque;
 use alloc::{vec, vec::Vec};
 use core::hash::Hash;
 use core::ops::Sub;
@@ -262,7 +263,7 @@ where
     let reweight = vec![K::default(); node_bound];
 
     // Queue of vertices capable of relaxation of the found shortest distances.
-    let mut queue: Vec<G::NodeId> = Vec::with_capacity(node_bound);
+    let mut queue: VecDeque<G::NodeId> = VecDeque::with_capacity(node_bound);
 
     // Adding all vertices to the queue is the same as starting the algorithm from a virtual node.
     queue.extend(graph.node_identifiers());

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -163,3 +163,22 @@ where
 
     Ok((distances, predecessors))
 }
+
+#[test]
+fn test_spfa_no_neg_cycle() {
+    // fails if spfa uses a stack instead of a queue
+    let mut g = Graph::new();
+    let ns = (0..5).map(|_| g.add_node(())).collect::<Vec<_>>();
+    g.add_edge(ns[0], ns[4], 1000);
+    g.add_edge(ns[0], ns[3], 100);
+    g.add_edge(ns[0], ns[2], 10);
+    g.add_edge(ns[0], ns[1], 1);
+    g.add_edge(ns[3], ns[4], 100);
+    g.add_edge(ns[2], ns[4], 150);
+    g.add_edge(ns[2], ns[3], 10);
+    g.add_edge(ns[1], ns[4], 111);
+    g.add_edge(ns[1], ns[3], 10);
+
+    let spfa_res = spfa(&g, ns[0], |edge| *edge.weight());
+    assert!(spfa_res.is_ok());
+}

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -165,22 +165,3 @@ where
 
     Ok((distances, predecessors))
 }
-
-#[test]
-fn test_spfa_no_neg_cycle() {
-    // fails if spfa uses a stack instead of a queue
-    let mut g = Graph::new();
-    let ns = (0..5).map(|_| g.add_node(())).collect::<Vec<_>>();
-    g.add_edge(ns[0], ns[4], 1000);
-    g.add_edge(ns[0], ns[3], 100);
-    g.add_edge(ns[0], ns[2], 10);
-    g.add_edge(ns[0], ns[1], 1);
-    g.add_edge(ns[3], ns[4], 100);
-    g.add_edge(ns[2], ns[4], 150);
-    g.add_edge(ns[2], ns[3], 10);
-    g.add_edge(ns[1], ns[4], 111);
-    g.add_edge(ns[1], ns[3], 10);
-
-    let spfa_res = spfa(&g, ns[0], |edge| *edge.weight());
-    assert!(spfa_res.is_ok());
-}

--- a/src/algo/spfa.rs
+++ b/src/algo/spfa.rs
@@ -1,4 +1,6 @@
 //! Shortest Path Faster Algorithm.
+use alloc::collections::VecDeque;
+
 use super::{bellman_ford::Paths, BoundedMeasure, NegativeCycle};
 use crate::prelude::*;
 use crate::visit::{IntoEdges, IntoNodeIdentifiers, NodeIndexable};
@@ -93,10 +95,10 @@ where
     dist[ix(source)] = K::default();
 
     // Queue of vertices capable of relaxation of the found shortest distances.
-    let mut queue: Vec<G::NodeId> = Vec::with_capacity(graph.node_bound());
+    let mut queue: VecDeque<G::NodeId> = VecDeque::with_capacity(graph.node_bound());
     let mut in_queue = vec![false; graph.node_bound()];
 
-    queue.push(source);
+    queue.push_back(source);
     in_queue[ix(source)] = true;
 
     let (distances, predecessors) = spfa_loop(graph, dist, Some(pred), queue, in_queue, edge_cost)?;
@@ -116,7 +118,7 @@ pub(crate) fn spfa_loop<G, F, K>(
     graph: G,
     mut distances: Vec<K>,
     mut predecessors: Option<Vec<Option<G::NodeId>>>,
-    mut queue: Vec<G::NodeId>,
+    mut queue: VecDeque<G::NodeId>,
     mut in_queue: Vec<bool>,
     mut edge_cost: F,
 ) -> Result<(Vec<K>, Option<Vec<Option<G::NodeId>>>), NegativeCycle>
@@ -131,7 +133,7 @@ where
     // in the queue to be able to detect a negative cycle.
     let mut visits = vec![0; graph.node_bound()];
 
-    while let Some(i) = queue.pop() {
+    while let Some(i) = queue.pop_front() {
         in_queue[ix(i)] = false;
 
         // In a graph without a negative cycle, no vertex can improve
@@ -155,7 +157,7 @@ where
 
                 if !in_queue[ix(j)] {
                     in_queue[ix(j)] = true;
-                    queue.push(j);
+                    queue.push_back(j);
                 }
             }
         }

--- a/tests/spfa.rs
+++ b/tests/spfa.rs
@@ -298,3 +298,22 @@ fn spfa_multiple_edges() {
         }
     }
 }
+
+#[test]
+fn spfa_no_neg_cycle() {
+    // fails if spfa uses a stack instead of a queue
+    let mut g = Graph::new();
+    let ns = (0..5).map(|_| g.add_node(())).collect::<Vec<_>>();
+    g.add_edge(ns[0], ns[4], 1000);
+    g.add_edge(ns[0], ns[3], 100);
+    g.add_edge(ns[0], ns[2], 10);
+    g.add_edge(ns[0], ns[1], 1);
+    g.add_edge(ns[3], ns[4], 100);
+    g.add_edge(ns[2], ns[4], 150);
+    g.add_edge(ns[2], ns[3], 10);
+    g.add_edge(ns[1], ns[4], 111);
+    g.add_edge(ns[1], ns[3], 10);
+
+    let spfa_res = spfa(&g, ns[0], |edge| *edge.weight());
+    assert!(spfa_res.is_ok());
+}


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->
  
fixes https://github.com/petgraph/petgraph/issues/862

The stack-based implementation of SPFA produces false negatives when detecting negative cycles. When benchmarking without a negative cycle, it actually runs faster than Bellman-Ford.

Since the SPFA implementation uses a fixed-size(capacity) queue, no reallocation occurs in `VecDeque`, so it is expected to be sufficiently fast.

**Before**: 46082d680ac1b56ba19da61ec90572307480eb27
```
test bellman_ford_bench        ... bench:       1,813.35 ns/iter (+/- 81.06)
test spfa_bench                ... bench:      21,197.04 ns/iter (+/- 1,145.72)
```
  
**After**: 10051b28c81c0bf5c7f32ba0be3fc5e391b84303
```
test bellman_ford_bench        ... bench:       1,826.56 ns/iter (+/- 155.06)
test spfa_bench                ... bench:       1,371.46 ns/iter (+/- 110.51)
```
  