### PR TITLE
feat: Expose mutable Edge Weight iterators for MatrixGraph

### DIFF
--- a/src/graph_impl/mod.rs
+++ b/src/graph_impl/mod.rs
@@ -125,6 +125,12 @@ impl<Ix: IndexType> NodeIndex<Ix> {
     }
 }
 
+impl<Ix: fmt::Display> fmt::Display for NodeIndex<Ix> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NodeIndex({})", self.0)
+    }
+}
+
 unsafe impl<Ix: IndexType> IndexType for NodeIndex<Ix> {
     fn index(&self) -> usize {
         self.0.index()
@@ -189,6 +195,12 @@ impl<Ix: IndexType> EdgeIndex<Ix> {
 impl<Ix: IndexType> From<Ix> for EdgeIndex<Ix> {
     fn from(ix: Ix) -> Self {
         EdgeIndex(ix)
+    }
+}
+
+impl<Ix: fmt::Display> fmt::Display for EdgeIndex<Ix> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "EdgeIndex({})", self.0)
     }
 }
 

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -524,6 +524,11 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
         None
     }
 
+    /// Return `true` if the node `a` exists.
+    pub fn has_node(&self, a: NodeIndex<Ix>) -> bool {
+        a.index() < self.node_capacity && self.nodes.removed_ids.contains(&a.index()) == false
+    }
+
     /// Return `true` if there is an edge between `a` and `b`.
     ///
     /// If any of the nodes don't exist - returns `false`.

--- a/src/matrix_graph.rs
+++ b/src/matrix_graph.rs
@@ -1772,6 +1772,8 @@ impl<N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexT
 
 #[cfg(test)]
 mod tests {
+    use hashbrown::HashSet;
+
     use super::*;
     use crate::{Incoming, Outgoing};
     use std::collections::hash_map::RandomState;
@@ -1850,6 +1852,20 @@ mod tests {
         assert!(g.has_edge(n2, n1));
         assert!(g.has_edge(n2, n3));
         assert!(g.has_edge(n2, n4));
+    }
+
+    #[test]
+    fn test_has_node() {
+        let mut g = MatrixGraph::<_, _, RandomState>::new();
+        let a = g.add_node('a');
+        let b = g.add_node('b');
+        let c = g.add_node('c');
+        g.add_edge(a, b, ());
+        g.add_edge(b, c, ());
+        assert!(g.has_node(a));
+        assert!(g.has_node(b));
+        assert!(g.has_node(c));
+        assert!(!g.has_node(10.into())); // Non-existent node.
     }
 
     #[test]
@@ -2169,6 +2185,88 @@ mod tests {
     fn test_edges_of_absent_node_is_empty_iterator() {
         let g: MatrixGraph<char, bool> = MatrixGraph::new();
         assert_eq!(g.edges(node_index(0)).count(), 0);
+    }
+
+    #[test]
+    fn test_all_edges() {
+        let g: MatrixGraph<(), ()> = MatrixGraph::from_edges([
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 5),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (4, 0),
+            (6, 6),
+        ]);
+
+        assert_eq!(g.all_edges().count(), g.edge_count());
+
+        let mut expected_edges: HashSet<(usize, usize)> = HashSet::from_iter([
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 5),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (4, 0),
+            (6, 6),
+        ]);
+
+        for (a, b, _) in g.all_edges() {
+            let edge = (a.index(), b.index());
+            assert!(expected_edges.remove(&edge));
+        }
+        assert!(expected_edges.is_empty());
+    }
+
+    #[test]
+    fn test_all_edges_mut() {
+        let mut g: MatrixGraph<(), ()> = MatrixGraph::from_edges([
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 5),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (4, 0),
+            (6, 6),
+        ]);
+
+        assert_eq!(g.all_edges_mut().count(), g.edge_count());
+
+        let mut expected_edges: HashSet<(usize, usize)> = HashSet::from_iter([
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (0, 5),
+            (1, 3),
+            (2, 3),
+            (2, 4),
+            (4, 0),
+            (6, 6),
+        ]);
+
+        for (a, b, _) in g.all_edges_mut() {
+            let edge = (a.index(), b.index());
+            assert!(expected_edges.remove(&edge));
+        }
+        assert!(expected_edges.is_empty());
+    }
+
+    #[test]
+    fn test_all_edges_empty_graph() {
+        let g: MatrixGraph<(), ()> = MatrixGraph::new();
+        assert_eq!(g.all_edges().count(), 0);
+    }
+
+    #[test]
+    fn test_all_edges_mut_empty_graph() {
+        let mut g: MatrixGraph<(), ()> = MatrixGraph::new();
+        assert_eq!(g.all_edges_mut().count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds `all_nodes`, `all_nodes_mut` and `all_edges`, `all_edges_mut` Methods to `MatrixGraph` (and adds corresponding tests).

During the implementation of the new Traits on the "old" graph types as described in https://github.com/petgraph/petgraph/issues/891, we noticed  that such methods would be useful, if not, necessary to implement the new traits on `MatrixGraph`.

This PR depends on the PR #941 being merged.