### PR TITLE
fix: Size max flow scratch vectors by index bound

### DIFF
--- a/src/algo/maximum_flow/dinics.rs
+++ b/src/algo/maximum_flow/dinics.rs
@@ -82,12 +82,12 @@ where
     if source == destination {
         return (
             G::EdgeWeight::zero(),
-            vec![G::EdgeWeight::zero(); network.edge_count()],
+            vec![G::EdgeWeight::zero(); network.edge_bound()],
         );
     }
 
     let mut max_flow = G::EdgeWeight::zero();
-    let mut flows = vec![G::EdgeWeight::zero(); network.edge_count()];
+    let mut flows = vec![G::EdgeWeight::zero(); network.edge_bound()];
     let mut visited = network.visit_map();
     let mut level_edges = vec![Default::default(); network.node_bound()];
 

--- a/src/algo/maximum_flow/ford_fulkerson.rs
+++ b/src/algo/maximum_flow/ford_fulkerson.rs
@@ -176,7 +176,7 @@ where
         + Visitable,
     G::EdgeWeight: Sub<Output = G::EdgeWeight> + PositiveMeasure,
 {
-    let mut edge_to = vec![None; network.node_count()];
+    let mut edge_to = vec![None; network.node_bound()];
     let mut flows = vec![G::EdgeWeight::zero(); network.edge_bound()];
     let mut max_flow = G::EdgeWeight::zero();
     while has_augmented_path(&network, source, destination, &mut edge_to, &flows) {

--- a/tests/dinics.rs
+++ b/tests/dinics.rs
@@ -199,3 +199,24 @@ fn test_dinics_source_equals_destination() {
     assert_eq!(0, max_flow);
     assert!(flows.is_empty());
 }
+
+#[cfg(feature = "stable_graph")]
+#[test]
+fn test_dinics_stable_graph_edge_hole() {
+    use petgraph::prelude::StableDiGraph;
+
+    // Removing the middle edge leaves the two live edges in slots 0 and 2, so the
+    // largest edge index is bigger than the edge count.
+    let mut graph = StableDiGraph::<(), u32>::new();
+    let source = graph.add_node(());
+    let middle = graph.add_node(());
+    let sink = graph.add_node(());
+
+    graph.add_edge(source, middle, 1);
+    let removed = graph.add_edge(source, sink, 1);
+    graph.add_edge(middle, sink, 1);
+
+    graph.remove_edge(removed);
+
+    assert_eq!(1, dinics(&graph, source, sink).0);
+}

--- a/tests/ford_fulkerson.rs
+++ b/tests/ford_fulkerson.rs
@@ -173,3 +173,19 @@ fn test_ford_fulkerson_stable_graphs() {
 
     assert_eq!(2, ford_fulkerson(&g, a, d).0);
 }
+
+#[cfg(feature = "stable_graph")]
+#[test]
+fn test_ford_fulkerson_stable_graph_node_hole() {
+    // Removing the middle node leaves live slots 0 and 2, so the largest node index is
+    // bigger than the node count.
+    let mut graph = StableDiGraph::<(), u32>::new();
+    let source = graph.add_node(());
+    let removed = graph.add_node(());
+    let sink = graph.add_node(());
+
+    graph.add_edge(source, sink, 1);
+    graph.remove_node(removed);
+
+    assert_eq!(1, ford_fulkerson(&graph, source, sink).0);
+}


### PR DESCRIPTION
`ford_fulkerson` allocates `edge_to` with `network.node_count()` and `dinics` allocates `flows` with `network.edge_count()`, but both vectors are read and written through `to_index`. Those are two different index spaces. On a `StableGraph` that has had a node or an edge removed, the live indices are sparse and the largest one can sit past the end of the vector.

A `StableDiGraph` with three nodes where the middle one is removed panics in `ford_fulkerson`:

```
thread 'test_ford_fulkerson_stable_graph_node_hole' panicked at
crates/petgraph/src/algo/maximum_flow/ford_fulkerson.rs:77:17:
index out of bounds: the len is 2 but the index is 2
```

and three edges where the middle one is removed panics in `dinics`:

```
thread 'test_dinics_stable_graph_edge_hole' panicked at
crates/petgraph/src/algo/maximum_flow/dinics.rs:138:79:
index out of bounds: the len is 2 but the index is 2
```

Both functions already size their other scratch vector correctly, `flows` in `ford_fulkerson` and `edge_to`/`level_edges`/`level_graph` in `dinics`, which is why the existing `StableGraph` tests pass: `test_ford_fulkerson_stable_graphs` only makes edge holes and `test_dinics_stable_graph` only makes a node hole, so each one exercises the half that was already right.

The fix is `node_bound()` and `edge_bound()` for the two remaining allocations, the same shape as #1026 for `articulation_points`. A bounds check would be wrong here, since a hole below the bound is a live part of the index space and the entry has to exist.

I ran `cargo test --all-features`, `cargo fmt --all -- --check`, `cargo clippy --all-features --lib --bins --examples --tests -- -D warnings`, and `cargo check --no-default-features -p petgraph --target wasm32v1-none --features graphmap,serde-1,stable_graph,matrix_graph,generate,unstable`.

Closes #972
Closes #971
