### PR TITLE
feat(dominators): add dominated_by iterator method and implement DAG dominators build

### DIFF
--- a/crates/petgraph/src/algo/dominators.rs
+++ b/crates/petgraph/src/algo/dominators.rs
@@ -17,7 +17,11 @@ use core::{cmp::Ordering, hash::Hash};
 
 use hashbrown::{HashMap, HashSet, hash_map::Iter};
 
-use crate::visit::{DfsPostOrder, GraphBase, IntoNeighbors, Visitable, Walker};
+use crate::EdgeDirection;
+use crate::visit::{
+    DfsPostOrder, GraphBase, IntoNeighbors, IntoNeighborsDirected, IntoNodeIdentifiers,
+    NodeIndexable, Visitable, Walker,
+};
 
 /// The dominance relation for some graph and root.
 #[derive(Debug, Clone)]
@@ -386,9 +390,173 @@ where
     (post_order, predecessor_sets)
 }
 
+/// Construct the dominance tree for a DAG with a single root.
+///
+/// This function uses a topological order approach which is more efficient
+/// for DAGs. For a node `u`, its immediate dominator is the LCA (Lowest Common
+/// Ancestor) of all its predecessors in the dominance tree.
+///
+/// # Arguments
+/// * `graph`: a directed acyclic graph with exactly one root.
+/// * `root`: the root node (node with in-degree 0).
+///
+/// # Returns
+/// * `Ok(Dominators)`: the dominance relation for the given graph and root.
+/// * `Err(Cycle)`: if the graph contains a cycle.
+///
+/// # Complexity
+/// * Time complexity: **O((V + E) log V)**
+/// * Auxiliary space: **O(V log V)**
+///
+/// # Errors
+/// Returns `Err(Cycle)` if the graph contains a cycle.
+pub fn dag_dominators<G>(
+    graph: G,
+    root: G::NodeId,
+) -> Result<Dominators<G::NodeId>, crate::algo::Cycle<G::NodeId>>
+where
+    G: IntoNeighborsDirected + Visitable + NodeIndexable + IntoNodeIdentifiers,
+    <G as GraphBase>::NodeId: Eq + Hash + Copy,
+{
+    use crate::algo::toposort;
+
+    // Get topological order
+    let topological_order = toposort(&graph, None)?;
+
+    // Binary lifting table: binary_lifting[node][k] = 2^k-th ancestor of node
+    let mut binary_lifting: HashMap<G::NodeId, Vec<G::NodeId>> = HashMap::new();
+    // Depth of each node in the dominance tree
+    let mut depth: HashMap<G::NodeId, usize> = HashMap::new();
+    // Immediate dominator of each node
+    let mut dominators: HashMap<G::NodeId, G::NodeId> = HashMap::new();
+
+    // Initialize root
+    dominators.insert(root, root);
+    depth.insert(root, 0);
+
+    // Initialize binary lifting for root (root's ancestors are itself)
+    let max_log = 0;
+    binary_lifting.insert(root, vec![root; max_log + 1]);
+
+    // Process nodes in topological order
+    for &u in &topological_order {
+        if u == root {
+            continue;
+        }
+
+        // Get predecessors of u
+        let predecessors: Vec<G::NodeId> = graph
+            .neighbors_directed(u, EdgeDirection::Incoming)
+            .collect();
+
+        if predecessors.is_empty() {
+            // Node is not reachable from root, skip
+            continue;
+        }
+
+        // Find LCA of all predecessors
+        let mut lca = predecessors[0];
+        for &pred in &predecessors[1..] {
+            lca = lca_with_binary_lifting(lca, pred, &binary_lifting, &depth);
+        }
+
+        // Set immediate dominator
+        dominators.insert(u, lca);
+
+        // Update depth and binary lifting for u
+        let u_depth = depth[&lca] + 1;
+        depth.insert(u, u_depth);
+
+        // Calculate required log size for binary lifting
+        let required_log = (u_depth + 1).next_power_of_two().ilog2() as usize + 1;
+
+        // Update binary lifting table for this node and potentially for ancestors
+        let mut ancestors = vec![root; required_log];
+        ancestors[0] = lca;
+
+        for k in 1..required_log {
+            let ancestor_k_minus_1 = ancestors[k - 1];
+            if let Some(ancestor_table) = binary_lifting.get(&ancestor_k_minus_1) {
+                if k - 1 < ancestor_table.len() {
+                    ancestors[k] = ancestor_table[k - 1];
+                }
+            }
+        }
+
+        binary_lifting.insert(u, ancestors);
+    }
+
+    Ok(Dominators { root, dominators })
+}
+
+/// Find the Lowest Common Ancestor of two nodes using binary lifting.
+fn lca_with_binary_lifting<N>(
+    mut u: N,
+    mut v: N,
+    binary_lifting: &HashMap<N, Vec<N>>,
+    depth: &HashMap<N, usize>,
+) -> N
+where
+    N: Copy + Eq + Hash,
+{
+    // Ensure u and v are in the dominance tree
+    if !depth.contains_key(&u) || !depth.contains_key(&v) {
+        // If one node is not in the tree, return the other
+        return if depth.contains_key(&u) { u } else { v };
+    }
+
+    // Make u the deeper node
+    let mut du = depth[&u];
+    let mut dv = depth[&v];
+    if du < dv {
+        core::mem::swap(&mut u, &mut v);
+        core::mem::swap(&mut du, &mut dv);
+    }
+
+    // Bring u to the same depth as v
+    let mut diff = du - dv;
+    let mut k = 0;
+    while diff > 0 {
+        if diff % 2 == 1 {
+            if let Some(table) = binary_lifting.get(&u) {
+                if k < table.len() {
+                    u = table[k];
+                }
+            }
+        }
+        diff /= 2;
+        k += 1;
+    }
+
+    if u == v {
+        return u;
+    }
+
+    // Lift both u and v up until their ancestors match
+    if let Some(table_u) = binary_lifting.get(&u) {
+        if let Some(table_v) = binary_lifting.get(&v) {
+            let max_log = table_u.len().min(table_v.len());
+            for k in (0..max_log).rev() {
+                if table_u[k] != table_v[k] {
+                    u = table_u[k];
+                }
+            }
+        }
+    }
+
+    // Return parent of u (or v, they should have the same parent now)
+    if let Some(table) = binary_lifting.get(&u) {
+        if !table.is_empty() {
+            return table[0];
+        }
+    }
+    u
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{Directed, Graph};
 
     #[test]
     fn test_iter_dominators() {
@@ -457,5 +625,109 @@ mod tests {
         // Test dominated_by for node that doesn't exist
         let dom_by_99: Vec<_> = doms.dominated_by(99).collect();
         assert!(dom_by_99.is_empty());
+    }
+
+    #[test]
+    fn test_dag_dominators_complex() {
+        // Construct a complex DAG to test dag_dominators
+        //
+        //       0 (root)
+        //      /|\
+        //     / | \
+        //    /  |  \
+        //   1   2   3
+        //  /|   |\  |\
+        // / |   | \ | \
+        //4  5   6  7 8 9
+        //|  |   |  | |  |
+        //10 11  12 13 14 15
+        // \ /    \ /   \ /
+        //  16     17    18
+        //   \     /     /
+        //    \   /     /
+        //     \ /     /
+        //      19    /
+        //       \   /
+        //        20
+
+        let mut graph: Graph<(), (), Directed> = Graph::new();
+        let nodes: Vec<_> = (0..=20).map(|_| graph.add_node(())).collect();
+
+        // Root's children
+        graph.add_edge(nodes[0], nodes[1], ());
+        graph.add_edge(nodes[0], nodes[2], ());
+        graph.add_edge(nodes[0], nodes[3], ());
+
+        // Level 2 edges
+        graph.add_edge(nodes[1], nodes[4], ());
+        graph.add_edge(nodes[1], nodes[5], ());
+        graph.add_edge(nodes[2], nodes[6], ());
+        graph.add_edge(nodes[2], nodes[7], ());
+        graph.add_edge(nodes[3], nodes[8], ());
+        graph.add_edge(nodes[3], nodes[9], ());
+
+        // Level 3 edges
+        graph.add_edge(nodes[4], nodes[10], ());
+        graph.add_edge(nodes[5], nodes[11], ());
+        graph.add_edge(nodes[6], nodes[12], ());
+        graph.add_edge(nodes[7], nodes[13], ());
+        graph.add_edge(nodes[8], nodes[14], ());
+        graph.add_edge(nodes[9], nodes[15], ());
+
+        // Level 4 edges (converging)
+        graph.add_edge(nodes[10], nodes[16], ());
+        graph.add_edge(nodes[11], nodes[16], ());
+        graph.add_edge(nodes[12], nodes[17], ());
+        graph.add_edge(nodes[13], nodes[17], ());
+        graph.add_edge(nodes[14], nodes[18], ());
+        graph.add_edge(nodes[15], nodes[18], ());
+
+        // Final converging edges
+        graph.add_edge(nodes[16], nodes[19], ());
+        graph.add_edge(nodes[17], nodes[19], ());
+        graph.add_edge(nodes[18], nodes[20], ());
+        graph.add_edge(nodes[19], nodes[20], ());
+
+        let root = nodes[0];
+
+        // Get dominators using both algorithms
+        let doms_dag = dag_dominators(&graph, root).unwrap();
+        let doms_simple = simple_fast(&graph, root);
+
+        // Compare results
+        assert_eq!(doms_dag.root(), doms_simple.root());
+
+        // Check that immediate dominators match for all nodes
+        for node in graph.node_indices() {
+            let idom_dag = doms_dag.immediate_dominator(node);
+            let idom_simple = doms_simple.immediate_dominator(node);
+            assert_eq!(
+                idom_dag, idom_simple,
+                "Immediate dominator mismatch for node {:?}: dag={:?}, simple={:?}",
+                node, idom_dag, idom_simple
+            );
+        }
+    }
+
+    #[test]
+    fn test_dag_dominators_cycle() {
+        // Test that dag_dominators returns an error for graphs with cycles
+        //
+        //   0 ---> 1 ---> 2
+        //          ^       |
+        //          |_______|
+
+        let mut graph: Graph<(), (), Directed> = Graph::new();
+        let nodes: Vec<_> = (0..=2).map(|_| graph.add_node(())).collect();
+
+        graph.add_edge(nodes[0], nodes[1], ());
+        graph.add_edge(nodes[1], nodes[2], ());
+        graph.add_edge(nodes[2], nodes[1], ()); // Creates a cycle
+
+        let root = nodes[0];
+
+        // dag_dominators should return an error when graph has a cycle
+        let result = dag_dominators(&graph, root);
+        assert!(result.is_err());
     }
 }

--- a/crates/petgraph/src/algo/mod.rs
+++ b/crates/petgraph/src/algo/mod.rs
@@ -43,6 +43,7 @@ pub use bellman_ford::{bellman_ford, find_negative_cycle};
 pub use bridges::bridges;
 pub use coloring::dsatur_coloring;
 pub use dijkstra::{bidirectional_dijkstra, dijkstra};
+pub use dominators::{dag_dominators, simple_fast};
 pub use feedback_arc_set::greedy_feedback_arc_set;
 pub use floyd_warshall::floyd_warshall;
 pub use isomorphism::{


### PR DESCRIPTION
This PR adds two new features to the dominators module:
1. **New `dominated_by` iterator method** - Iterates over all nodes dominated by a given node (including indirectly dominated nodes)
  - This method returns all nodes that the given node dominates, including those that are indirectly dominated (i.e., descendants in the dominance tree). It uses BFS traversal through the dominance tree starting from the given node.
2. **New `dag_dominators` algorithm** - An efficient dominance computation algorithm specifically optimized for directed acyclic graphs (DAGs) using binary lifting：
    - Uses topological ordering and binary lifting (also known as jump pointers)
    - Computes immediate dominators as the Lowest Common Ancestor (LCA) of all predecessors
    - Returns Err(Cycle) if the graph contains a cycle
    **Complexity**:
    - Time: O((V + E) log V)
    - Space: O(V log V)
    The new function is more commonly used when implementing a graph compiler, as it often ensures that the graph being processed is a DAG.
    Algorithm Details: The algorithm processes nodes in topological order and uses binary lifting to efficiently compute LCAs. For each node u, its immediate dominator is the LCA of all its predecessors in the dominance tree.

Tests：Added comprehensive tests including:
test_dominated_by - Tests the new dominated_by iterator method
test_dag_dominators_complex - Tests dag_dominators on a complex 21-node DAG and verifies correctness against simple_fast
test_dag_dominators_cycle - Verifies that dag_dominators returns an error for cyclic graphs

