### PR TITLE
fix: correct panic message in List::add_edge

### DIFF
--- a/crates/petgraph/src/adj.rs
+++ b/crates/petgraph/src/adj.rs
@@ -236,7 +236,7 @@ impl<E, Ix: IndexType> List<E, Ix> {
         if b.index() >= self.suc.len() {
             panic!(
                 "{} is not a valid node index for a {} nodes adjacency list",
-                b.index(),
+                b,
                 self.suc.len()
             );
         }


### PR DESCRIPTION

This is a small fix to improve the panic message in `List::add_edge`.

Changed the panic message to display the `NodeIndex` value instead of just its internal index, making it more helpful for debugging.

In `crates/petgraph/src/adj.rs`, changed `b.index()` to `b` in the panic message of `List::add_edge`

This change is purely cosmetic and doesn't affect functionality, so no new tests are needed. The existing tests continue to pass.

When `add_edge` panics due to an invalid node index, the previous message only showed the internal index value (e.g., "5 is not a valid node index for a 3 nodes adjacency list"). With this change, the full NodeIndex is displayed, providing more context for debugging.

Tested on stable Rust (1.70.0)
