### PR TITLE
chore: Update to hashbrown 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ debug = true
 [dependencies]
 fixedbitset = { version = "0.5.7", default-features = false }
 indexmap = { version = "2.5.0", default-features = false }
-hashbrown = { version = "^0.15.0", default-features = false, features = ["default-hasher", "inline-more"] }
+hashbrown = { version = "^0.16.0", default-features = false, features = ["default-hasher", "inline-more"] }
 quickcheck = { optional = true, version = "0.8", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0", default-features = false, optional = true }


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->

Hello, I noticed while updating the dependencies of Lalrpop that petgraph is pulling in two versions of hashbrown. One explicitly set at 0.15 in the toml, and one implicitly through the indexmap dependency which sets hashbrown to 0.16. It would be nice if this duplication was removed.

BREAKING CHANGE: Disclaimer, I didn't look far enough to see if the version of hashbrown is publicly exposed somehow by petgraph.