### PR TITLE
feat(algo): Lexicographical topological sort

### DIFF
--- a/crates/petgraph/src/algo/mod.rs
+++ b/crates/petgraph/src/algo/mod.rs
@@ -263,9 +263,10 @@ where
     })
 }
 
-/// Perform a lexicographic topological sort of a directed graph.
+/// Perform a lexicographic topological sort of a directed graph using a custom
+/// key.
 ///
-/// `toposort` returns `Err` on graphs with cycles.
+/// `lexicographic_toposort_by_key` returns `Err` on graphs with cycles.
 /// To handle graphs with cycles, use the one of scc algorithms or
 /// [`DfsPostOrder`](struct@crate::visit::DfsPostOrder)
 ///   instead of this function.
@@ -326,6 +327,13 @@ where
     }
     Ok(result)
 }
+/// Perform a lexicographic topological sort of a directed graph using node id's
+/// as keys. Node id's must be `Ord`.
+///
+/// `lexicographic_toposort` returns `Err` on graphs with cycles.
+/// To handle graphs with cycles, use the one of scc algorithms or
+/// [`DfsPostOrder`](struct@crate::visit::DfsPostOrder)
+///   instead of this function.
 pub fn lexicographic_toposort<G>(
     g: G,
     space: Option<&mut LfsSpace<G::NodeId, G::NodeId>>,
@@ -422,6 +430,7 @@ impl<N, K: Eq + Ord> Ord for Proxy<N, K> {
     }
 }
 
+/// Workspace for lexicographic graph traversal using some comparison key
 pub struct LfsSpace<N, K: Eq + Ord> {
     indegree: HashMap<N, usize>,
     sources: BinaryHeap<Reverse<Proxy<N, K>>>,

--- a/crates/petgraph/src/algo/mod.rs
+++ b/crates/petgraph/src/algo/mod.rs
@@ -283,11 +283,13 @@ where
 {
     let mut local_space;
     let lfs = if let Some(v) = space {
+        v.clear();
         v
     } else {
         local_space = LfsSpace::default();
         &mut local_space
     };
+
 
     lfs.indegree.extend(g.node_identifiers().filter_map(|n| {
         let deg = g.neighbors_directed(n, Direction::Incoming).count();
@@ -441,6 +443,12 @@ impl<N, K: Eq + Ord> Default for LfsSpace<N, K> {
             indegree: Default::default(),
             sources: Default::default(),
         }
+    }
+}
+impl<N, K: Eq + Ord> LfsSpace<N, K> {
+    fn clear(&mut self) {
+        self.indegree.clear();
+        self.sources.clear();
     }
 }
 

--- a/crates/petgraph/src/algo/mod.rs
+++ b/crates/petgraph/src/algo/mod.rs
@@ -37,6 +37,7 @@ pub mod steiner_tree;
 pub mod tred;
 
 use alloc::{collections::BinaryHeap, vec, vec::Vec};
+use hashbrown::HashMap;
 
 pub use astar::astar;
 pub use bellman_ford::{bellman_ford, find_negative_cycle};
@@ -45,7 +46,6 @@ pub use coloring::dsatur_coloring;
 pub use dijkstra::{bidirectional_dijkstra, dijkstra};
 pub use feedback_arc_set::greedy_feedback_arc_set;
 pub use floyd_warshall::floyd_warshall;
-use hashbrown::HashMap;
 pub use isomorphism::{
     is_isomorphic, is_isomorphic_matching, is_isomorphic_subgraph, is_isomorphic_subgraph_matching,
     subgraph_isomorphisms_iter,

--- a/crates/petgraph/src/algo/mod.rs
+++ b/crates/petgraph/src/algo/mod.rs
@@ -338,7 +338,7 @@ where
 ///   instead of this function.
 pub fn lexicographic_toposort<G>(
     g: G,
-    space: Option<&mut LfsSpace<G::NodeId, G::NodeId>>,
+    space: Option<&mut LfsSpace<G::NodeId>>,
 ) -> Result<Vec<G::NodeId>, Cycle<G::NodeId>>
 where
     G: IntoNeighborsDirected + IntoNodeIdentifiers + Visitable,
@@ -411,16 +411,16 @@ where
     }
 }
 
-pub struct Proxy<N, K: Eq + Ord> {
+pub struct Proxy<N, K> {
     key: K,
     id: N,
 }
-impl<N, K: Eq + Ord> PartialEq for Proxy<N, K> {
+impl<N, K: Eq> PartialEq for Proxy<N, K> {
     fn eq(&self, other: &Self) -> bool {
         self.key.eq(&other.key)
     }
 }
-impl<N, K: Eq + Ord> Eq for Proxy<N, K> {}
+impl<N, K: Eq> Eq for Proxy<N, K> {}
 impl<N, K: Eq + Ord> PartialOrd for Proxy<N, K> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         self.key.partial_cmp(&other.key)
@@ -433,7 +433,7 @@ impl<N, K: Eq + Ord> Ord for Proxy<N, K> {
 }
 
 /// Workspace for lexicographic graph traversal using some comparison key
-pub struct LfsSpace<N, K: Eq + Ord> {
+pub struct LfsSpace<N, K = N> {
     indegree: HashMap<N, usize>,
     sources: BinaryHeap<Reverse<Proxy<N, K>>>,
 }

--- a/crates/petgraph/src/algo/mod.rs
+++ b/crates/petgraph/src/algo/mod.rs
@@ -270,7 +270,7 @@ where
 /// To handle graphs with cycles, use the one of scc algorithms or
 /// [`DfsPostOrder`](struct@crate::visit::DfsPostOrder)
 ///   instead of this function.
-pub fn lexicographic_toposort_by_key<G, K: Eq + Ord, F>(
+pub fn lexicographic_toposort_by_key<G, K, F>(
     g: G,
     space: Option<&mut LfsSpace<G::NodeId, K>>,
     mut f: F,

--- a/crates/petgraph/tests/graph.rs
+++ b/crates/petgraph/tests/graph.rs
@@ -757,7 +757,7 @@ fn test_toposort() {
 
     assert_is_topo_order(&gr, &order);
 
-    let order = petgraph::algo::lexicographic_toposort(&gr).unwrap();
+    let order = petgraph::algo::lexicographic_toposort(&gr, None).unwrap();
     println!("{order:?}");
     assert_eq!(order.len(), gr.node_count());
 
@@ -772,6 +772,21 @@ fn test_toposort_eq() {
     g.add_edge(a, b, ());
 
     assert_eq!(petgraph::algo::toposort(&g, None), Ok(vec![a, b]));
+}
+
+#[test]
+fn test_lexicographic_toposort() {
+    let mut gr = Graph::<_, ()>::new();
+    let a = gr.add_node("AAAA");
+    let b = gr.add_node("BB");
+    let c = gr.add_node("CCC");
+    let d = gr.add_node("D");
+    let order = petgraph::algo::lexicographic_toposort_by_key(&gr, None, |n| {
+        gr.node_weight(*n).unwrap().len()
+    }).unwrap();
+
+    assert_eq!(order, vec![d, b, c, a]);
+    assert_is_topo_order(&gr, &order);
 }
 
 #[test]

--- a/crates/petgraph/tests/graph.rs
+++ b/crates/petgraph/tests/graph.rs
@@ -756,6 +756,12 @@ fn test_toposort() {
     assert_eq!(order.len(), gr.node_count());
 
     assert_is_topo_order(&gr, &order);
+
+    let order = petgraph::algo::lexicographic_toposort(&gr).unwrap();
+    println!("{order:?}");
+    assert_eq!(order.len(), gr.node_count());
+
+    assert_is_topo_order(&gr, &order);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a lexicographic topological sort based on the implementation in https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.dag.lexicographical_topological_sort.html

Resolves #939

One problem with this is we cannot directly reuse the dfs space. I added a new `LfsSpace` which could be used for other operations where node traversal has to follow some particular key order in the case of ambiguity. `LfsSpace` space is slightly different from `DfsSpace`, in that it stores a remaining in-degree map and a heap, but not `visited`. Both of these data structures can have capacity drastically smaller than the graph itself. Although their sizes must sum to the graph node count.

- [x] Add `lexicographic_toposort`
- [x] Add `LfsSpace::<NodeId, Key>` for reusable spaces
- [x] Sorting by custom keys in `lexicographic_toposort_by_key`