### PR TITLE
fix: out of bounds bug in isomorphism

### DIFF
--- a/crates/petgraph/src/algo/isomorphism.rs
+++ b/crates/petgraph/src/algo/isomorphism.rs
@@ -752,8 +752,8 @@ mod matching {
 
             // We hardcode n! values into an array that accounts for architectures
             // with smaller usizes to get our upper bound.
-            let upper_bounds: Vec<Option<usize>> = [
-                1u64,
+            const UPPER_BOUNDS: &[u64] = &[
+                1,
                 1,
                 2,
                 6,
@@ -774,16 +774,14 @@ mod matching {
                 6402373705728000,
                 121645100408832000,
                 2432902008176640000,
-            ]
-            .iter()
-            .map(|n| usize::try_from(*n).ok())
-            .collect();
+            ];
 
-            if n > upper_bounds.len() {
-                return (0, None);
-            }
+            let upper = UPPER_BOUNDS
+                .get(n)
+                .copied()
+                .and_then(|val| usize::try_from(val).ok());
 
-            (0, upper_bounds[n])
+            (0, upper)
         }
     }
 }


### PR DESCRIPTION
the `size_hint` function previously used a bad out of bounds check