### PR TITLE
fix: correct undirected edge count in Generator::all without self-loops

### DIFF
--- a/crates/petgraph/src/generate.rs
+++ b/crates/petgraph/src/generate.rs
@@ -63,7 +63,7 @@ impl<Ty: EdgeType> Generator<Ty> {
         let nedges = if allow_selfloops {
             (nodes * nodes - nodes) / scale + nodes
         } else {
-            (nodes * nodes) / scale - nodes
+            (nodes * nodes - nodes) / scale
         };
         assert!(nedges < 64);
         Generator {

--- a/crates/petgraph/tests/graph.rs
+++ b/crates/petgraph/tests/graph.rs
@@ -623,6 +623,21 @@ fn test_generate_undirected() {
 
 #[cfg(feature = "generate")]
 #[test]
+fn test_generate_undirected_without_selfloops_counts_all_graphs() {
+    // 3 nodes, no self-loops => 3 possible edges => 2^3 = 8 graphs
+    assert_eq!(
+        pg::generate::Generator::<Undirected>::all(3, false).count(),
+        8
+    );
+    // guard against a `/2` regression: directed, no self-loops => 3*2 = 6 edges => 2^6 = 64 graphs
+    assert_eq!(
+        pg::generate::Generator::<Directed>::all(3, false).count(),
+        64
+    );
+}
+
+#[cfg(feature = "generate")]
+#[test]
 fn test_generate_directed() {
     // Number of DAG out of all graphs (all permutations) per node size
     //            0, 1, 2, 3,  4,   5 ..

--- a/crates/petgraph/tests/graph.rs
+++ b/crates/petgraph/tests/graph.rs
@@ -629,10 +629,24 @@ fn test_generate_undirected_without_selfloops_counts_all_graphs() {
         pg::generate::Generator::<Undirected>::all(3, false).count(),
         8
     );
-    // guard against a `/2` regression: directed, no self-loops => 3*2 = 6 edges => 2^6 = 64 graphs
+
+    // 3 nodes, with self-loops => 6 possible edges => 2^6 = 64 graphs
+    assert_eq!(
+        pg::generate::Generator::<Undirected>::all(3, true).count(),
+        64
+    );
+
+    // guard against a `/2` regression:
+    // directed, no self-loops => 3*2 = 6 edges => 2^6 = 64 graphs
     assert_eq!(
         pg::generate::Generator::<Directed>::all(3, false).count(),
         64
+    );
+
+    // directed, with self-loops => 3*3 = 9 edges => 2^9 = 512 graphs
+    assert_eq!(
+        pg::generate::Generator::<Directed>::all(3, true).count(),
+        512
     );
 }
 


### PR DESCRIPTION
## What

Fix the number of possible edges computed by `Generator::<Ty>::all(nodes, allow_selfloops)` in the no-self-loops branch, and add a regression test.

```diff
 let nedges = if allow_selfloops {
     (nodes * nodes - nodes) / scale + nodes
 } else {
-    (nodes * nodes) / scale - nodes
+    (nodes * nodes - nodes) / scale
 };
```

## Why

For the no-self-loops case the code computed `(nodes * nodes) / scale - nodes` (with `scale = 2` for undirected, `1` for directed). For undirected graphs this is `n^2/2 - n`, which is not the correct simple-graph edge count `n(n-1)/2`.

For `n = 3` it yields `9/2 - 3 = 1` possible edge, so the generator enumerates only `2^1 = 2` graphs instead of the correct `2^3 = 8`. The bit-counting loop in `state_to_graph` still walks the correct `n(n-1)/2` node pairs, so `nedges` disagreed with the actual iteration and most graphs were silently skipped. The old expression also underflows (usize) for `n = 1` (`1/2 - 1`).

The corrected expression `(nodes * nodes - nodes) / scale` equals:

- undirected, no self-loops: `n(n-1)/2` (fixed)
- directed, no self-loops: `n(n-1)` (unchanged, already correct)

and the self-loops branch is untouched, so directed+self-loops (`n^2`) and undirected+self-loops (`n(n-1)/2 + n`) are unaffected. Keeping `/ scale` (rather than hardcoding `/ 2`) preserves the correct directed count.

The bug went unnoticed because the only existing test, `test_generate_undirected`, exercises just the `allow_selfloops = true` branch.

## Testing

Added `test_generate_undirected_without_selfloops_counts_all_graphs`, which asserts 8 undirected graphs for `n = 3` (fails on master with `left: 2, right: 8`) and 64 directed graphs for `n = 3` to guard against a `/2` regression.

```
cargo test -p petgraph --features generate --test graph
```

All four generate tests pass (`test_generate_undirected`, the new test, `test_generate_dag`, `test_generate_directed`); `cargo fmt --check` and `cargo clippy --features generate --tests -- -D warnings` are clean.

Fixes #974
