### PR TITLE
chore: reduce published package size with cargo diet

### DIFF
--- a/crates/petgraph/Cargo.toml
+++ b/crates/petgraph/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 
 keywords   = ["data-structure", "graph", "unionfind", "graph-algorithms"]
 categories = ["data-structures"]
+include = ["src/**/*", "README.md"]
 
 [package.metadata.docs.rs]
 features = ["rayon", "serde-1", "quickcheck"]


### PR DESCRIPTION
<!--
  -- Thanks for contributing to `petgraph`! 
  --
  -- We require PR titles to follow the Conventional Commits specification,
  -- https://www.conventionalcommits.org/en/v1.0.0/. This helps us generate
  -- changelogs and follow semantic versioning.
  --
  -- Start the PR title with one of the following:
  --  * `feat:` for new features
  --  * `fix:` for bug fixes
  --  * `refactor:` for code refactors
  --  * `docs:` for documentation changes
  --  * `test:` for test changes
  --  * `perf:` for performance improvements
  --  * `revert:` for reverting changes
  --  * `ci:` for CI/CD changes
  --  * `chore:` for changes that don't fit in any of the above categories
  -- The last two categories will not be included in the changelog.
  --
  -- If your PR includes a breaking change, please add a `!` after the type
  -- and include a `BREAKING CHANGE:` line in the body of the PR describing
  -- the necessary changes for users to update their code.
  --
  -->

as part of an [e18e](https://e18e.dev) effort to slim down published crates across the Rust ecosystem, this PR runs [`cargo diet`](https://github.com/the-lean-crate/cargo-diet) to add an `include` list to `Cargo.toml`, excluding tests, benches, and other files that aren't needed by consumers of the published package. no code changes.

package size (`cargo package`): 128 files / 5.1 MiB (257.6 KiB compressed) → 69 files / 847.8 KiB (177.1 KiB compressed) and **~84% smaller uncompressed, ~31% compressed**. given petgraph's download volume, the compressed savings add up to meaningful bandwidth for crates.io and faster fetches for consumers.

`include` only affects packaging. builds, tests, and local development are unchanged, and everything stays in the repo.

the bandwidth saved is 1.07 TB/mo.

| | Before | After | Reduction |
|---|---|---|---|
| Files | 128 | 69 | −59 files |
| Uncompressed | 5.1 MiB | 847.8 KiB | ~84% |
| Compressed (.crate) | 257.6 KiB | 177.1 KiB | ~31% |