### PR TITLE
perf: Kruskal's iterator creation 2x faster via O(E) bottom-up heapify

### DIFF
--- a/crates/petgraph/benches/min_spanning_tree.rs
+++ b/crates/petgraph/benches/min_spanning_tree.rs
@@ -14,6 +14,14 @@ use petgraph::{
     visit::{Data, IntoEdgeReferences, IntoEdges, IntoNodeReferences, NodeIndexable},
 };
 
+use crate::common::build_2d_grid;
+
+#[bench]
+fn min_spanning_tree_kruskal_create_iter(bench: &mut Bencher) {
+    let g = build_2d_grid(100, 100);
+    bench.iter(|| std::hint::black_box(min_spanning_tree(&g)));
+}
+
 #[bench]
 fn min_spanning_tree_kruskal_praust_undir_bench(bench: &mut Bencher) {
     let a = ungraph().praust_a();

--- a/crates/petgraph/src/algo/min_spanning_tree.rs
+++ b/crates/petgraph/src/algo/min_spanning_tree.rs
@@ -96,13 +96,9 @@ where
     let subgraphs = UnionFind::new(g.node_bound());
 
     let edges = g.edge_references();
-    let mut sort_edges = BinaryHeap::with_capacity(edges.size_hint().0);
-    for edge in edges {
-        sort_edges.push(MinScored(
-            edge.weight().clone(),
-            (edge.source(), edge.target()),
-        ));
-    }
+    let sort_edges = BinaryHeap::from_iter(
+        edges.map(|edge| MinScored(edge.weight().clone(), (edge.source(), edge.target()))),
+    );
 
     MinSpanningTree {
         graph: g,


### PR DESCRIPTION
As requested by @RaoulLuque #984  this PR ports the Kruskal's algorithm optimization to the main branch. This ensures the O(E) bottom-up heapify performance improvement is preserved in the upcoming versions...

I noticed that Prim's algorithm (`min_spanning_tree_prim`) also utilizes a BinaryHeap. I'm not familiar with that specific algorithm yet, but it might be another candidate for a similar O(E) heapify optimization. 