### PR TITLE
feat: Add unsafe node weight getter methods

### DIFF
--- a/crates/petgraph/src/graph_impl/mod.rs
+++ b/crates/petgraph/src/graph_impl/mod.rs
@@ -614,6 +614,34 @@ where
         self.nodes.get_mut(a.index()).map(|n| &mut n.weight)
     }
 
+    /// Return a reference to a node without doing any bounds checking
+    ///
+    /// For a safe alternative see `node_weight`.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index or an index that has
+    /// been removed from the graph is undefined behavior even if the
+    /// resulting reference is not used. You can think of this like calling
+    /// `.get(a).unwrap_unchecked()`
+    pub unsafe fn node_weight_unchecked(&self, a: NodeIndex<Ix>) -> &N {
+        unsafe { &self.nodes.get_unchecked(a.index()).weight }
+    }
+
+    /// Return a mutable reference to a node without doing any bounds checking
+    ///
+    /// For a safe alternative see `node_weight_mut`.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index or an index that has
+    /// been removed from the graph is undefined behavior even if the
+    /// resulting reference is not used. You can think of this like calling
+    /// `.get(a).unwrap_unchecked()`
+    pub unsafe fn node_weight_mut_unchecked(&mut self, a: NodeIndex<Ix>) -> &mut N {
+        unsafe { &mut self.nodes.get_unchecked_mut(a.index()).weight }
+    }
+
     /// Add an edge from `a` to `b` to the graph, with its associated
     /// data `weight`.
     ///

--- a/crates/petgraph/src/graph_impl/stable_graph/mod.rs
+++ b/crates/petgraph/src/graph_impl/stable_graph/mod.rs
@@ -661,6 +661,48 @@ where
         }
     }
 
+    /// Return a reference to a node without doing any bounds checking
+    ///
+    /// For a safe alternative see `node_weight`.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index or an index that has
+    /// been removed from the graph is undefined behavior even if the
+    /// resulting reference is not used. You can think of this like calling
+    /// `.get(a).unwrap_unchecked()`.
+    pub unsafe fn node_weight_unchecked(&self, a: NodeIndex<Ix>) -> &N {
+        unsafe {
+            self.g
+                .nodes
+                .get_unchecked(a.index())
+                .weight
+                .as_ref()
+                .unwrap()
+        }
+    }
+
+    /// Return a mutable reference to a node without doing any bounds checking
+    ///
+    /// For a safe alternative see `node_weight_mut`.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index or an index that has
+    /// been removed from the graph is undefined behavior even if the
+    /// resulting reference is not used. You can think of this like calling
+    /// `.get_mut(a).unwrap_unchecked()`.
+    pub unsafe fn node_weight_mut_unchecked(&mut self, a: NodeIndex<Ix>) -> &mut N {
+        unsafe {
+            self.g
+                .nodes
+                .get_unchecked_mut(a.index())
+                .weight
+                .as_mut()
+                .unwrap()
+        }
+    }
+
     /// Return an iterator yielding immutable access to all node weights.
     ///
     /// The order in which weights are yielded matches the order of their node

--- a/crates/petgraph/tests/graph.rs
+++ b/crates/petgraph/tests/graph.rs
@@ -3243,3 +3243,33 @@ fn test_edges_connecting_iteration_order() {
         ]
     );
 }
+
+#[test]
+fn test_unsafe_node_weight() {
+    let mut g: UnGraph<i32, ()> = Graph::new_undirected();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    unsafe {
+        assert_eq!(&0, g.node_weight_unchecked(a));
+        assert_eq!(&1, g.node_weight_unchecked(b));
+        assert_eq!(&2, g.node_weight_unchecked(c));
+        assert_eq!(&3, g.node_weight_unchecked(d));
+    }
+}
+
+#[test]
+fn test_unsafe_node_weight_mut() {
+    let mut g: UnGraph<i32, ()> = Graph::new_undirected();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    unsafe {
+        assert_eq!(&mut 0, g.node_weight_mut_unchecked(a));
+        assert_eq!(&mut 1, g.node_weight_mut_unchecked(b));
+        assert_eq!(&mut 2, g.node_weight_mut_unchecked(c));
+        assert_eq!(&mut 3, g.node_weight_mut_unchecked(d));
+    }
+}

--- a/crates/petgraph/tests/stable_graph.rs
+++ b/crates/petgraph/tests/stable_graph.rs
@@ -1308,3 +1308,33 @@ fn test_edges_connecting_iteration_order() {
         ]
     );
 }
+
+#[test]
+fn test_unsafe_node_weight() {
+    let mut g: StableDiGraph<i32, ()> = StableGraph::new();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    unsafe {
+        assert_eq!(&0, g.node_weight_unchecked(a));
+        assert_eq!(&1, g.node_weight_unchecked(b));
+        assert_eq!(&2, g.node_weight_unchecked(c));
+        assert_eq!(&3, g.node_weight_unchecked(d));
+    }
+}
+
+#[test]
+fn test_unsafe_node_weight_mut() {
+    let mut g: StableDiGraph<i32, ()> = StableGraph::new();
+    let a = g.add_node(0);
+    let b = g.add_node(1);
+    let c = g.add_node(2);
+    let d = g.add_node(3);
+    unsafe {
+        assert_eq!(&mut 0, g.node_weight_mut_unchecked(a));
+        assert_eq!(&mut 1, g.node_weight_mut_unchecked(b));
+        assert_eq!(&mut 2, g.node_weight_mut_unchecked(c));
+        assert_eq!(&mut 3, g.node_weight_mut_unchecked(d));
+    }
+}


### PR DESCRIPTION
This commit adds new methods to the Graph and StableGraph types to get a node weight without bounds or validity checking. There are several use cases where the user can know with confidence that all the indices used when accessing the weights from the graph are valid and correct and having the overhead of bounds checking or whether the node has been removed from a stable graph. Having an unsafe method where the user asserts in their program the indices calling these methods with are valid and does it explicitly in an unsafe block is a valid can help address these use cases.

<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->