### PR TITLE
test: Add `DirectedGraph` Test macro

### DIFF
--- a/crates/core/src/utils/directed.rs
+++ b/crates/core/src/utils/directed.rs
@@ -94,6 +94,16 @@ where
         self.edges.insert(id, (source, target, edge));
         Some(id)
     }
+
+    pub fn remove_node(&mut self, node_id: NI) -> Option<N> {
+        self.edges
+            .retain(|_, (source, target, _)| *source != node_id && *target != node_id);
+        self.nodes.remove(&node_id)
+    }
+
+    pub fn remove_edge(&mut self, edge_id: EI) -> Option<E> {
+        self.edges.remove(&edge_id).map(|(_, _, data)| data)
+    }
 }
 
 impl<N, E, NI, EI> Default for DirectedTestGraph<N, E, NI, EI>
@@ -178,6 +188,13 @@ mod test {
     use super::*;
     use crate::test_directed_graph;
 
+    fn remove_node_with_unwrap(
+        graph: &mut DirectedTestGraph<(), (), NodeId, EdgeId>,
+        node_id: NodeId,
+    ) {
+        graph.remove_node(node_id).unwrap();
+    }
+
     fn add_edge_with_unwrap(
         graph: &mut DirectedTestGraph<(), (), NodeId, EdgeId>,
         source: NodeId,
@@ -187,9 +204,18 @@ mod test {
         graph.add_edge(source, target, ()).unwrap()
     }
 
+    fn remove_edge_with_unwrap(
+        graph: &mut DirectedTestGraph<(), (), NodeId, EdgeId>,
+        edge_id: EdgeId,
+    ) {
+        graph.remove_edge(edge_id).unwrap();
+    }
+
     test_directed_graph!(
         DirectedTestGraph::<(), (), NodeId, EdgeId>::new,
         DirectedTestGraph::<(), (), NodeId, EdgeId>::add_node,
-        add_edge_with_unwrap
+        remove_node_with_unwrap,
+        add_edge_with_unwrap,
+        remove_edge_with_unwrap
     );
 }

--- a/crates/core/src/utils/directed.rs
+++ b/crates/core/src/utils/directed.rs
@@ -13,7 +13,7 @@ use crate::{
     node::{Node, NodeMut, NodeRef},
 };
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub struct NodeId(usize);
 
 impl AddAssign<usize> for NodeId {
@@ -30,7 +30,7 @@ impl Display for NodeId {
 
 impl Id for NodeId {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub struct EdgeId(usize);
 
 impl AddAssign<usize> for EdgeId {
@@ -171,4 +171,25 @@ where
                 data,
             })
     }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_directed_graph;
+
+    fn add_edge_with_unwrap(
+        graph: &mut DirectedTestGraph<(), (), NodeId, EdgeId>,
+        source: NodeId,
+        target: NodeId,
+        _data: (),
+    ) -> EdgeId {
+        graph.add_edge(source, target, ()).unwrap()
+    }
+
+    test_directed_graph!(
+        DirectedTestGraph::<(), (), NodeId, EdgeId>::new,
+        DirectedTestGraph::<(), (), NodeId, EdgeId>::add_node,
+        add_edge_with_unwrap
+    );
 }

--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod directed;
+pub mod testing;

--- a/crates/core/src/utils/testing.rs
+++ b/crates/core/src/utils/testing.rs
@@ -15,8 +15,8 @@ pub const DIRECTED_TEST_GRAPH_EDGE_COUNT: usize = 4;
 /// For ordering of added nodes and edges, see the implementation of the macro.
 #[macro_export]
 macro_rules! create_directed_test_graph {
-    ($graph_constructer:expr, $add_node:expr, $add_edge:expr) => {{
-        let mut graph = $graph_constructer();
+    ($graph_constructor:expr, $add_node:expr, $add_edge:expr) => {{
+        let mut graph = $graph_constructor();
 
         let node_zero = $add_node(&mut graph, ());
         let node_one = $add_node(&mut graph, ());
@@ -49,11 +49,11 @@ macro_rules! create_directed_test_graph {
 /// TODO Check where it would be useful to have a remove_node and remove_edge function
 #[macro_export]
 macro_rules! test_directed_graph {
-    ($graph_constructer:expr, $add_node:expr, $add_edge:expr) => {
+    ($graph_constructor:expr, $add_node:expr, $add_edge:expr) => {
         #[test]
         fn test_cardinality() {
             let (graph, _, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
                 graph.node_count(),
                 $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
@@ -81,7 +81,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_nodes() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let nodes_count = graph.nodes().count();
             assert_eq!(
                 nodes_count,
@@ -100,7 +100,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_nodes_mut() {
             let (mut graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let nodes_count = graph.nodes_mut().count();
             assert_eq!(
                 nodes_count,
@@ -119,7 +119,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_isolated_nodes() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let isolated_nodes_count = graph.isolated_nodes().count();
             assert_eq!(
                 isolated_nodes_count, 1,
@@ -140,7 +140,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_edges() {
             let (graph, _, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let edges_count = graph.edges().count();
             assert_eq!(
                 edges_count,
@@ -159,7 +159,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_edges_mut() {
             let (mut graph, _, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let edges_count = graph.edges_mut().count();
             assert_eq!(
                 edges_count,
@@ -178,7 +178,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_node() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             for &node_id in &nodes {
                 let node = graph.node(node_id).unwrap();
                 assert_eq!(
@@ -191,7 +191,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_node_mut() {
             let (mut graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             for &node_id in &nodes {
                 let node = graph.node_mut(node_id).unwrap();
                 assert_eq!(
@@ -204,7 +204,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_edge() {
             let (graph, _, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             for &edge_id in &edges {
                 let edge = graph.edge(edge_id).unwrap();
                 assert_eq!(
@@ -217,7 +217,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_edge_mut() {
             let (mut graph, _, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             for &edge_id in &edges {
                 let edge = graph.edge_mut(edge_id).unwrap();
                 assert_eq!(
@@ -230,7 +230,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_in_degree() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
                 graph.in_degree(nodes[0]),
                 0,
@@ -261,7 +261,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_out_degree() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
                 graph.out_degree(nodes[0]),
                 2,
@@ -292,7 +292,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_degree() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
                 graph.degree(nodes[0]),
                 2,
@@ -347,7 +347,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_incoming_edges() {
             let (graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert!(
                 graph.incoming_edges(nodes[0]).next().is_none(),
                 "graph.incoming_edges() did not return an empty iterator for node 0"
@@ -395,7 +395,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_incoming_edges_mut() {
             let (mut graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert!(
                 graph.incoming_edges_mut(nodes[0]).next().is_none(),
                 "graph.incoming_edges_mut() did not return an empty iterator for node 0"
@@ -443,7 +443,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_outgoing_edges() {
             let (graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let expected_edges_zero =
                 hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
                     edges[0], edges[1],
@@ -491,7 +491,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_outgoing_edges_mut() {
             let (mut graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let expected_edges_zero =
                 hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
                     edges[0], edges[1],
@@ -539,7 +539,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_incident_edges() {
             let (graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let expected_edges_zero =
                 hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
                     edges[0], edges[1],
@@ -593,7 +593,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_incident_edges_mut() {
             let (mut graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let expected_edges_zero =
                 hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
                     edges[0], edges[1],
@@ -672,7 +672,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_predecessors() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert!(
                 graph.predecessors(nodes[0]).next().is_none(),
                 "graph.predecessors() did not return an empty iterator for node 0"
@@ -720,7 +720,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_successors() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let expected_successors_zero = hashbrown::hash_set::HashSet::<
                 _,
                 foldhash::fast::RandomState,
@@ -768,7 +768,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_adjacencies() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             let expected_adjacencies_zero = hashbrown::hash_set::HashSet::<
                 _,
                 foldhash::fast::RandomState,
@@ -823,7 +823,7 @@ macro_rules! test_directed_graph {
         #[allow(clippy::too_many_lines)]
         fn test_edges_between() {
             let (graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             // Source 0
             assert!(
@@ -983,7 +983,7 @@ macro_rules! test_directed_graph {
         #[allow(clippy::too_many_lines)]
         fn test_edges_between_mut() {
             let (mut graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             // Source 0
             assert!(
@@ -1151,7 +1151,7 @@ macro_rules! test_directed_graph {
         #[allow(clippy::too_many_lines)]
         fn test_edges_connecting() {
             let (graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             // Source 0
             assert!(
@@ -1295,7 +1295,7 @@ macro_rules! test_directed_graph {
         #[allow(clippy::too_many_lines)]
         fn test_edges_connecting_mut() {
             let (mut graph, nodes, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             // Source 0
             assert!(
@@ -1475,7 +1475,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_contains_node() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             for node in nodes.iter() {
                 assert!(
@@ -1489,7 +1489,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_contains_edge() {
             let (graph, _, edges) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             for edge in edges.iter() {
                 assert!(
@@ -1503,7 +1503,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_is_adjacent() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             let adjacent_node_pairs = [
                 (nodes[0], nodes[1]),
@@ -1529,14 +1529,14 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_is_empty() {
             let (graph, _, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             assert!(
                 !graph.is_empty(),
                 "graph.is_empty() returned true for a non-empty graph"
             );
 
-            let new_graph = $graph_constructer();
+            let new_graph = $graph_constructor();
             assert!(
                 new_graph.is_empty(),
                 "graph.is_empty() returned false for an empty graph"
@@ -1546,7 +1546,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_sources() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             let expected_sources =
                 hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
@@ -1563,7 +1563,7 @@ macro_rules! test_directed_graph {
         #[test]
         fn test_sinks() {
             let (graph, nodes, _) =
-                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             let expected_sinks =
                 hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([

--- a/crates/core/src/utils/testing.rs
+++ b/crates/core/src/utils/testing.rs
@@ -1,0 +1,454 @@
+pub const DIRECTED_TEST_GRAPH_NODE_COUNT: usize = 5;
+pub const DIRECTED_TEST_GRAPH_EDGE_COUNT: usize = 4;
+
+/// A macro to create a simple directed graph for testing purposes.
+///
+/// The graph looks as follows:
+/// 0 --> 1
+/// |      |
+/// v      v
+/// 2 <----3     4
+///
+/// The macro returns a tuple containing the constructed graph,
+/// a vector of the indices of added nodes, and a vector of the indices of added edges.
+///
+/// For ordering of added nodes and edges, see the implementation of the macro.
+#[macro_export]
+macro_rules! create_directed_test_graph {
+    ($graph_constructer:expr, $add_node:expr, $add_edge:expr) => {{
+        let mut graph = $graph_constructer();
+
+        let node_zero = $add_node(&mut graph, ());
+        let node_one = $add_node(&mut graph, ());
+        let node_two = $add_node(&mut graph, ());
+        let node_three = $add_node(&mut graph, ());
+        let node_four = $add_node(&mut graph, ());
+
+        let nodes = [node_zero, node_one, node_two, node_three, node_four];
+
+        let edge_zero = $add_edge(&mut graph, nodes[0], nodes[1], ());
+        let edge_one = $add_edge(&mut graph, nodes[0], nodes[2], ());
+        let edge_two = $add_edge(&mut graph, nodes[1], nodes[3], ());
+        let edge_three = $add_edge(&mut graph, nodes[3], nodes[2], ());
+
+        let edges = [edge_zero, edge_one, edge_two, edge_three];
+
+        assert_eq!(
+            nodes.len(),
+            $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT
+        );
+        assert_eq!(
+            edges.len(),
+            $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT
+        );
+
+        (graph, nodes, edges)
+    }};
+}
+
+#[macro_export]
+macro_rules! test_directed_graph {
+    ($graph_constructer:expr, $add_node:expr, $add_edge:expr) => {
+        #[test]
+        fn test_cardinality() {
+            let (graph, _, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            assert_eq!(
+                graph.node_count(),
+                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
+                "graph.node_count() did not match expected value"
+            );
+            assert_eq!(
+                graph.edge_count(),
+                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT,
+                "graph.edge_count() did not match expected value"
+            );
+
+            let cardinality = graph.cardinality();
+            assert_eq!(
+                cardinality.order,
+                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
+                "graph.cardinality().order did not match expected value"
+            );
+            assert_eq!(
+                cardinality.size,
+                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT,
+                "graph.cardinality().size did not match expected value"
+            );
+        }
+
+        #[test]
+        fn test_nodes() {
+            let (graph, nodes, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            let nodes_count = graph.nodes().count();
+            assert_eq!(
+                nodes_count,
+                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
+                "graph.nodes().count() did not match expected value"
+            );
+            for node in graph.nodes() {
+                assert!(
+                    nodes.contains(&node.id),
+                    "graph.nodes() contained unexpected node id: {:?}",
+                    node.id
+                );
+            }
+        }
+
+        #[test]
+        fn test_nodes_mut() {
+            let (mut graph, nodes, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            let nodes_count = graph.nodes_mut().count();
+            assert_eq!(
+                nodes_count,
+                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
+                "graph.nodes_mut().count() did not match expected value"
+            );
+            for node in graph.nodes_mut() {
+                assert!(
+                    nodes.contains(&node.id),
+                    "graph.nodes_mut() contained unexpected node id: {:?}",
+                    node.id
+                );
+            }
+        }
+
+        #[test]
+        fn test_isolated_nodes() {
+            let (graph, nodes, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            let isolated_nodes_count = graph.isolated_nodes().count();
+            assert_eq!(
+                isolated_nodes_count, 1,
+                "graph.isolated_nodes().count() did not match expected value"
+            );
+            let mut isolated_nodes_iter = graph.isolated_nodes();
+            let first_isolated_node = isolated_nodes_iter.next().unwrap();
+            assert_eq!(
+                first_isolated_node.id, nodes[4],
+                "graph.isolated_nodes() did not return expected node id"
+            );
+            assert!(
+                isolated_nodes_iter.next().is_none(),
+                "graph.isolated_nodes() returned more nodes than expected"
+            );
+        }
+
+        #[test]
+        fn test_edges() {
+            let (graph, _, edges) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            let edges_count = graph.edges().count();
+            assert_eq!(
+                edges_count,
+                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT,
+                "graph.edges().count() did not match expected value"
+            );
+            for edge in graph.edges() {
+                assert!(
+                    edges.contains(&edge.id),
+                    "graph.edges() contained unexpected edge id: {:?}",
+                    edge.id
+                );
+            }
+        }
+
+        #[test]
+        fn test_edges_mut() {
+            let (mut graph, _, edges) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            let edges_count = graph.edges_mut().count();
+            assert_eq!(
+                edges_count,
+                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT,
+                "graph.edges_mut().count() did not match expected value"
+            );
+            for edge in graph.edges_mut() {
+                assert!(
+                    edges.contains(&edge.id),
+                    "graph.edges_mut() contained unexpected edge id: {:?}",
+                    edge.id
+                );
+            }
+        }
+
+        #[test]
+        fn test_node() {
+            let (graph, nodes, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            for &node_id in &nodes {
+                let node = graph.node(node_id).unwrap();
+                assert_eq!(
+                    node.id, node_id,
+                    "graph.node() did not return expected node id"
+                );
+            }
+        }
+
+        #[test]
+        fn test_node_mut() {
+            let (mut graph, nodes, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            for &node_id in &nodes {
+                let node = graph.node_mut(node_id).unwrap();
+                assert_eq!(
+                    node.id, node_id,
+                    "graph.node_mut() did not return expected node id"
+                );
+            }
+        }
+
+        #[test]
+        fn test_edge() {
+            let (graph, _, edges) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            for &edge_id in &edges {
+                let edge = graph.edge(edge_id).unwrap();
+                assert_eq!(
+                    edge.id, edge_id,
+                    "graph.edge() did not return expected edge id"
+                );
+            }
+        }
+
+        #[test]
+        fn test_edge_mut() {
+            let (mut graph, _, edges) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            for &edge_id in &edges {
+                let edge = graph.edge_mut(edge_id).unwrap();
+                assert_eq!(
+                    edge.id, edge_id,
+                    "graph.edge_mut() did not return expected edge id"
+                );
+            }
+        }
+
+        #[test]
+        fn test_in_degree() {
+            let (graph, nodes, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            assert_eq!(
+                graph.in_degree(nodes[0]),
+                0,
+                "graph.in_degree() did not return expected value for node 0"
+            );
+            assert_eq!(
+                graph.in_degree(nodes[1]),
+                1,
+                "graph.in_degree() did not return expected value for node 1"
+            );
+            assert_eq!(
+                graph.in_degree(nodes[2]),
+                2,
+                "graph.in_degree() did not return expected value for node 2"
+            );
+            assert_eq!(
+                graph.in_degree(nodes[3]),
+                1,
+                "graph.in_degree() did not return expected value for node 3"
+            );
+            assert_eq!(
+                graph.in_degree(nodes[4]),
+                0,
+                "graph.in_degree() did not return expected value for node 4"
+            );
+        }
+
+        #[test]
+        fn test_out_degree() {
+            let (graph, nodes, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            assert_eq!(
+                graph.out_degree(nodes[0]),
+                2,
+                "graph.out_degree() did not return expected value for node 0"
+            );
+            assert_eq!(
+                graph.out_degree(nodes[1]),
+                1,
+                "graph.out_degree() did not return expected value for node 1"
+            );
+            assert_eq!(
+                graph.out_degree(nodes[2]),
+                0,
+                "graph.out_degree() did not return expected value for node 2"
+            );
+            assert_eq!(
+                graph.out_degree(nodes[3]),
+                1,
+                "graph.out_degree() did not return expected value for node 3"
+            );
+            assert_eq!(
+                graph.out_degree(nodes[4]),
+                0,
+                "graph.out_degree() did not return expected value for node 4"
+            );
+        }
+
+        #[test]
+        fn test_degree() {
+            let (graph, nodes, _) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            assert_eq!(
+                graph.degree(nodes[0]),
+                2,
+                "graph.degree() did not return expected value for node 0"
+            );
+            assert_eq!(
+                graph.degree(nodes[1]),
+                2,
+                "graph.degree() did not return expected value for node 1"
+            );
+            assert_eq!(
+                graph.degree(nodes[2]),
+                2,
+                "graph.degree() did not return expected value for node 2"
+            );
+            assert_eq!(
+                graph.degree(nodes[3]),
+                2,
+                "graph.degree() did not return expected value for node 3"
+            );
+            assert_eq!(
+                graph.degree(nodes[4]),
+                0,
+                "graph.degree() did not return expected value for node 4"
+            );
+        }
+
+        fn check_if_incoming_edges_matches<T: core::hash::Hash + Eq + core::fmt::Debug>(
+            mut expected_edges: hashbrown::hash_set::HashSet<T, foldhash::fast::RandomState>,
+            actual_edges: impl Iterator<Item = T>,
+            node_number: usize,
+        ) {
+            for edge in actual_edges {
+                assert!(
+                    expected_edges.contains(&edge),
+                    "graph.incoming_edges() contained unexpected edge id: {:?} for node {}",
+                    edge,
+                    node_number
+                );
+                expected_edges.remove(&edge);
+            }
+            assert!(
+                expected_edges.is_empty(),
+                "graph.incoming_edges() did not return all expected edges for node {}",
+                node_number
+            );
+        }
+
+        #[test]
+        fn test_incoming_edges() {
+            let (graph, nodes, edges) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            assert!(
+                graph.incoming_edges(nodes[0]).next().is_none(),
+                "graph.incoming_edges() did not return an empty iterator for node 0"
+            );
+
+            let expected_edges_one =
+                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
+                    edges[0]
+                ]);
+            check_if_incoming_edges_matches(
+                expected_edges_one,
+                graph.incoming_edges(nodes[1]).map(|edge| edge.id),
+                1,
+            );
+
+            let expected_edges_two =
+                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
+                    edges[1], edges[3],
+                ]);
+            check_if_incoming_edges_matches(
+                expected_edges_two,
+                graph.incoming_edges(nodes[2]).map(|edge| edge.id),
+                2,
+            );
+
+            let expected_edges_three =
+                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
+                    edges[2]
+                ]);
+            check_if_incoming_edges_matches(
+                expected_edges_three,
+                graph.incoming_edges(nodes[3]).map(|edge| edge.id),
+                3,
+            );
+
+            assert!(
+                graph.incoming_edges(nodes[4]).next().is_none(),
+                "graph.incoming_edges() did not return an empty iterator for node 4"
+            );
+        }
+
+        fn check_if_incoming_edges_mut_matches<T: core::hash::Hash + Eq + core::fmt::Debug>(
+            mut expected_edges: hashbrown::hash_set::HashSet<T, foldhash::fast::RandomState>,
+            actual_edges: impl Iterator<Item = T>,
+            node_number: usize,
+        ) {
+            for edge in actual_edges {
+                assert!(
+                    expected_edges.contains(&edge),
+                    "graph.incoming_edges() contained unexpected edge id: {:?} for node {}",
+                    edge,
+                    node_number
+                );
+                expected_edges.remove(&edge);
+            }
+            assert!(
+                expected_edges.is_empty(),
+                "graph.incoming_edges() did not return all expected edges for node {}",
+                node_number
+            );
+        }
+
+        #[test]
+        fn test_incoming_edges_mut() {
+            let (mut graph, nodes, edges) =
+                $crate::create_directed_test_graph!($graph_constructer, $add_node, $add_edge);
+            assert!(
+                graph.incoming_edges_mut(nodes[0]).next().is_none(),
+                "graph.incoming_edges_mut() did not return an empty iterator for node 0"
+            );
+
+            let expected_edges_one =
+                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
+                    edges[0]
+                ]);
+            check_if_incoming_edges_mut_matches(
+                expected_edges_one,
+                graph.incoming_edges_mut(nodes[1]).map(|edge| edge.id),
+                1,
+            );
+
+            let expected_edges_two =
+                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
+                    edges[1], edges[3],
+                ]);
+            check_if_incoming_edges_mut_matches(
+                expected_edges_two,
+                graph.incoming_edges_mut(nodes[2]).map(|edge| edge.id),
+                2,
+            );
+
+            let expected_edges_three =
+                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
+                    edges[2]
+                ]);
+            check_if_incoming_edges_mut_matches(
+                expected_edges_three,
+                graph.incoming_edges_mut(nodes[3]).map(|edge| edge.id),
+                3,
+            );
+
+            assert!(
+                graph.incoming_edges_mut(nodes[4]).next().is_none(),
+                "graph.incoming_edges_mut() did not return an empty iterator for node 4"
+            );
+        }
+    };
+}

--- a/crates/core/src/utils/testing.rs
+++ b/crates/core/src/utils/testing.rs
@@ -46,15 +46,16 @@ macro_rules! create_directed_test_graph {
     }};
 }
 
-/// Generates a suite of tests for [`DirectedGraph`] implementations.
+/// Generates a suite of tests for [`DirectedGraph`][crate::graph::DirectedGraph]
+/// implementations.
 ///
-/// One test is generated for each method in the [`DirectedGraph`] trait.
-/// The following invariants are expected from the graph implementation:
+/// One test is generated for each method in the [`DirectedGraph`][crate::graph::DirectedGraph]
+/// trait. The following invariants are expected from the graph implementation:
 /// - If the most recently added node or edge is removed, its ID will no longer be valid. I.e.,
 ///   calling methods with that ID should return `None` or indicate non-existence.
 ///
 /// The arguments to this macro are as follows (`G` is used to denote the graph type being tested).
-/// For a reference usage, see the tests [`petgraph_core::utils::directed`].
+/// For a reference usage, see the tests [`crate::utils::directed`].
 /// - `$graph_constructor`: An expression that constructs a new instance of the graph type to be
 ///   tested. The generated graph must be empty (e.g. `G::new()`).
 /// - `$add_node`: An expression that adds a node to the graph. It must take two arguments: a


### PR DESCRIPTION
This PR implements a macro that can be used with a `Graph` implementing the new `DirectedGraph` trait, to automatically generate a set of tests, which will test the correctness / reasonableness of each method in the `DirectedGraph` trait.

Such a macro for `UndirectedGraph` should also be created, but it seemed sensible to start with either first and agree on the details for one first and then copy the tests over for `UndirectedGraph`, as the trait methods are a strict subset anyways.