### PR TITLE
docs: add a brief description to the generate module

### DIFF
--- a/crates/petgraph/src/generate.rs
+++ b/crates/petgraph/src/generate.rs
@@ -1,6 +1,8 @@
 //! ***Unstable.*** Graph generation.
 //!
 //! ***Unstable: API may change at any time.*** Depends on `feature = "generate"`.
+//!
+//! This module provides utilities for generating different types of graphs.
 
 use crate::{Directed, EdgeType, Graph, graph::NodeIndex};
 


### PR DESCRIPTION
This PR adds a brief one-line description to the generate module to clarify its purpose.

The change is minimal and contains only a single line of documentation, following the project's documentation style.

This PR is created as part of a task to open one pull request following the project's guidelines.