### PR TITLE
fix: handle StableGraph holes in ford_fulkerson

### DIFF
--- a/crates/petgraph/src/algo/maximum_flow/ford_fulkerson.rs
+++ b/crates/petgraph/src/algo/maximum_flow/ford_fulkerson.rs
@@ -176,7 +176,7 @@ where
         + Visitable,
     G::EdgeWeight: Sub<Output = G::EdgeWeight> + PositiveMeasure,
 {
-    let mut edge_to = vec![None; network.node_count()];
+    let mut edge_to = vec![None; network.node_bound()];
     let mut flows = vec![G::EdgeWeight::zero(); network.edge_bound()];
     let mut max_flow = G::EdgeWeight::zero();
     while has_augmented_path(&network, source, destination, &mut edge_to, &flows) {

--- a/crates/petgraph/tests/ford_fulkerson.rs
+++ b/crates/petgraph/tests/ford_fulkerson.rs
@@ -123,6 +123,21 @@ fn test_ford_fulkerson() {
 
 #[cfg(feature = "stable_graph")]
 #[test]
+fn test_ford_fulkerson_stable_graph_node_hole_regression() {
+    let mut graph = StableDiGraph::<(), u32>::new();
+    let source = graph.add_node(());
+    let removed = graph.add_node(());
+    let sink = graph.add_node(());
+
+    graph.add_edge(source, sink, 1);
+    graph.remove_node(removed);
+
+    let (max_flow, _) = ford_fulkerson(&graph, source, sink);
+    assert_eq!(1, max_flow);
+}
+
+#[cfg(feature = "stable_graph")]
+#[test]
 fn test_ford_fulkerson_stable_graphs() {
     // See issue https://github.com/petgraph/petgraph/issues/792
     let mut g: StableGraph<(), u32, Directed> = StableDiGraph::new();


### PR DESCRIPTION
Summary:
- Allocate `ford_fulkerson`'s node-indexed scratch vector with `node_bound()` instead of `node_count()`.
- This keeps the scratch vector in the same sparse index domain used by `NodeIndexable::to_index`, so `StableGraph` node holes no longer panic during augmenting-path search.
- Add a regression test covering a `StableDiGraph` with live node indices 0 and 2 after removing node 1.

Fixes #972

Testing:
- RED check before the fix: `cargo test -p petgraph test_ford_fulkerson_stable_graph_node_hole_regression --features stable_graph -- --nocapture` failed with `index out of bounds: the len is 2 but the index is 2`.
- `cargo test -p petgraph test_ford_fulkerson_stable_graph_node_hole_regression --features stable_graph -- --nocapture`
- `cargo fmt --check && git diff --check && cargo test -p petgraph --test ford_fulkerson --features stable_graph -- --nocapture && cargo test -p petgraph --features stable_graph`
- `cargo clippy -p petgraph --lib --tests --features stable_graph -- -D warnings`

Note: I also tried `cargo clippy -p petgraph --all-targets --features stable_graph -- -D warnings`; it fails on the pre-existing bench lint `crates/petgraph/benches/bridges.rs:18` (`clippy::needless_range_loop`), which is unrelated to this change.
