### PR TITLE
fix: preserve unreachable Floyd-Warshall distances

### DIFF
--- a/crates/petgraph/src/algo/floyd_warshall.rs
+++ b/crates/petgraph/src/algo/floyd_warshall.rs
@@ -308,6 +308,7 @@ where
     K: BoundedMeasure + Copy,
 {
     let num_of_nodes = graph.node_count();
+    let unreachable = K::max();
 
     // Initialize distances and predecessors for edges
     for edge in graph.edge_references() {
@@ -337,6 +338,9 @@ where
         for i in 0..num_of_nodes {
             for j in 0..num_of_nodes {
                 if let Some(dist) = m_dist {
+                    if dist[i][k] >= unreachable || dist[k][j] >= unreachable {
+                        continue;
+                    }
                     let (result, overflow) = dist[i][k].overflowing_add(dist[k][j]);
                     if !overflow && dist[i][j] > result {
                         dist[i][j] = result;

--- a/crates/petgraph/tests/floyd_warshall.rs
+++ b/crates/petgraph/tests/floyd_warshall.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-use petgraph::{Directed, Graph, Undirected, algo::floyd_warshall, prelude::*};
+use petgraph::{
+    Directed, Graph, Undirected,
+    algo::{floyd_warshall, floyd_warshall::floyd_warshall_path},
+    prelude::*,
+};
 
 #[test]
 fn floyd_warshall_uniform_weight() {
@@ -281,6 +285,38 @@ fn floyd_warshall_negative_cycle() {
     });
 
     assert!(res.is_err());
+}
+
+#[test]
+fn floyd_warshall_unreachable_negative_edge_stays_infinite() {
+    let mut graph: Graph<(), i32, Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+
+    graph.add_edge(b, c, -5);
+
+    let res = floyd_warshall(&graph, |edge| *edge.weight()).unwrap();
+
+    assert_eq!(res[&(a, a)], 0);
+    assert_eq!(res[&(a, b)], i32::MAX);
+    assert_eq!(res[&(a, c)], i32::MAX);
+}
+
+#[test]
+fn floyd_warshall_path_unreachable_negative_edge_stays_infinite() {
+    let mut graph: Graph<(), i32, Directed> = Graph::new();
+    let a = graph.add_node(());
+    let b = graph.add_node(());
+    let c = graph.add_node(());
+
+    graph.add_edge(b, c, -5);
+
+    let (res, prev) = floyd_warshall_path(&graph, |edge| *edge.weight()).unwrap();
+
+    assert_eq!(res[&(a, c)], i32::MAX);
+    assert_eq!(prev[a.index()][c.index()], None);
+    assert_eq!(prev[b.index()][c.index()], Some(b.index()));
 }
 
 #[test]


### PR DESCRIPTION
Summary
- skip Floyd–Warshall relaxations that still involve an unreachable subpath sentinel
- add regression coverage for both `floyd_warshall` and `floyd_warshall_path` on a graph with a negative edge and an unreachable source/target pair
- preserve `i32::MAX` for unreachable pairs instead of fabricating a finite distance like `i32::MAX - 5`

Testing
- `RUSTUP_TOOLCHAIN=stable cargo test -p petgraph --test floyd_warshall -- --nocapture`
- `RUSTUP_TOOLCHAIN=stable cargo test -p petgraph --all-features --test floyd_warshall -- --nocapture`
- `RUSTUP_TOOLCHAIN=stable cargo fmt --all --check`
- `RUSTUP_TOOLCHAIN=stable cargo clippy -p petgraph --all-features --lib --tests -- -D warnings`

Notes
- Fixes #980.
- I also reran a standalone local repro against the patched crate to confirm the unreachable `a -> c` pair stays at `i32::MAX`.