### PR TITLE
feat: Add `into_edge_type` for `StableGraph`

### DIFF
--- a/crates/petgraph/src/graph_impl/stable_graph/mod.rs
+++ b/crates/petgraph/src/graph_impl/stable_graph/mod.rs
@@ -1418,6 +1418,23 @@ where
         result_g
     }
 
+    /// Convert the graph into either undirected or directed. No edge adjustments
+    /// are done, so you may want to go over the result to remove or add edges.
+    ///
+    /// Computes in **O(1)** time.
+    pub fn into_edge_type<NewTy>(self) -> StableGraph<N, E, NewTy, Ix>
+    where
+        NewTy: EdgeType,
+    {
+        StableGraph {
+            g: self.g.into_edge_type(),
+            node_count: self.node_count,
+            edge_count: self.edge_count,
+            free_node: self.free_node,
+            free_edge: self.free_edge
+        }
+    }
+
     /// Extend the graph from an iterable of edges.
     ///
     /// Node weights `N` are set to default values.


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->

This PR adds `.into_edge_type()` for `StableGraph` - it just calls `.into_edge_type()` on the underlying `Graph` directly.

The use case is some code that requires switching between directed and undirected graphs often while keeping the same node indices. This was possible but quite inefficient with the current API because you have to copy over all of the nodes and edges into a new graph (and I think it may also invalidate the edge indices when doing so, although this wasn't important for my application).