### PR TITLE
fix: correct undirected edge count in Generator::all without self-loops

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -65,7 +65,7 @@ impl<Ty: EdgeType> Generator<Ty> {
         let nedges = if allow_selfloops {
             (nodes * nodes - nodes) / scale + nodes
         } else {
-            (nodes * nodes) / scale - nodes
+            (nodes * nodes - nodes) / scale
         };
         assert!(nedges < 64);
         Generator {

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -629,6 +629,35 @@ fn test_generate_undirected() {
 
 #[cfg(feature = "generate")]
 #[test]
+fn test_generate_undirected_without_selfloops_counts_all_graphs() {
+    // 3 nodes, no self-loops => 3 possible edges => 2^3 = 8 graphs
+    assert_eq!(
+        pg::generate::Generator::<Undirected>::all(3, false).count(),
+        8
+    );
+
+    // 3 nodes, with self-loops => 6 possible edges => 2^6 = 64 graphs
+    assert_eq!(
+        pg::generate::Generator::<Undirected>::all(3, true).count(),
+        64
+    );
+
+    // guard against a `/2` regression:
+    // directed, no self-loops => 3*2 = 6 edges => 2^6 = 64 graphs
+    assert_eq!(
+        pg::generate::Generator::<Directed>::all(3, false).count(),
+        64
+    );
+
+    // directed, with self-loops => 3*3 = 9 edges => 2^9 = 512 graphs
+    assert_eq!(
+        pg::generate::Generator::<Directed>::all(3, true).count(),
+        512
+    );
+}
+
+#[cfg(feature = "generate")]
+#[test]
 fn test_generate_directed() {
     // Number of DAG out of all graphs (all permutations) per node size
     //            0, 1, 2, 3,  4,   5 ..


### PR DESCRIPTION
Backport of #1000 to the `0.8` branch, as suggested by @RaoulLuque there.

## What

```diff
 let nedges = if allow_selfloops {
     (nodes * nodes - nodes) / scale + nodes
 } else {
-    (nodes * nodes) / scale - nodes
+    (nodes * nodes - nodes) / scale
 };
```

## Why

For the no-self-loops case the code computed `(nodes * nodes) / scale - nodes` (with `scale = 2` for undirected, `1` for directed). For undirected graphs this is `n^2/2 - n`, not the correct simple-graph edge count `n(n-1)/2`.

For `n = 3` it yields `9/2 - 3 = 1` possible edge, so the generator enumerates only `2^1 = 2` graphs instead of the correct `2^3 = 8`. The bit-counting loop in `state_to_graph` still walks the correct `n(n-1)/2` node pairs, so `nedges` disagreed with the actual iteration and most graphs were silently skipped. The old expression also underflows (usize) for `n = 1`.

`(nodes * nodes - nodes) / scale` equals `n(n-1)/2` for undirected and `n(n-1)` for directed, and the self-loops branch is untouched.

## Testing

Added the same regression test as on master, covering all four branches (undirected/directed x with/without self-loops). It fails on `0.8` without the fix (`left: 2, right: 8`).

```
cargo test --features generate --test graph
```

68 tests pass. `cargo fmt --check` and `cargo clippy --features generate --tests -- -D warnings` are clean.

The file paths differ from #1000 because `0.8` predates the workspace restructure (`src/generate.rs` instead of `crates/petgraph/src/generate.rs`).