### PR TITLE
ci: fix needless_bool that breaks the Lints job on current nightly

### DIFF
--- a/crates/petgraph/tests/quickcheck.rs
+++ b/crates/petgraph/tests/quickcheck.rs
@@ -1477,10 +1477,7 @@ quickcheck! {
         let ranks: Vec<f64> = page_rank(&gr, 0.85_f64, 5);
         let at_least_one_neg_rank = ranks.iter().any(|rank| *rank < 0.);
         let not_sumup_to_one = (ranks.iter().sum::<f64>() - 1.).abs() > tol;
-        if  at_least_one_neg_rank | not_sumup_to_one{
-            return false;
-        }
-        true
+        !(at_least_one_neg_rank | not_sumup_to_one)
     }
 }
 


### PR DESCRIPTION
The `Lints` job is red on `master` and on every open PR right now. `just clippy` runs with `-D warnings`, and current nightly clippy fires `needless_bool` on the `test_page_rank_proba` body:

```
error: this `if` guard returns a bool literal and is followed by another
    --> crates/petgraph/tests/quickcheck.rs:1480:9
     |
1480 | /         if  at_least_one_neg_rank | not_sumup_to_one{
1481 | |             return false;
1482 | |         }
1483 | |         true
     | |____________^ help: you can reduce it to: `!(at_least_one_neg_rank | not_sumup_to_one)`
```

Nothing changed in the repo, the runners' toolchain moved. clippy 0.1.95 (stable) and 0.1.99 (`nightly-2026-08-08`) both accept that code; `nightly-2026-09-05`, rustc 1.100.0-nightly, rejects it. The job installs plain `nightly`, so it picks up whatever is current that day.

I took clippy's own suggestion and returned the condition. Both operands are already-bound locals, so leaving `|` instead of switching to `||` changes nothing about evaluation and keeps the expression as it was written.

`cargo test --all-features` is green including `test_page_rank_proba`, and `cargo fmt --all -- --check` is clean on nightly.

One thing this does not fix. With clippy unblocked the job moves on to `cargo doc`, and that fails too: nightly rustdoc reports 16 `redundant explicit link target` errors under `RUSTDOCFLAGS=-Dwarnings`, in `visit/mod.rs`, `matrix_graph.rs`, `algo/min_spanning_tree.rs` and `algo/matching.rs`. Same cause, a lint that got stricter. That one touches a lot of doc comments, so it belongs in its own PR rather than riding along here.
