### PR TITLE
ci: Fix release-plz for 0.8 branch

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,8 @@
 [workspace]
 pr_draft = true
 git_tag_name = "{{ package }}@v{{ version }}"
+pr_base = "0.8"
+git_release_latest = false
 
 # Include a list of contributors in the release body
 git_release_body = """


### PR DESCRIPTION
This PR adapts the release-plz.toml and the GitHub action accordingly for the branch tracking the `0.8.x` versions of petgraph.