### PR TITLE
refactor: Remove unnecessary trait bounds for `articulation_points`

### DIFF
--- a/crates/petgraph/src/algo/articulation_points.rs
+++ b/crates/petgraph/src/algo/articulation_points.rs
@@ -54,8 +54,6 @@ use crate::{
 pub fn articulation_points<G>(g: G) -> HashSet<G::NodeId>
 where
     G: IntoNodeReferences + IntoEdges + NodeIndexable + visit::GraphProp,
-    G::NodeWeight: Clone,
-    G::EdgeWeight: Clone + PartialOrd,
     G::NodeId: Eq + Hash,
 {
     let graph_size = g.node_references().size_hint().0;


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->

This PR removes some unnecessary trait bounds from `algo::articulation_points::articulation_points`. In particular, there were `Clone` and `PartialOrd` bounds on the node and edge weights. These ought to be unnecessary in any implementation of this algorithm. There is also a redundant `visit::GraphProp` bound, but I didn't remove it because it's conceivable that a future implementation change might make use of it and then it would be a breaking change to reintroduce it.