### PR TITLE
docs: Adjust edges_directed docs to reflect properly document behavior.

### DIFF
--- a/src/graphmap.rs
+++ b/src/graphmap.rs
@@ -511,8 +511,8 @@ where
     /// Return an iterator of target nodes with an edge starting from `a`,
     /// paired with their respective edge weights.
     ///
-    /// - `Directed`, `Outgoing`: All edges from `a`.
-    /// - `Directed`, `Incoming`: All edges to `a`.
+    /// - `Directed`, `Outgoing`: All edges from `a`, with `a` being the source of each edge.
+    /// - `Directed`, `Incoming`: All edges to `a`, with `a` being the target of each edge.
     /// - `Undirected`, `Outgoing`: All edges connected to `a`, with `a` being the source of each
     ///   edge.
     /// - `Undirected`, `Incoming`: All edges connected to `a`, with `a` being the target of each


### PR DESCRIPTION
This PR makes the documentation of `GraphMap` more specific. That is, when using `edges_directed` to query the outgoing edges of a vertex, the vertex will be the source of the resulting edges. This is already reflected in the tests, but was not specified for directed graphs in the documentation of `GraphMap::edges_directed`.