### PR TITLE
fix: removed unnecessary trait on is_bipartite_undirected function

### DIFF
--- a/crates/petgraph/src/algo/mod.rs
+++ b/crates/petgraph/src/algo/mod.rs
@@ -540,7 +540,7 @@ pub struct NegativeCycle(pub ());
 /// A graph is bipartite if its nodes can be divided into
 /// two disjoint and indepedent sets U and V such that every edge connects U to one in V.
 ///
-/// This algorithm implements 2-coloring algorithm based on the BFS algorithm.
+/// This algorithm implements 2-coloring algorithm based on the DFS algorithm.
 /// Always treats the input graph as if undirected.
 ///
 /// \* The algorithm checks only the subgraph that is reachable from the `start`.
@@ -561,50 +561,37 @@ pub struct NegativeCycle(pub ());
 pub fn is_bipartite_undirected<G, N, VM>(g: G, start: N) -> bool
 where
     G: GraphRef + Visitable<NodeId = N, Map = VM> + IntoNeighbors<NodeId = N>,
-    N: Copy + PartialEq + core::fmt::Debug,
+    N: Copy,
     VM: VisitMap<N>,
 {
+    #[derive(Copy, Clone)]
+    enum Color {
+        Red,
+        Blue,
+    }
+
     let mut red = g.visit_map();
-    red.visit(start);
     let mut blue = g.visit_map();
 
-    let mut stack = ::alloc::collections::VecDeque::new();
-    stack.push_front(start);
+    let mut dfs_stack = Vec::new();
+    red.visit(start);
+    dfs_stack.push((start, Color::Red));
 
-    while let Some(node) = stack.pop_front() {
-        let is_red = red.is_visited(&node);
-        let is_blue = blue.is_visited(&node);
-
-        assert!(is_red ^ is_blue);
+    while let Some((node, color)) = dfs_stack.pop() {
+        let (same_color, other_color, next_color) = match color {
+            Color::Red => (&red, &mut blue, Color::Blue),
+            Color::Blue => (&blue, &mut red, Color::Red),
+        };
 
         for neighbour in g.neighbors(node) {
-            let is_neigbour_red = red.is_visited(&neighbour);
-            let is_neigbour_blue = blue.is_visited(&neighbour);
-
-            if (is_red && is_neigbour_red) || (is_blue && is_neigbour_blue) {
+            if same_color.is_visited(&neighbour) {
                 return false;
             }
-
-            if !is_neigbour_red && !is_neigbour_blue {
-                //hasn't been visited yet
-
-                match (is_red, is_blue) {
-                    (true, false) => {
-                        blue.visit(neighbour);
-                    }
-                    (false, true) => {
-                        red.visit(neighbour);
-                    }
-                    (_, _) => {
-                        panic!("Invariant doesn't hold");
-                    }
-                }
-
-                stack.push_back(neighbour);
+            if other_color.visit(neighbour) {
+                dfs_stack.push((neighbour, next_color));
             }
         }
     }
-
     true
 }
 


### PR DESCRIPTION
This PR refactors `is_bipartite_undirected` to eliminate unnecessary trait bounds, optimize performance, and remove potential runtime panics by replacing the BFS implementation with a  DFS approach.

### Motivation
The previous implementation constrained the starting node `start: N` with `Copy + PartialEq + Debug`. However, `PartialEq` and `Debug` were only required to support possible internal `assert!` and `panic!` statements. 

By eliminating the runtime assertions and rewriting the underlying logic, we can drop these restrictive trait bounds entirely, leaving only `N: Copy`. This makes the function significantly more flexible for downstream users.
### Key Changes
* **Dropped Unnecessary Trait Bounds:** Removed `PartialEq` and `Debug` from the `N` generic parameter.
* **Removed Panics/Assertions:** Eliminated the `assert!` and `panic!` macros by using a local scoped `Color` enum. This guarantees exhaustive pattern matching at compile-time and eliminates impossible runtime states.
* **DFS Migration (Performance):** Swapped the `VecDeque`-based BFS traversal for a standard `Vec`-based DFS. `Vec` offers better cache locality and slightly lower memory overhead.
* **Reduced Map Lookups:** Optimized the inner loop logic to cut the number of `visit`/`is_visited` lookup operations roughly in half.