### PR TITLE
feat: Add parallel iterators for `Graph` and `StableGraph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
+- Add parallel iterators to `Graph` and `StableGraph` ([#929](https://github.com/petgraph/petgraph/pull/929))
 - Add `into_nodes_edges_iters` to `StableGraph` ([#841](https://github.com/petgraph/petgraph/pull/841))
 - Add methods to reserve & shrink `StableGraph` capacity ([#846](https://github.com/petgraph/petgraph/pull/846))
 - Add Dinic's Maximum Flow Algorithm ([#739](https://github.com/petgraph/petgraph/pull/739))

--- a/crates/petgraph/tests/stable_graph.rs
+++ b/crates/petgraph/tests/stable_graph.rs
@@ -1308,3 +1308,115 @@ fn test_edges_connecting_iteration_order() {
         ]
     );
 }
+
+#[test]
+#[cfg(feature = "rayon")]
+fn test_parallel_iterator() {
+    use petgraph::{csr::DefaultIx, visit::*};
+    use rayon::prelude::*;
+
+    let mut gr = StableGraph::<u32, u32>::new();
+
+    for i in 0..1000 {
+        gr.add_node(i);
+    }
+    for i in 0..1000 {
+        gr.add_edge(NodeIndex::new(i / 2), NodeIndex::new(i), (i + i / 2) as u32);
+    }
+    for i in 0..200 {
+        gr.remove_node(NodeIndex::new(i * 2));
+    }
+    for i in 0..200 {
+        gr.remove_edge(EdgeIndex::new(i * 3));
+    }
+
+    let node_indices: Vec<_> = gr.node_indices().collect();
+    let par_node_indices: Vec<_> = gr.par_node_indices().collect();
+    assert_eq!(node_indices, par_node_indices);
+
+    let node_references: Vec<_> = gr.node_references().collect();
+    let par_node_references: Vec<_> = gr.par_node_references().collect();
+    assert_eq!(node_references, par_node_references);
+
+    let node_weights: Vec<_> = gr
+        .node_weights()
+        .map(|x| (x as *const u32).addr())
+        .collect();
+    let par_node_weights: Vec<_> = gr
+        .par_node_weights()
+        .map(|x| (x as *const u32).addr())
+        .collect();
+    assert_eq!(node_weights, par_node_weights);
+
+    let node_weights_mut: Vec<_> = gr
+        .node_weights_mut()
+        .map(|x| (x as *mut u32).addr())
+        .collect();
+    let par_node_weights_mut: Vec<_> = gr
+        .par_node_weights_mut()
+        .map(|x| (x as *mut u32).addr())
+        .collect();
+    assert_eq!(node_weights_mut, par_node_weights_mut);
+
+    let edge_indices: Vec<_> = gr.edge_indices().collect();
+    let par_edge_indices: Vec<_> = gr.par_edge_indices().collect();
+    assert_eq!(edge_indices, par_edge_indices);
+
+    let edge_references: Vec<_> = gr.edge_references().collect();
+    let par_edge_references: Vec<_> = gr.par_edge_references().collect();
+    assert_eq!(edge_references, par_edge_references);
+
+    let edge_weights: Vec<_> = gr
+        .edge_weights()
+        .map(|x| (x as *const u32).addr())
+        .collect();
+    let par_edge_weights: Vec<_> = gr
+        .par_edge_weights()
+        .map(|x| (x as *const u32).addr())
+        .collect();
+    assert_eq!(edge_weights, par_edge_weights);
+
+    let edge_weights_mut: Vec<_> = gr
+        .edge_weights_mut()
+        .map(|x| (x as *mut u32).addr())
+        .collect();
+    let par_edge_weights_mut: Vec<_> = gr
+        .par_edge_weights_mut()
+        .map(|x| (x as *mut u32).addr())
+        .collect();
+    assert_eq!(edge_weights_mut, par_edge_weights_mut);
+
+    fn node_map(idx: NodeIndex<DefaultIx>, weight: &u32) -> i32 {
+        *weight as i32 * 2 - idx.index() as i32
+    }
+    fn edge_map(idx: EdgeIndex<DefaultIx>, weight: &u32) -> i32 {
+        *weight as i32 - idx.index() as i32 * 2
+    }
+    let mgr = gr.map(node_map, edge_map);
+    let p_mgr = gr.par_map(node_map, edge_map);
+
+    let node_references: Vec<_> = mgr.node_references().collect();
+    let p_node_references: Vec<_> = p_mgr.node_references().collect();
+    assert_eq!(node_references, p_node_references);
+    
+    let edge_references: Vec<_> = mgr.edge_references().collect();
+    let p_edge_references: Vec<_> = p_mgr.edge_references().collect();
+    assert_eq!(edge_references, p_edge_references);
+
+    fn node_map_owned(idx: NodeIndex<DefaultIx>, weight: u32) -> i32 {
+        weight as i32 * 2 - idx.index() as i32
+    }
+    fn edge_map_owned(idx: EdgeIndex<DefaultIx>, weight: u32) -> i32 {
+        weight as i32 - idx.index() as i32 * 2
+    }
+    let mgr = gr.clone().map_owned(node_map_owned, edge_map_owned);
+    let p_mgr = gr.par_map_owned(node_map_owned, edge_map_owned);
+
+    let node_references: Vec<_> = mgr.node_references().collect();
+    let p_node_references: Vec<_> = p_mgr.node_references().collect();
+    assert_eq!(node_references, p_node_references);
+    
+    let edge_references: Vec<_> = mgr.edge_references().collect();
+    let p_edge_references: Vec<_> = p_mgr.edge_references().collect();
+    assert_eq!(edge_references, p_edge_references);
+}


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->

I have implemented `ParallelIterator`s running on nodes and edges in `Graph` and `StableGraph`.

cf: #198 