### PR TITLE
feat: add try_map for `Graph`

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -1594,6 +1594,14 @@ where
         g
     }
 
+    /// Create a new `Graph` by trying to map node and
+    /// edge weights to new values.
+    ///
+    /// The resulting graph has the same structure and the same
+    /// graph indices as `self`.
+    ///
+    /// if a mapping should fail, an `MapError` gets returned
+    /// which contains the index of the node or edge, and its value
     pub fn try_map<'a, F, G, N2, E2, RN, RE>(
         &'a self,
         mut node_map: F,
@@ -1872,8 +1880,13 @@ pub struct Externals<'a, N: 'a, Ty, Ix: IndexType = DefaultIx> {
 }
 
 #[derive(Debug)]
+/// Calling `try_map` on a graph has failed
 pub enum MapError<RN, RE, Ix> {
+    /// the first node where mapping has failed
+    /// with its index and error
     Node(NodeIndex<Ix>, RN),
+    /// the first edge where mapping has failed
+    /// with its index and error
     Edge(EdgeIndex<Ix>, RE),
 }
 


### PR DESCRIPTION
as per #829, it would be nice if `Graph` had a fallible `try_map`, returning a `Result<Graph>`
I didnt write a `owning_try_map`, because the graph would be lost on an error, and no `try_filter_map` because its is too niche.

There could be still mappings where only nodes fail but not edges or vice versa, but thats again very niche. Maybe if `map` was generally split into `map_edges` and `map_nodes`, the user could just have that fine grained control, but i think its silly because the code is very simple anyway

Since this pr might be too niche and not get accepted, i didnt bother writing a doc example. In case it does get accepted, i will amend this pr with a doc example

