### PR TITLE
refactor: write the all() edge bound as nodes*(nodes-1)

### DIFF
--- a/crates/petgraph/src/generate.rs
+++ b/crates/petgraph/src/generate.rs
@@ -63,7 +63,7 @@ impl<Ty: EdgeType> Generator<Ty> {
         let nedges = if allow_selfloops {
             (nodes * nodes - nodes) / scale + nodes
         } else {
-            (nodes * nodes - nodes) / scale
+            (nodes * (nodes - 1)) / scale
         };
         assert!(nedges < 64);
         Generator {


### PR DESCRIPTION
For undirected graphs without self-loops, the edge count calculation used `(nodes*nodes - nodes) / scale` which is mathematically equivalent to `nodes*(nodes-1) / scale`. This change improves code clarity without changing the actual behavior.

- Simplified the edge count calculation in `crates/petgraph/src/generate.rs`
- Changed from `(nodes*nodes - nodes)` to `nodes*(nodes-1)` in the else branch for undirected graphs without self-loops

This is a net-negative change (simplifies the code) with no functional impact. The mathematical result is identical, but the new expression more clearly represents the calculation of possible edges in a complete undirected graph without self-loops.