### PR TITLE
fix: return zero flow when dinics source equals destination

### DIFF
--- a/src/algo/maximum_flow/dinics.rs
+++ b/src/algo/maximum_flow/dinics.rs
@@ -79,6 +79,13 @@ where
     G: NodeCount + EdgeCount + IntoEdgesDirected + EdgeIndexable + NodeIndexable + Visitable,
     G::EdgeWeight: Sub<Output = G::EdgeWeight> + PositiveMeasure,
 {
+    if source == destination {
+        return (
+            G::EdgeWeight::zero(),
+            vec![G::EdgeWeight::zero(); network.edge_count()],
+        );
+    }
+
     let mut max_flow = G::EdgeWeight::zero();
     let mut flows = vec![G::EdgeWeight::zero(); network.edge_count()];
     let mut visited = network.visit_map();

--- a/tests/dinics.rs
+++ b/tests/dinics.rs
@@ -190,3 +190,12 @@ fn test_dinics_stable_graph() {
     let (max_flow, _) = dinics(&graph, source, sink);
     assert_eq!(5, max_flow);
 }
+
+#[test]
+fn test_dinics_source_equals_destination() {
+    let mut graph = Graph::<(), u32>::new();
+    let source = graph.add_node(());
+    let (max_flow, flows) = dinics(&graph, source, source);
+    assert_eq!(0, max_flow);
+    assert!(flows.is_empty());
+}


### PR DESCRIPTION
`dinics` never returns when source and destination are the same node. `build_level_graph` labels the source as 1, the outer loop waits for the destination's level to drop to 0, and `find_blocking_flow` only succeeds when a *next* vertex is the destination, so it keeps adding zero flow forever.

Repro on `0.8`:

    let mut graph = Graph::<(), u32>::new();
    let s = graph.add_node(());
    dinics(&graph, s, s); // hangs

One-node, no edges is enough. I killed it after 15s.

Return zero flow (and a zeroed residual of `edge_count()`) when the terminals are the same node. That is the usual s-t definition, and it matches what the issue suggested.

`cargo test --all-features` is green on `0.8`. Added `test_dinics_source_equals_destination`.

Fixes #973