### PR TITLE
feat!: Add UndirectedTestGraph as a testing graph

### DIFF
--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod directed;
 pub mod testing;
+pub mod undirected;

--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -1,3 +1,2 @@
 pub mod test_graphs;
 pub mod testing;
-

--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -1,3 +1,3 @@
-pub mod directed;
+pub mod test_graphs;
 pub mod testing;
-pub mod undirected;
+

--- a/crates/core/src/utils/test_graphs/directed.rs
+++ b/crates/core/src/utils/test_graphs/directed.rs
@@ -14,40 +14,40 @@ use crate::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
-pub struct NodeId(usize);
+pub struct DirNodeId(usize);
 
-impl AddAssign<usize> for NodeId {
+impl AddAssign<usize> for DirNodeId {
     fn add_assign(&mut self, other: usize) {
         self.0 += other;
     }
 }
 
-impl Display for NodeId {
+impl Display for DirNodeId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, fmt)
     }
 }
 
-impl Id for NodeId {}
+impl Id for DirNodeId {}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
-pub struct EdgeId(usize);
+pub struct DirEdgeId(usize);
 
-impl AddAssign<usize> for EdgeId {
+impl AddAssign<usize> for DirEdgeId {
     fn add_assign(&mut self, other: usize) {
         self.0 += other;
     }
 }
 
-impl Display for EdgeId {
+impl Display for DirEdgeId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, fmt)
     }
 }
 
-impl Id for EdgeId {}
+impl Id for DirEdgeId {}
 
-pub struct DirectedTestGraph<N, E, NI = NodeId, EI = EdgeId> {
+pub struct DirectedTestGraph<N, E, NI = DirNodeId, EI = DirEdgeId> {
     next_node: NI,
     next_edge: EI,
 
@@ -189,31 +189,31 @@ mod test {
     use crate::test_directed_graph;
 
     fn remove_node_with_unwrap(
-        graph: &mut DirectedTestGraph<(), (), NodeId, EdgeId>,
-        node_id: NodeId,
+        graph: &mut DirectedTestGraph<(), (), DirNodeId, DirEdgeId>,
+        node_id: DirNodeId,
     ) {
         graph.remove_node(node_id).unwrap();
     }
 
     fn add_edge_with_unwrap(
-        graph: &mut DirectedTestGraph<(), (), NodeId, EdgeId>,
-        source: NodeId,
-        target: NodeId,
+        graph: &mut DirectedTestGraph<(), (), DirNodeId, DirEdgeId>,
+        source: DirNodeId,
+        target: DirNodeId,
         _data: (),
-    ) -> EdgeId {
+    ) -> DirEdgeId {
         graph.add_edge(source, target, ()).unwrap()
     }
 
     fn remove_edge_with_unwrap(
-        graph: &mut DirectedTestGraph<(), (), NodeId, EdgeId>,
-        edge_id: EdgeId,
+        graph: &mut DirectedTestGraph<(), (), DirNodeId, DirEdgeId>,
+        edge_id: DirEdgeId,
     ) {
         graph.remove_edge(edge_id).unwrap();
     }
 
     test_directed_graph!(
-        DirectedTestGraph::<(), (), NodeId, EdgeId>::new,
-        DirectedTestGraph::<(), (), NodeId, EdgeId>::add_node,
+        DirectedTestGraph::<(), (), DirNodeId, DirEdgeId>::new,
+        DirectedTestGraph::<(), (), DirNodeId, DirEdgeId>::add_node,
         remove_node_with_unwrap,
         add_edge_with_unwrap,
         remove_edge_with_unwrap

--- a/crates/core/src/utils/test_graphs/mod.rs
+++ b/crates/core/src/utils/test_graphs/mod.rs
@@ -1,0 +1,2 @@
+pub mod undirected;
+pub mod directed;

--- a/crates/core/src/utils/test_graphs/mod.rs
+++ b/crates/core/src/utils/test_graphs/mod.rs
@@ -1,2 +1,2 @@
-pub mod undirected;
 pub mod directed;
+pub mod undirected;

--- a/crates/core/src/utils/test_graphs/undirected.rs
+++ b/crates/core/src/utils/test_graphs/undirected.rs
@@ -14,40 +14,40 @@ use crate::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
-pub struct NodeId(usize);
+pub struct UndirNodeId(usize);
 
-impl AddAssign<usize> for NodeId {
+impl AddAssign<usize> for UndirNodeId {
     fn add_assign(&mut self, other: usize) {
         self.0 += other;
     }
 }
 
-impl Display for NodeId {
+impl Display for UndirNodeId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, fmt)
     }
 }
 
-impl Id for NodeId {}
+impl Id for UndirNodeId {}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
-pub struct EdgeId(usize);
+pub struct UndirEdgeId(usize);
 
-impl AddAssign<usize> for EdgeId {
+impl AddAssign<usize> for UndirEdgeId {
     fn add_assign(&mut self, other: usize) {
         self.0 += other;
     }
 }
 
-impl Display for EdgeId {
+impl Display for UndirEdgeId {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, fmt)
     }
 }
 
-impl Id for EdgeId {}
+impl Id for UndirEdgeId {}
 
-pub struct UndirectedTestGraph<N, E, NI = NodeId, EI = EdgeId> {
+pub struct UndirectedTestGraph<N, E, NI = UndirNodeId, EI = UndirEdgeId> {
     next_node: NI,
     next_edge: EI,
 

--- a/crates/core/src/utils/testing.rs
+++ b/crates/core/src/utils/testing.rs
@@ -55,7 +55,7 @@ macro_rules! create_directed_test_graph {
 ///   calling methods with that ID should return `None` or indicate non-existence.
 ///
 /// The arguments to this macro are as follows (`G` is used to denote the graph type being tested).
-/// For a reference usage, see the tests [`crate::utils::directed`].
+/// For a reference usage, see the tests in [`crate::utils::test_graphs::directed`].
 /// - `$graph_constructor`: An expression that constructs a new instance of the graph type to be
 ///   tested. The generated graph must be empty (e.g. `G::new()`).
 /// - `$add_node`: An expression that adds a node to the graph. It must take two arguments: a

--- a/crates/core/src/utils/undirected.rs
+++ b/crates/core/src/utils/undirected.rs
@@ -1,0 +1,184 @@
+use core::{
+    fmt::{self, Display},
+    hash::Hash,
+    ops::AddAssign,
+};
+
+use hashbrown::HashMap;
+
+use crate::{
+    edge::{Edge, EdgeMut, EdgeRef},
+    graph::{Graph, UndirectedGraph},
+    id::Id,
+    node::{Node, NodeMut, NodeRef},
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+pub struct NodeId(usize);
+
+impl AddAssign<usize> for NodeId {
+    fn add_assign(&mut self, other: usize) {
+        self.0 += other;
+    }
+}
+
+impl Display for NodeId {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, fmt)
+    }
+}
+
+impl Id for NodeId {}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+pub struct EdgeId(usize);
+
+impl AddAssign<usize> for EdgeId {
+    fn add_assign(&mut self, other: usize) {
+        self.0 += other;
+    }
+}
+
+impl Display for EdgeId {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, fmt)
+    }
+}
+
+impl Id for EdgeId {}
+
+pub struct UndirectedTestGraph<N, E, NI = NodeId, EI = EdgeId> {
+    next_node: NI,
+    next_edge: EI,
+
+    nodes: HashMap<NI, N, foldhash::fast::RandomState>,
+    edges: HashMap<EI, (NI, NI, E), foldhash::fast::RandomState>,
+}
+
+impl<N, E, NI, EI> UndirectedTestGraph<N, E, NI, EI>
+where
+    NI: Id + Eq + Hash + AddAssign<usize>,
+    EI: Id + Eq + Hash + AddAssign<usize>,
+{
+    #[must_use]
+    pub fn new() -> Self
+    where
+        NI: Default,
+        EI: Default,
+    {
+        Self {
+            next_node: NI::default(),
+            next_edge: EI::default(),
+
+            nodes: HashMap::default(),
+            edges: HashMap::default(),
+        }
+    }
+
+    pub fn add_node(&mut self, node: N) -> NI {
+        let id = self.next_node;
+        self.next_node += 1;
+
+        self.nodes.insert(id, node);
+        id
+    }
+
+    pub fn add_edge(&mut self, source: NI, target: NI, edge: E) -> Option<EI> {
+        if !self.nodes.contains_key(&source) || !self.nodes.contains_key(&target) {
+            return None;
+        }
+
+        let id = self.next_edge;
+        self.next_edge += 1;
+
+        self.edges.insert(id, (source, target, edge));
+        Some(id)
+    }
+
+    pub fn remove_node(&mut self, node_id: NI) -> Option<N> {
+        self.edges
+            .retain(|_, (source, target, _)| *source != node_id && *target != node_id);
+        self.nodes.remove(&node_id)
+    }
+
+    pub fn remove_edge(&mut self, edge_id: EI) -> Option<E> {
+        self.edges.remove(&edge_id).map(|(_, _, data)| data)
+    }
+}
+
+impl<N, E, NI, EI> Default for UndirectedTestGraph<N, E, NI, EI>
+where
+    NI: Id + Eq + Hash + AddAssign<usize> + Default,
+    EI: Id + Eq + Hash + AddAssign<usize> + Default,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<N, E, NI, EI> Graph for UndirectedTestGraph<N, E, NI, EI>
+where
+    NI: Id,
+    EI: Id,
+{
+    type EdgeData<'graph>
+        = E
+    where
+        Self: 'graph;
+    type EdgeDataMut<'graph>
+        = &'graph mut E
+    where
+        Self: 'graph;
+    type EdgeDataRef<'graph>
+        = &'graph E
+    where
+        Self: 'graph;
+    type EdgeId = EI;
+    type NodeData<'graph>
+        = N
+    where
+        Self: 'graph;
+    type NodeDataMut<'graph>
+        = &'graph mut N
+    where
+        Self: 'graph;
+    type NodeDataRef<'graph>
+        = &'graph N
+    where
+        Self: 'graph;
+    type NodeId = NI;
+}
+
+impl<N, E, NI, EI> UndirectedGraph for UndirectedTestGraph<N, E, NI, EI>
+where
+    NI: Id,
+    EI: Id,
+{
+    fn nodes(&self) -> impl Iterator<Item = NodeRef<'_, Self>> {
+        self.nodes.iter().map(|(&id, data)| Node { id, data })
+    }
+
+    fn nodes_mut(&mut self) -> impl Iterator<Item = NodeMut<'_, Self>> {
+        self.nodes.iter_mut().map(|(&id, data)| Node { id, data })
+    }
+
+    fn edges(&self) -> impl Iterator<Item = EdgeRef<'_, Self>> {
+        self.edges.iter().map(|(&id, (source, target, data))| Edge {
+            id,
+            source: *source,
+            target: *target,
+            data,
+        })
+    }
+
+    fn edges_mut(&mut self) -> impl Iterator<Item = EdgeMut<'_, Self>> {
+        self.edges
+            .iter_mut()
+            .map(|(&id, (source, target, data))| Edge {
+                id,
+                source: *source,
+                target: *target,
+                data,
+            })
+    }
+}


### PR DESCRIPTION
Adds `UndirectedTestGraph` which has the same idea and backend as `DirectedTestGraph` but just implements the `UndirectedGraph` trait.

Curiously, the existing `DirectedTestGraph` could implement `DirectedGraph` and `UndirectedGraph` both at the same time and should work as both of them at the same time.

BREAKING CHANGE: Moves `DirectedTestGraph` to a new location, but since `DirectedTestGraph` has never been released, this is not actually breaking.