### PR TITLE
feat: mark nodes_iter as DoubleEndedIterator and ExactSizeIterator

### DIFF
--- a/src/acyclic.rs
+++ b/src/acyclic.rs
@@ -106,7 +106,9 @@ impl<G: Visitable> Acyclic<G> {
     }
 
     /// Get an iterator over the nodes, ordered by their position.
-    pub fn nodes_iter(&self) -> impl Iterator<Item = G::NodeId> + '_ {
+    pub fn nodes_iter(
+        &self,
+    ) -> impl Iterator<Item = G::NodeId> + DoubleEndedIterator + ExactSizeIterator + '_ {
         self.order_map.nodes_iter()
     }
 

--- a/src/acyclic/order_map.rs
+++ b/src/acyclic/order_map.rs
@@ -106,7 +106,9 @@ impl<N: Copy> OrderMap<N> {
     }
 
     /// Get an iterator over the nodes, ordered by their position.
-    pub(super) fn nodes_iter(&self) -> impl Iterator<Item = N> + '_ {
+    pub(super) fn nodes_iter(
+        &self,
+    ) -> impl Iterator<Item = N> + DoubleEndedIterator + ExactSizeIterator + '_ {
         self.pos_to_node.values().copied()
     }
 


### PR DESCRIPTION
This allows you to get the postorder of an acyclic graph using `graph.nodes_iter().rev()`