### PR TITLE
refactor: IntoEdges independent of IntoEdgeReferences

### DIFF
--- a/crates/petgraph/src/acyclic.rs
+++ b/crates/petgraph/src/acyclic.rs
@@ -712,6 +712,7 @@ macro_rules! impl_graph_traits {
         }
 
         impl<'a, N, E, Ix: IndexType> IntoEdges for &'a Acyclic<$graph_type<N, E, Ix>> {
+            type EdgeRef = <Self::Edges as Iterator>::Item;
             type Edges = <&'a $graph_type<N, E, Ix> as IntoEdges>::Edges;
 
             fn edges(self, a: Self::NodeId) -> Self::Edges {

--- a/crates/petgraph/src/adj.rs
+++ b/crates/petgraph/src/adj.rs
@@ -557,6 +557,7 @@ iter: SomeIter<'a, E, Ix>,
 }
 
 impl<'a, Ix: IndexType, E> visit::IntoEdges for &'a List<E, Ix> {
+    type EdgeRef = <Self::Edges as Iterator>::Item;
     type Edges = OutgoingEdgeReferences<'a, E, Ix>;
 
     fn edges(self, a: Self::NodeId) -> Self::Edges {

--- a/crates/petgraph/src/algo/maximum_flow/dinics.rs
+++ b/crates/petgraph/src/algo/maximum_flow/dinics.rs
@@ -5,8 +5,8 @@ use crate::{
     algo::{EdgeRef, PositiveMeasure},
     prelude::Direction,
     visit::{
-        Data, EdgeCount, EdgeIndexable, IntoEdgeReferences, IntoEdges, IntoEdgesDirected,
-        NodeCount, NodeIndexable, VisitMap, Visitable,
+        Data, EdgeCount, EdgeIndexable, IntoEdges, IntoEdgesDirected, NodeCount, NodeIndexable,
+        VisitMap, Visitable,
     },
 };
 
@@ -333,7 +333,7 @@ where
 /// Gets the other endpoint of graph edge, if any, otherwise panics.
 fn other_endpoint<G>(network: G, edge: G::EdgeRef, vertex: G::NodeId) -> G::NodeId
 where
-    G: NodeIndexable + IntoEdgeReferences,
+    G: NodeIndexable + IntoEdges,
 {
     if vertex == edge.source() {
         edge.target()

--- a/crates/petgraph/src/csr.rs
+++ b/crates/petgraph/src/csr.rs
@@ -617,6 +617,7 @@ where
     Ty: EdgeType,
     Ix: IndexType,
 {
+    type EdgeRef = <Self::Edges as Iterator>::Item;
     type Edges = Edges<'a, E, Ty, Ix>;
 
     fn edges(self, a: Self::NodeId) -> Self::Edges {

--- a/crates/petgraph/src/graph_impl/mod.rs
+++ b/crates/petgraph/src/graph_impl/mod.rs
@@ -1996,6 +1996,7 @@ where
     Ty: EdgeType,
     Ix: IndexType,
 {
+    type EdgeRef = <Self::Edges as Iterator>::Item;
     type Edges = Edges<'a, E, Ty, Ix>;
 
     fn edges(self, a: Self::NodeId) -> Self::Edges {

--- a/crates/petgraph/src/graph_impl/stable_graph/mod.rs
+++ b/crates/petgraph/src/graph_impl/stable_graph/mod.rs
@@ -2386,6 +2386,7 @@ where
     Ty: EdgeType,
     Ix: IndexType,
 {
+    type EdgeRef = <Self::Edges as Iterator>::Item;
     type Edges = Edges<'a, E, Ty, Ix>;
 
     fn edges(self, a: Self::NodeId) -> Self::Edges {

--- a/crates/petgraph/src/graphmap.rs
+++ b/crates/petgraph/src/graphmap.rs
@@ -1323,6 +1323,7 @@ where
     Ty: EdgeType,
     S: BuildHasher,
 {
+    type EdgeRef = <Self::Edges as Iterator>::Item;
     type Edges = Edges<'a, N, E, Ty, S>;
 
     fn edges(self, a: Self::NodeId) -> Self::Edges {

--- a/crates/petgraph/src/matrix_graph.rs
+++ b/crates/petgraph/src/matrix_graph.rs
@@ -1405,6 +1405,7 @@ impl<'a, N, E, S, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> Into
 impl<'a, N, E, S: BuildHasher, Ty: EdgeType, Null: Nullable<Wrapped = E>, Ix: IndexType> IntoEdges
     for &'a MatrixGraph<N, E, S, Ty, Null, Ix>
 {
+    type EdgeRef = <Self::Edges as Iterator>::Item;
     type Edges = Edges<'a, Ty, Null, Ix>;
 
     fn edges(self, a: Self::NodeId) -> Self::Edges {

--- a/crates/petgraph/src/visit/filter.rs
+++ b/crates/petgraph/src/visit/filter.rs
@@ -269,6 +269,7 @@ where
     G: IntoEdges,
     F: FilterNode<G::NodeId>,
 {
+    type EdgeRef = G::EdgeRef;
     type Edges = NodeFilteredEdges<'a, G, G::Edges, F>;
 
     fn edges(self, a: G::NodeId) -> Self::Edges {
@@ -503,6 +504,7 @@ where
     G: IntoEdges,
     F: FilterEdge<G::EdgeRef>,
 {
+    type EdgeRef = G::EdgeRef;
     type Edges = EdgeFilteredEdges<'a, G, G::Edges, F>;
 
     fn edges(self, n: G::NodeId) -> Self::Edges {
@@ -538,11 +540,10 @@ pub struct EdgeFilteredEdges<'a, G, I, F: 'a> {
     f: &'a F,
 }
 
-impl<G, I, F> Iterator for EdgeFilteredEdges<'_, G, I, F>
+impl<G, I, F, EdgeRef: Copy> Iterator for EdgeFilteredEdges<'_, G, I, F>
 where
-    F: FilterEdge<G::EdgeRef>,
-    G: IntoEdgeReferences,
-    I: Iterator<Item = G::EdgeRef>,
+    F: FilterEdge<EdgeRef>,
+    I: Iterator<Item = EdgeRef>,
 {
     type Item = I::Item;
 

--- a/crates/petgraph/src/visit/mod.rs
+++ b/crates/petgraph/src/visit/mod.rs
@@ -150,7 +150,10 @@ trait_template! {
 /// yields edge references (trait [`EdgeRef`][er]).
 ///
 /// [er]: trait.EdgeRef.html
-pub trait IntoEdges : IntoEdgeReferences + IntoNeighbors {
+pub trait IntoEdges : IntoNeighbors + Data {
+    @section type
+    type EdgeRef: EdgeRef<NodeId=Self::NodeId, EdgeId=Self::EdgeId,
+                          Weight=Self::EdgeWeight>;
     @section type
     type Edges: Iterator<Item=Self::EdgeRef>;
     @section self

--- a/crates/petgraph/src/visit/reversed.rs
+++ b/crates/petgraph/src/visit/reversed.rs
@@ -49,6 +49,7 @@ impl<G> IntoEdges for Reversed<G>
 where
     G: IntoEdgesDirected,
 {
+    type EdgeRef = <Self::Edges as Iterator>::Item;
     type Edges = ReversedEdges<G::EdgesDirected>;
 
     fn edges(self, a: Self::NodeId) -> Self::Edges {

--- a/crates/petgraph/src/visit/undirected_adaptor.rs
+++ b/crates/petgraph/src/visit/undirected_adaptor.rs
@@ -30,6 +30,7 @@ impl<G> IntoEdges for UndirectedAdaptor<G>
 where
     G: IntoEdgesDirected,
 {
+    type EdgeRef = <Self::Edges as Iterator>::Item;
     type Edges = core::iter::Chain<
         MaybeReversedEdges<G::EdgesDirected>,
         MaybeReversedEdges<G::EdgesDirected>,


### PR DESCRIPTION
IntoEdges required IntoEdgeReferences only to easily access EdgeRef. This implied that the graph type needs to be fully materialized, and limits the construction of lazy graph types. Specifically, lazy graph types cannot (and should not) cheaply provide a complete iterator over all the graph's edges.

BREAKING CHANGE: update IntoEdges implementation with a `type EdgeRef`. `type EdgeRef = <Self::Edges as Iterator>::Item;` will suffice in nearly all cases.

BREAKING CHANGE: if you implicitly depended on IntoEdgeReferences to be implemented through IntoEdges, you will have to manually add the `+ IntoEdgeReferences` bound.

Probably this doesn't even need the extra type alias; another pass over the code might do away with it entirely.