### PR TITLE
fix: return zero colors for empty DSATUR graphs

### DIFF
--- a/crates/petgraph/src/algo/coloring.rs
+++ b/crates/petgraph/src/algo/coloring.rs
@@ -98,5 +98,7 @@ where
         }
     }
 
-    (colored, max_color + 1)
+    let nb_colors = if colored.is_empty() { 0 } else { max_color + 1 };
+
+    (colored, nb_colors)
 }

--- a/crates/petgraph/tests/coloring.rs
+++ b/crates/petgraph/tests/coloring.rs
@@ -1,6 +1,16 @@
 use petgraph::{Graph, Undirected, algo::dsatur_coloring};
 
 #[test]
+fn dsatur_coloring_empty_graph_uses_zero_colors() {
+    let graph: Graph<(), (), Undirected> = Graph::new_undirected();
+
+    let (coloring, nb_colors) = dsatur_coloring(&graph);
+
+    assert!(coloring.is_empty());
+    assert_eq!(nb_colors, 0);
+}
+
+#[test]
 fn dsatur_coloring_cycle6() {
     let mut graph: Graph<(), (), Undirected> = Graph::new_undirected();
     let a = graph.add_node(());


### PR DESCRIPTION
## Summary
- Return zero colors when `dsatur_coloring` receives an empty graph.
- Add regression coverage for an empty undirected graph.

## Verification
- `cargo test -p petgraph --test coloring`

Fixes #975