### PR TITLE
ci: Change actions to run only on changes with respect to master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    branches: [ '*' ]
+    branches: [ master ]
   merge_group:
     types: [ checks_requested ]
   workflow_dispatch: { }

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ '*' ]
+    branches: [ master ]
   workflow_dispatch: { }
 
 name: Merge check

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,7 @@ name: Check Conventional Commits format
 
 on:
   pull_request:
-    branches: [ '*' ]
+    branches: [ master ]
   # The action does not support running on merge_group events,
   # but if the check succeeds in the PR there is no need to check it again.
   merge_group:


### PR DESCRIPTION
This tries to fix Actions not running on PRs targeting the `0.8` branch, as seen in this PR https://github.com/petgraph/petgraph/pull/951.

The theory being that workflows from the `master` branch are triggered as they are triggered on PRs to any branch but they don't actually exist on the target branch which confuses GitHub and leads to unexpected behaviour.