### PR TITLE
fix: find_negative_cycle returns a non-cycle single vertex

### DIFF
--- a/crates/petgraph/src/algo/bellman_ford.rs
+++ b/crates/petgraph/src/algo/bellman_ford.rs
@@ -164,7 +164,7 @@ where
 /// let path = find_negative_cycle(&graph_with_neg_cycle, NodeIndex::new(0));
 /// assert_eq!(
 ///     path,
-///     Some([NodeIndex::new(1), NodeIndex::new(3), NodeIndex::new(2)].to_vec())
+///     Some([NodeIndex::new(3), NodeIndex::new(2), NodeIndex::new(1)].to_vec())
 /// );
 /// ```
 pub fn find_negative_cycle<G>(g: G, source: G::NodeId) -> Option<Vec<G::NodeId>>
@@ -184,8 +184,29 @@ where
             let j = edge.target();
             let w = *edge.weight();
             if distance[ix(i)] + w < distance[ix(j)] {
-                // Step 3: negative cycle found
-                let start = j;
+                // Step 3: negative cycle found.
+                //
+                // The relaxable edge `(i, j)` proves that `j` is affected by a
+                // negative cycle, but neither `i` nor `j` is guaranteed to lie
+                // *on* the cycle -- they may only be reachable from it. Starting
+                // the reconstruction directly at `j` is therefore wrong: if `j`
+                // has no predecessor (e.g. it is the source, whose distance was
+                // never relaxed) the loop below would treat it as a bogus
+                // single-node self cycle and return a `j` that is not a cycle at
+                // all.
+                //
+                // Walk back `node_count` predecessor links from the affected
+                // vertex `i` first. Every affected vertex has a predecessor
+                // (its chain stays within the affected region and never reaches
+                // the source), so after at most `node_count` steps we are
+                // guaranteed to have landed on a vertex that lies on the cycle.
+                let mut start = i;
+                for _ in 0..g.node_count() {
+                    match predecessor[ix(start)] {
+                        Some(predecessor_node) => start = predecessor_node,
+                        None => break,
+                    }
+                }
                 let mut node = start;
                 let mut visited = g.visit_map();
                 // Go backward in the predecessor chain

--- a/crates/petgraph/src/csr.rs
+++ b/crates/petgraph/src/csr.rs
@@ -1145,7 +1145,7 @@ mod tests {
         ])
         .unwrap();
         let result = find_negative_cycle(&m, 0);
-        assert_eq!(result, Some([1, 3, 2].to_vec()));
+        assert_eq!(result, Some([3, 2, 1].to_vec()));
     }
 
     #[test]
@@ -1153,6 +1153,21 @@ mod tests {
         let m: Csr<(), _> = Csr::from_sorted_edges(&[(0, 0, -1.)]).unwrap();
         let result = find_negative_cycle(&m, 0);
         assert_eq!(result, Some([0].to_vec()));
+    }
+
+    #[test]
+    fn test_find_neg_cycle5() {
+        // Regression test: the negative cycle `{1, 2}` does not contain the
+        // source `0`, but `0` is still affected by it via the edge `1 -> 0`.
+        // The relaxable edge found during detection points at `0`, which has no
+        // predecessor. Previously this made `find_negative_cycle` return the
+        // bogus single-vertex "cycle" `Some([0])` -- a vertex with no self-loop,
+        // which is not a cycle at all. It must instead return an actual cycle.
+        let m: Csr<(), _> =
+            Csr::from_sorted_edges(&[(0, 2, 2.), (1, 0, 5.), (1, 2, 1.), (2, 0, 7.), (2, 1, -5.)])
+                .unwrap();
+        let result = find_negative_cycle(&m, 0);
+        assert_eq!(result, Some([2, 1].to_vec()));
     }
 
     #[test]

--- a/crates/petgraph/tests/quickcheck.rs
+++ b/crates/petgraph/tests/quickcheck.rs
@@ -1070,6 +1070,22 @@ quickcheck! {
             if i >= 10 { break; } // testing all is too slow
             if let Some(path) = find_negative_cycle(&gr, start) {
                 assert!(!path.is_empty());
+                // The returned path must be an actual cycle: every consecutive
+                // pair (wrapping around) is connected by an edge, and the total
+                // weight of the closed walk is strictly negative.
+                let mut total = 0.0f32;
+                for k in 0..path.len() {
+                    let u = path[k];
+                    let v = path[(k + 1) % path.len()];
+                    // Use the lightest parallel edge between `u` and `v`.
+                    let w = gr
+                        .edges_connecting(u, v)
+                        .map(|e| *e.weight())
+                        .fold(f32::INFINITY, f32::min);
+                    assert!(w.is_finite(), "returned path is not a cycle: no edge {:?} -> {:?}", u, v);
+                    total += w;
+                }
+                assert!(total < 0.0, "returned cycle is not negative: total weight {}", total);
             }
         }
         true


### PR DESCRIPTION
### Problem

`find_negative_cycle` can return a single vertex that is not a cycle. When a negative cycle is reachable from `source` but the relaxable edge detected during Bellman-Ford points at a vertex that isn't on the cycle — notably the `source` itself, whose predecessor is `None` — the reconstruction's "no predecessor, self cycle" fallback returns `Some([that_vertex])`, even though it has no self-loop.

Example: with the negative cycle `{1, 2}` and an edge `1 -> 0` feeding the source `0`, `find_negative_cycle(&g, 0)` returned `Some([0])` instead of the cycle `{1, 2}`. Node `0` has no self-loop, so `[0]` is not a cycle at all.

### Fix

Before reconstructing, walk `node_count` predecessor links from the affected tail vertex of the relaxable edge. That vertex always has a predecessor and its chain stays within the affected region (never reaching the unrelaxed source), so we are guaranteed to land on a vertex that lies on the cycle. Negative self-loops still return a single vertex, unchanged.

### Tests

- Added `test_find_neg_cycle5` (deterministic regression; failed before as `Some([0])`).
- Strengthened the `test_find_negative_cycle` quickcheck to verify the returned path is a real cycle with negative total weight — it previously only checked non-emptiness, which is why this slipped through.
- Updated the `find_negative_cycle` doc example and `test_find_neg_cycle3` to a still-valid rotation of the same cycle (the fix changes the cycle's starting vertex).

Related: #642 (interpreting `find_negative_cycle` output).
