### PR TITLE
perf:  Kruskal's iterator creation 2x faster via O(E) bottom-up heapify

### DIFF
--- a/benches/min_spanning_tree.rs
+++ b/benches/min_spanning_tree.rs
@@ -15,6 +15,14 @@ use petgraph::{
     Graph, Undirected,
 };
 
+use crate::common::build_2d_grid;
+
+#[bench]
+fn min_spanning_tree_kruskal_create_iter(bench: &mut Bencher) {
+    let g = build_2d_grid(100, 100);
+    bench.iter(|| std::hint::black_box(min_spanning_tree(&g)));
+}
+
 #[bench]
 fn min_spanning_tree_kruskal_praust_undir_bench(bench: &mut Bencher) {
     let a = ungraph().praust_a();

--- a/src/algo/min_spanning_tree.rs
+++ b/src/algo/min_spanning_tree.rs
@@ -98,13 +98,9 @@ where
     let subgraphs = UnionFind::new(g.node_bound());
 
     let edges = g.edge_references();
-    let mut sort_edges = BinaryHeap::with_capacity(edges.size_hint().0);
-    for edge in edges {
-        sort_edges.push(MinScored(
-            edge.weight().clone(),
-            (edge.source(), edge.target()),
-        ));
-    }
+    let sort_edges = BinaryHeap::from_iter(
+        edges.map(|edge| MinScored(edge.weight().clone(), (edge.source(), edge.target()))),
+    );
 
     MinSpanningTree {
         graph: g,


### PR DESCRIPTION
## Overview
This PR optimizes the initialization of the `BinaryHeap` in the `min_spanning_tree` (Kruskal's algorithm) implementation. By leveraging Rust's `FromIterator`  implementation for `BinaryHeap`, we transition from an $O(E \log E)$ construction to a linear $O(E)$ "bottom-up" heapify.

## Technical Details
Previously, the heap was populated by iterating over edge references and calling `.push()` for each element. This resulted in a total setup cost of $O(E \log E)$ as the heap re-balanced itself upon every insertion.

This change uses `BinaryHeap::from_iter()`. As documented in the [Rust Standard Library](https://doc.rust-lang.org/beta/std/collections/struct.BinaryHeap.html#impl-From%3CVec%3CT,+A%3E%3E-for-BinaryHeap%3CT,+A%3E), this organizes the elements in-place in $O(E)$ time.

## Benchmarks
To verify the impact, I added a benchmark specifically targeting the iterator creation (where the heapification occurs). For a **100x100 lattice graph**, the new implementation is approximately **2x faster** on my computer.
![Screenshot_20260402_120242](https://github.com/user-attachments/assets/cd2fbbb5-a6e8-416c-9385-99c81a075de6)


## Changes
- Refactored `min_spanning_tree` to use ``BinaryHeap::from()`.
- Added a benchmark case for MST iterator initialization.