### PR TITLE
fix: size articulation_points scratch state by node bound, not node count

### DIFF
--- a/crates/petgraph/src/algo/articulation_points.rs
+++ b/crates/petgraph/src/algo/articulation_points.rs
@@ -58,8 +58,10 @@ where
     G::EdgeWeight: Clone + PartialOrd,
     G::NodeId: Eq + Hash,
 {
-    let graph_size = g.node_references().size_hint().0;
-    let mut auxiliary_const = ArticulationPointTracker::new(graph_size);
+    // The scratch state below is indexed by `to_index`, so it has to be sized by the
+    // index bound and not by the node count: graphs such as `StableGraph` have sparse
+    // node indices, where the largest index can exceed the number of nodes.
+    let mut auxiliary_const = ArticulationPointTracker::new(g.node_bound());
 
     for node in g.node_references() {
         let node_id = g.to_index(node.id());
@@ -94,13 +96,13 @@ struct ArticulationPointTracker {
 }
 
 impl ArticulationPointTracker {
-    fn new(graph_size: usize) -> Self {
+    fn new(node_bound: usize) -> Self {
         Self {
-            visited: FixedBitSet::with_capacity(graph_size),
-            low: vec![usize::MAX; graph_size],
-            disc: vec![usize::MAX; graph_size],
-            parent: vec![usize::MAX; graph_size],
-            articulation_points: HashSet::with_capacity(graph_size),
+            visited: FixedBitSet::with_capacity(node_bound),
+            low: vec![usize::MAX; node_bound],
+            disc: vec![usize::MAX; node_bound],
+            parent: vec![usize::MAX; node_bound],
+            articulation_points: HashSet::with_capacity(node_bound),
             time: 0,
         }
     }

--- a/crates/petgraph/tests/articulation_points.rs
+++ b/crates/petgraph/tests/articulation_points.rs
@@ -179,3 +179,64 @@ fn art_simple2() {
 
     assert_eq!(articulation_points(&gr), set);
 }
+
+#[cfg(feature = "stable_graph")]
+#[test]
+fn art_stable_graph_linear_chain_regression() {
+    use petgraph::stable_graph::StableUnGraph;
+
+    let mut gr = StableUnGraph::<&str, ()>::default();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+
+    gr.add_edge(a, b, ());
+    gr.add_edge(b, c, ());
+
+    let set: HashSet<_> = [b].iter().cloned().collect();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[cfg(feature = "stable_graph")]
+#[test]
+fn art_stable_graph_empty() {
+    use petgraph::stable_graph::StableUnGraph;
+
+    let gr = StableUnGraph::<&str, ()>::default();
+
+    let set: HashSet<NodeIndex> = HashSet::new();
+
+    assert_eq!(articulation_points(&gr), set);
+}
+
+#[cfg(feature = "stable_graph")]
+#[test]
+fn art_stable_graph_with_removed_nodes() {
+    use petgraph::stable_graph::StableUnGraph;
+
+    // The removals leave holes, so the remaining node indices are sparse: the largest
+    // one is 6, while only five nodes are left.
+    let mut gr = StableUnGraph::<&str, ()>::default();
+    let a = gr.add_node("A");
+    let b = gr.add_node("B");
+    let c = gr.add_node("C");
+    let d = gr.add_node("D");
+    let e = gr.add_node("E");
+    let f = gr.add_node("F");
+    let g = gr.add_node("G");
+
+    gr.remove_node(a);
+    gr.remove_node(d);
+
+    // B - C - E, with E, F and G forming a triangle.
+    gr.add_edge(b, c, ());
+    gr.add_edge(c, e, ());
+    gr.add_edge(e, f, ());
+    gr.add_edge(f, g, ());
+    gr.add_edge(g, e, ());
+
+    let set: HashSet<_> = [c, e].iter().cloned().collect();
+
+    assert_eq!(articulation_points(&gr), set);
+}

--- a/crates/petgraph/tests/quickcheck.rs
+++ b/crates/petgraph/tests/quickcheck.rs
@@ -1629,6 +1629,29 @@ quickcheck! {
 }
 
 #[cfg(feature = "stable_graph")]
+quickcheck! {
+    // Test that articulation points do not depend on how dense the node indices are: a
+    // `StableGraph` with holes must agree with the equivalent compacted `Graph`.
+    fn test_articulation_points_stable_graph(g: StableGraph<(), (), Undirected>) -> bool {
+        let mut compacted = UnGraph::<(), ()>::default();
+        let mut compacted_ix = HashMap::new();
+        for node in g.node_indices() {
+            compacted_ix.insert(node, compacted.add_node(()));
+        }
+        for edge in g.edge_references() {
+            compacted.add_edge(compacted_ix[&edge.source()], compacted_ix[&edge.target()], ());
+        }
+
+        let from_stable: HashSet<_> = articulation_points(&g)
+            .into_iter()
+            .map(|node| compacted_ix[&node])
+            .collect();
+
+        from_stable == articulation_points(&compacted)
+    }
+}
+
+#[cfg(feature = "stable_graph")]
 #[test]
 fn steiner_tree_spans_terminals() {
     fn prop(g: UnGraph<(), u32>) -> bool {


### PR DESCRIPTION
`articulation_points` panics on any non-empty `StableGraph`:

```
thread 'main' panicked at fixedbitset-0.5.7/src/lib.rs:426:9:
insert at index 0 exceeds fixedbitset size 0
```

The scratch state is sized from `g.node_references().size_hint().0` but indexed with `g.to_index(node)`, and those are two different domains. `size_hint().0` is only a lower bound, and `StableGraph`'s node-reference iterator reports 0, so `visited`, `low`, `disc` and `parent` all come out empty and the first DFS visit runs off the end.

Sized it by `node_bound()` instead. That is documented as an upper bound on the node indices, suitable for the size of a bitmap, and it is what `bridges.rs` already uses for the same job. `NodeIndexable` was already a bound on the function so nothing public changes. `node_count()` looks like it would work and does pass the reported case, but it is wrong as soon as a graph has holes, and it would need a new `NodeCount` bound.

I also renamed the `ArticulationPointTracker::new` parameter from `graph_size` to `node_bound`. It is a private constructor, and the old name is more or less the misconception that caused this.

Tests are the reported chain, a graph with removed nodes so the indices are genuinely sparse, and a quickcheck property that a `StableGraph` agrees with the equivalent compacted `Graph`. The sparse one is the one that earns its place, since the chain on its own passes under `node_count()` too. `art_stable_graph_empty` is only edge-case coverage, it already passes on master.

`cargo test -p petgraph --all-features`, `cargo fmt --all -- --check` and clippy with `-D warnings` are green. The new tests are gated on the `stable_graph` feature so `--no-default-features` still builds the test target.

Fixes #970
