### PR TITLE
Hardening CI workflow 

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,7 +1,8 @@
 name: Rust semver-checks
 
 on:
-    pull_request_target:
+#do not run on pull request target , run on in pull request similare without base credentials 
+    pull_request:
         branches:
             - master
         types:


### PR DESCRIPTION
Security Issue

The workflow is currently triggered using `pull_request_target`. This event runs in the context of the **base repository**, giving the workflow access to: