### PR TITLE
feat: Add rayon parallel iterators for node and edge weights

### DIFF
--- a/crates/petgraph/src/graph_impl/mod.rs
+++ b/crates/petgraph/src/graph_impl/mod.rs
@@ -10,6 +10,8 @@ use core::{
 };
 
 use fixedbitset::FixedBitSet;
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
 
 use crate::{
     Directed, Direction, EdgeType, Incoming, IntoWeightedEdge, Outgoing, Undirected,
@@ -1183,6 +1185,26 @@ where
         }
     }
 
+    /// Return a parallel iterator yielding mutable access to all node weights.
+    #[cfg(feature = "rayon")]
+    pub fn par_node_weights_mut(&mut self) -> impl ParallelIterator<Item = &mut N>
+    where
+        N: Send + Sync,
+        Ix: Send + Sync,
+    {
+        self.nodes.par_iter_mut().map(|x| &mut x.weight)
+    }
+
+    /// Return a parallel iterator yielding immutable access to all node weights.
+    #[cfg(feature = "rayon")]
+    pub fn par_node_weights(&self) -> impl ParallelIterator<Item = &N>
+    where
+        N: Send + Sync,
+        Ix: Send + Sync,
+    {
+        self.nodes.par_iter().map(|x| &x.weight)
+    }
+
     /// Return an iterator over the edge indices of the graph
     pub fn edge_indices(&self) -> EdgeIndices<Ix> {
         EdgeIndices {
@@ -1218,6 +1240,26 @@ where
         EdgeWeightsMut {
             edges: self.edges.iter_mut(),
         }
+    }
+
+    /// Return a parallel iterator yielding mutable access to all edge weights.
+    #[cfg(feature = "rayon")]
+    pub fn par_edge_weights_mut(&mut self) -> impl ParallelIterator<Item = &mut E>
+    where
+        E: Send + Sync,
+        Ix: Send + Sync,
+    {
+        self.edges.par_iter_mut().map(|x| &mut x.weight)
+    }
+
+    /// Return an iterator yielding immutable access to all node weights.
+    #[cfg(feature = "rayon")]
+    pub fn par_edge_weights(&self) -> impl ParallelIterator<Item = &E>
+    where
+        E: Send + Sync,
+        Ix: Send + Sync,
+    {
+        self.edges.par_iter().map(|x| &x.weight)
     }
 
     // Remaining methods are of the more internal flavour, read-only access to

--- a/crates/petgraph/src/graph_impl/stable_graph/mod.rs
+++ b/crates/petgraph/src/graph_impl/stable_graph/mod.rs
@@ -12,6 +12,8 @@ use core::{
 };
 
 use fixedbitset::FixedBitSet;
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
 
 use super::{DIRECTIONS, Edge, Frozen, GraphError, Node, Pair, index_twice};
 // reexport those things that are shared with Graph
@@ -681,6 +683,30 @@ where
             .filter_map(|maybe_node| maybe_node.as_mut())
     }
 
+    /// Return a parallel iterator yielding immutable access to all node weights.
+    #[cfg(feature = "rayon")]
+    pub fn par_node_weights(&self) -> impl ParallelIterator<Item = &N>
+    where
+        N: Send + Sync,
+        Ix: Send + Sync,
+    {
+        self.g
+            .par_node_weights()
+            .filter_map(|maybe_node| maybe_node.as_ref())
+    }
+
+    /// Return a parallel iterator yielding mutable access to all node weights.
+    #[cfg(feature = "rayon")]
+    pub fn par_node_weights_mut(&mut self) -> impl ParallelIterator<Item = &mut N>
+    where
+        N: Send + Sync,
+        Ix: Send + Sync,
+    {
+        self.g
+            .par_node_weights_mut()
+            .filter_map(|maybe_node| maybe_node.as_mut())
+    }
+
     /// Return an iterator over the node indices of the graph
     pub fn node_indices(&self) -> NodeIndices<'_, N, Ix> {
         NodeIndices {
@@ -725,6 +751,30 @@ where
     pub fn edge_weights_mut(&mut self) -> impl Iterator<Item = &mut E> {
         self.g
             .edge_weights_mut()
+            .filter_map(|maybe_edge| maybe_edge.as_mut())
+    }
+
+    /// Return a parallel iterator yielding immutable access to all edge weights.
+    #[cfg(feature = "rayon")]
+    pub fn par_edge_weights(&self) -> impl ParallelIterator<Item = &E>
+    where
+        E: Send + Sync,
+        Ix: Send + Sync,
+    {
+        self.g
+            .par_edge_weights()
+            .filter_map(|maybe_edge| maybe_edge.as_ref())
+    }
+
+    /// Return an iterator yielding mutable access to all edge weights.
+    #[cfg(feature = "rayon")]
+    pub fn par_edge_weights_mut(&mut self) -> impl ParallelIterator<Item = &mut E>
+    where
+        E: Send + Sync,
+        Ix: Send + Sync,
+    {
+        self.g
+            .par_edge_weights_mut()
             .filter_map(|maybe_edge| maybe_edge.as_mut())
     }
 

--- a/crates/petgraph/tests/graph.rs
+++ b/crates/petgraph/tests/graph.rs
@@ -3265,7 +3265,7 @@ fn test_parallel_node_weights_mut() {
     for i in 0..100 {
         graph.add_node(i);
     }
-    graph.par_node_weights_mut().for_each(|x| *x = *x * 2);
+    graph.par_node_weights_mut().for_each(|x| *x *= 2);
     let result = graph.par_node_weights().copied().collect::<Vec<_>>();
     let expected = (0..100).map(|x| x * 2).collect::<Vec<_>>();
     assert_eq!(result, expected);
@@ -3292,7 +3292,7 @@ fn test_parallel_edge_weights_mut() {
         graph.add_node(i);
         graph.add_edge(NodeIndex::new(i as usize), NodeIndex::new(i as usize), i);
     }
-    graph.par_edge_weights_mut().for_each(|x| *x = *x * 2);
+    graph.par_edge_weights_mut().for_each(|x| *x *= 2);
     let result = graph.par_edge_weights().copied().collect::<Vec<_>>();
     let expected = (0..100).map(|x| x * 2).collect::<Vec<_>>();
     assert_eq!(result, expected);

--- a/crates/petgraph/tests/graph.rs
+++ b/crates/petgraph/tests/graph.rs
@@ -21,6 +21,8 @@ use petgraph::{
         Topo, VisitMap, Walker,
     },
 };
+#[cfg(feature = "rayon")]
+use rayon::iter::ParallelIterator;
 
 fn set<I>(iter: I) -> HashSet<I::Item>
 where
@@ -3242,4 +3244,56 @@ fn test_edges_connecting_iteration_order() {
             edge_five, edge_four, edge_three, edge_two, edge_one, edge_zero
         ]
     );
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn test_parallel_node_weights() {
+    let mut graph: StableDiGraph<i32, i32> = StableGraph::new();
+    for i in 0..100 {
+        graph.add_node(i);
+    }
+    let result = graph.par_node_weights().copied().collect::<Vec<_>>();
+    let expected = (0..100).collect::<Vec<_>>();
+    assert_eq!(result, expected);
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn test_parallel_node_weights_mut() {
+    let mut graph: StableDiGraph<i32, i32> = StableGraph::new();
+    for i in 0..100 {
+        graph.add_node(i);
+    }
+    graph.par_node_weights_mut().for_each(|x| *x = *x * 2);
+    let result = graph.par_node_weights().copied().collect::<Vec<_>>();
+    let expected = (0..100).map(|x| x * 2).collect::<Vec<_>>();
+    assert_eq!(result, expected);
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn test_parallel_edge_weights() {
+    let mut graph: StableDiGraph<i32, i32> = StableGraph::new();
+    for i in 0..100 {
+        graph.add_node(i);
+        graph.add_edge(NodeIndex::new(i as usize), NodeIndex::new(i as usize), i);
+    }
+    let result = graph.par_edge_weights().copied().collect::<Vec<_>>();
+    let expected = (0..100).collect::<Vec<_>>();
+    assert_eq!(result, expected);
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn test_parallel_edge_weights_mut() {
+    let mut graph: StableDiGraph<i32, i32> = StableGraph::new();
+    for i in 0..100 {
+        graph.add_node(i);
+        graph.add_edge(NodeIndex::new(i as usize), NodeIndex::new(i as usize), i);
+    }
+    graph.par_edge_weights_mut().for_each(|x| *x = *x * 2);
+    let result = graph.par_edge_weights().copied().collect::<Vec<_>>();
+    let expected = (0..100).map(|x| x * 2).collect::<Vec<_>>();
+    assert_eq!(result, expected);
 }

--- a/crates/petgraph/tests/stable_graph.rs
+++ b/crates/petgraph/tests/stable_graph.rs
@@ -17,6 +17,8 @@ use petgraph::{
     stable_graph::{edge_index as e, node_index as n},
     visit::{EdgeIndexable, IntoEdgeReferences, IntoNodeReferences, NodeIndexable},
 };
+#[cfg(feature = "rayon")]
+use rayon::iter::ParallelIterator;
 
 fn assert_graph_consistent<N, E, Ty, Ix>(g: &StableGraph<N, E, Ty, Ix>)
 where
@@ -1307,4 +1309,56 @@ fn test_edges_connecting_iteration_order() {
             edge_five, edge_four, edge_three, edge_two, edge_one, edge_zero
         ]
     );
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn test_parallel_node_weights() {
+    let mut graph: StableDiGraph<i32, i32> = StableGraph::new();
+    for i in 0..100 {
+        graph.add_node(i);
+    }
+    let result = graph.par_node_weights().copied().collect::<Vec<_>>();
+    let expected = (0..100).collect::<Vec<_>>();
+    assert_eq!(result, expected);
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn test_parallel_node_weights_mut() {
+    let mut graph: StableDiGraph<i32, i32> = StableGraph::new();
+    for i in 0..100 {
+        graph.add_node(i);
+    }
+    graph.par_node_weights_mut().for_each(|x| *x = *x * 2);
+    let result = graph.par_node_weights().copied().collect::<Vec<_>>();
+    let expected = (0..100).map(|x| x * 2).collect::<Vec<_>>();
+    assert_eq!(result, expected);
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn test_parallel_edge_weights() {
+    let mut graph: StableDiGraph<i32, i32> = StableGraph::new();
+    for i in 0..100 {
+        graph.add_node(i);
+        graph.add_edge(NodeIndex::new(i as usize), NodeIndex::new(i as usize), i);
+    }
+    let result = graph.par_edge_weights().copied().collect::<Vec<_>>();
+    let expected = (0..100).collect::<Vec<_>>();
+    assert_eq!(result, expected);
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn test_parallel_edge_weights_mut() {
+    let mut graph: StableDiGraph<i32, i32> = StableGraph::new();
+    for i in 0..100 {
+        graph.add_node(i);
+        graph.add_edge(NodeIndex::new(i as usize), NodeIndex::new(i as usize), i);
+    }
+    graph.par_edge_weights_mut().for_each(|x| *x = *x * 2);
+    let result = graph.par_edge_weights().copied().collect::<Vec<_>>();
+    let expected = (0..100).map(|x| x * 2).collect::<Vec<_>>();
+    assert_eq!(result, expected);
 }

--- a/crates/petgraph/tests/stable_graph.rs
+++ b/crates/petgraph/tests/stable_graph.rs
@@ -1330,7 +1330,7 @@ fn test_parallel_node_weights_mut() {
     for i in 0..100 {
         graph.add_node(i);
     }
-    graph.par_node_weights_mut().for_each(|x| *x = *x * 2);
+    graph.par_node_weights_mut().for_each(|x| *x *= 2);
     let result = graph.par_node_weights().copied().collect::<Vec<_>>();
     let expected = (0..100).map(|x| x * 2).collect::<Vec<_>>();
     assert_eq!(result, expected);
@@ -1357,7 +1357,7 @@ fn test_parallel_edge_weights_mut() {
         graph.add_node(i);
         graph.add_edge(NodeIndex::new(i as usize), NodeIndex::new(i as usize), i);
     }
-    graph.par_edge_weights_mut().for_each(|x| *x = *x * 2);
+    graph.par_edge_weights_mut().for_each(|x| *x *= 2);
     let result = graph.par_edge_weights().copied().collect::<Vec<_>>();
     let expected = (0..100).map(|x| x * 2).collect::<Vec<_>>();
     assert_eq!(result, expected);


### PR DESCRIPTION
This commit adds new iterators par_node_weights(), par_node_weights_mut(), par_edge_weights(), and par_edge_weights_mut() for Graph and StableGraph. These methods provide direct parallel iteration over the inner Vecs used for storing these nodes or edges. They're only built if the rayon feature is enabled.

<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->