### PR TITLE
ci: Fix release-plz (pretty please)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,6 +6,8 @@ edition.workspace      = true
 license.workspace      = true
 repository.workspace   = true
 rust-version.workspace = true
+# We can remove this this crate has been released at least once
+publish                = false
 
 [dependencies]
 foldhash  = { workspace = true, optional = true }


### PR DESCRIPTION
This just marks the `core` crate as `publish = false` in order for `release-plz` not to try to release it and fail since it has no version yet.