### PR TITLE
ci: added doctest to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,9 +6,10 @@ default:
 build:
     cargo build
 
-# Tests with all features enabled
+# Runs tests and doctests with all features enabled
 test:
     cargo test --features all
+    cargo test --doc --features all
 
 # Miri with all tests (this might take very long). Consider the fast-miri recipe instead or specify individual tests
 miri:


### PR DESCRIPTION
This PR simply adds a line to also test doctests when `just test` is run. Currently, running `just test` does not test doctests, so incorrect formatting on those can pass `just test`, but fail during CI/CD. [Example](https://github.com/petgraph/petgraph/actions/runs/18420112265/job/52542782846).

<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->