### PR TITLE
feat: Add Display Implementation for NodeIndex<Ix> and EdgeIndex<Ix> whenever Ix: Display.

### DIFF
--- a/src/dot/mod.rs
+++ b/src/dot/mod.rs
@@ -364,9 +364,9 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if f.alternate() {
-            writeln!(&mut Escaper(f), "{:#}", &self.0)
+            writeln!(&mut Escaper(f), "{:#}", self.0)
         } else {
-            write!(&mut Escaper(f), "{}", &self.0)
+            write!(&mut Escaper(f), "{}", self.0)
         }
     }
 }

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -125,6 +125,12 @@ impl<Ix: IndexType> NodeIndex<Ix> {
     }
 }
 
+impl<Ix: fmt::Display> fmt::Display for NodeIndex<Ix> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NodeIndex({})", self.0)
+    }
+}
+
 unsafe impl<Ix: IndexType> IndexType for NodeIndex<Ix> {
     fn index(&self) -> usize {
         self.0.index()
@@ -189,6 +195,12 @@ impl<Ix: IndexType> EdgeIndex<Ix> {
 impl<Ix: IndexType> From<Ix> for EdgeIndex<Ix> {
     fn from(ix: Ix) -> Self {
         EdgeIndex(ix)
+    }
+}
+
+impl<Ix: fmt::Display> fmt::Display for EdgeIndex<Ix> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "EdgeIndex({})", self.0)
     }
 }
 

--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -865,10 +865,11 @@ where
         // every edge is part of two lists,
         // outgoing and incoming edges.
         // Remove it from both
-        let (edge_node, edge_next) = match self.edges.get(e.index()) {
-            None => return None,
-            Some(x) => (x.node, x.next),
+        let (edge_node, edge_next) = {
+            let x = self.edges.get(e.index())?;
+            (x.node, x.next)
         };
+
         // Remove the edge from its in and out lists by replacing it with
         // a link to the next in the list.
         self.change_edge_links(edge_node, e, edge_next);

--- a/src/graph_impl/stable_graph/mod.rs
+++ b/src/graph_impl/stable_graph/mod.rs
@@ -621,9 +621,9 @@ where
         // every edge is part of two lists,
         // outgoing and incoming edges.
         // Remove it from both
-        let (is_edge, edge_node, edge_next) = match self.g.edges.get(e.index()) {
-            None => return None,
-            Some(x) => (x.weight.is_some(), x.node, x.next),
+        let (is_edge, edge_node, edge_next) = {
+            let x = self.g.edges.get(e.index())?;
+            (x.weight.is_some(), x.node, x.next)
         };
         if !is_edge {
             return None;
@@ -2506,7 +2506,7 @@ fn dfs() {
 
     let mut dfs = Dfs::new(&gr, a);
     while let Some(next) = dfs.next(&gr) {
-        println!("dfs visit => {:?}, weight={:?}", next, &gr[next]);
+        println!("dfs visit => {:?}, weight={:?}", next, gr[next]);
     }
 }
 

--- a/tests/maximal_cliques.rs
+++ b/tests/maximal_cliques.rs
@@ -209,7 +209,7 @@ fn test_maximal_cliques_undirected() {
     g.extend_with_edges([(a, b), (a, e), (b, e), (b, c), (c, d), (d, e), (e, f)]);
 
     let cliques = maximal_cliques(&g);
-    println!("{:?}", &cliques);
+    println!("{:?}", cliques);
 
     let expected_cliques = vec![
         vec![a, b, e],
@@ -240,7 +240,7 @@ fn test_maximal_cliques_ref_undirected() {
     g.extend_with_edges([(a, b), (a, e), (b, e), (b, c), (c, d), (d, e), (e, f)]);
 
     let cliques = maximal_cliques_ref(&g);
-    println!("{:?}", &cliques);
+    println!("{:?}", cliques);
 
     let expected_cliques = vec![
         vec![a, b, e],
@@ -288,7 +288,7 @@ fn test_maximal_cliques_directed() {
     ]);
 
     let cliques = maximal_cliques(&g);
-    println!("{:?}", &cliques);
+    println!("{:?}", cliques);
 
     let expected_cliques = vec![
         vec![a, b, e],
@@ -336,7 +336,7 @@ fn test_maximal_cliques_ref_directed() {
     ]);
 
     let cliques = maximal_cliques_ref(&g);
-    println!("{:?}", &cliques);
+    println!("{:?}", cliques);
 
     let expected_cliques = vec![
         vec![a, b, e],


### PR DESCRIPTION
This PR implements the `Display` trait for `NodeIndex<Ix>` and `EdgeIndex<Ix>`, if `Ix: Display`.

During the implementation of the new Traits on the "old" graph types as described in https://github.com/petgraph/petgraph/issues/891, we noticed that these Impls would be useful.