### PR TITLE
fix!: Return an error instead of panicking on malformed graph6 input

### DIFF
--- a/crates/petgraph/benches/graph6_decoder.rs
+++ b/crates/petgraph/benches/graph6_decoder.rs
@@ -33,5 +33,5 @@ fn from_graph6_str_63(bench: &mut Bencher) {
 }
 
 fn from_graph6_bench(bench: &mut Bencher, graph6_str: &str) {
-    bench.iter(|| (from_graph6_representation::<u16>(graph6_str.to_string())));
+    bench.iter(|| (from_graph6_representation::<u16>(graph6_str.to_string()).unwrap()));
 }

--- a/crates/petgraph/src/graph6/graph6_decoder.rs
+++ b/crates/petgraph/src/graph6/graph6_decoder.rs
@@ -5,6 +5,7 @@ use alloc::{
     vec,
     vec::Vec,
 };
+use core::fmt;
 #[cfg(any(feature = "graphmap", feature = "matrix_graph"))]
 use core::hash::BuildHasher;
 
@@ -18,51 +19,115 @@ use crate::{Graph, Undirected, csr::Csr, graph::IndexType};
 
 const N: usize = 63;
 
+/// The error type for decoding a graph6 format string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Graph6Error {
+    /// The string was empty, so it has no order byte.
+    Empty,
+    /// The string holds a character outside the graph6 printable range `'?'..='~'`.
+    InvalidCharacter(char),
+    /// The string starts the `~` long form but stops before the three order bytes are complete.
+    TruncatedOrder,
+    /// The string starts the 8-byte `~~` order form, which this decoder does not support.
+    UnsupportedOrder,
+    /// The adjacency matrix carries fewer bits than the declared order needs.
+    TruncatedAdjacencyMatrix {
+        /// Number of bits the declared order requires.
+        expected: usize,
+        /// Number of bits the string actually carries.
+        found: usize,
+    },
+}
+
+impl core::error::Error for Graph6Error {}
+
+impl fmt::Display for Graph6Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Graph6Error::Empty => write!(f, "empty graph6 string"),
+            Graph6Error::InvalidCharacter(c) => {
+                write!(f, "character {c:?} is outside the graph6 range '?'..='~'")
+            }
+            Graph6Error::TruncatedOrder => write!(f, "truncated graph6 order in the `~` long form"),
+            Graph6Error::UnsupportedOrder => {
+                write!(
+                    f,
+                    "graph order beyond 258047 (the `~~` form) is not supported"
+                )
+            }
+            Graph6Error::TruncatedAdjacencyMatrix { expected, found } => write!(
+                f,
+                "adjacency matrix has {found} bits, the declared order needs {expected}"
+            ),
+        }
+    }
+}
+
 /// A graph that can be converted from graph6 format string.
-pub trait FromGraph6 {
-    fn from_graph6_string(graph6_string: String) -> Self;
+pub trait FromGraph6: Sized {
+    fn from_graph6_string(graph6_string: String) -> Result<Self, Graph6Error>;
 }
 
 /// Converts a graph6 format string into data can be used to construct an undirected graph.
 /// Returns a tuple containing the graph order and its edges.
-pub fn from_graph6_representation<Ix>(graph6_representation: String) -> (usize, Vec<(Ix, Ix)>)
+///
+/// # Errors
+///
+/// Returns [`Graph6Error`] if the string is not a well formed graph6 representation.
+pub fn from_graph6_representation<Ix>(
+    graph6_representation: String,
+) -> Result<(usize, Vec<(Ix, Ix)>), Graph6Error>
 where
     Ix: IndexType,
 {
     let (order_bytes, adj_matrix_bytes) =
-        get_order_bytes_and_adj_matrix_bytes(graph6_representation);
+        get_order_bytes_and_adj_matrix_bytes(graph6_representation)?;
 
     let order_bits = bytes_vector_to_bits_vector(order_bytes);
     let adj_matrix_bits = bytes_vector_to_bits_vector(adj_matrix_bytes);
 
     let graph_order = get_bits_as_decimal(order_bits);
-    let edges = get_edges(graph_order, adj_matrix_bits);
+    let edges = get_edges(graph_order, adj_matrix_bits)?;
 
-    (graph_order, edges)
+    Ok((graph_order, edges))
 }
 
 // Converts a graph6 format string into a vector of bytes, converted from ASCII characters,
 // split into two parts, the first representing the graph order, and the second its adjacency
 // matrix.
-fn get_order_bytes_and_adj_matrix_bytes(graph6_representation: String) -> (Vec<usize>, Vec<usize>) {
-    let bytes: Vec<usize> = graph6_representation
-        .chars()
-        .map(|c| (c as usize) - N)
-        .collect();
+fn get_order_bytes_and_adj_matrix_bytes(
+    graph6_representation: String,
+) -> Result<(Vec<usize>, Vec<usize>), Graph6Error> {
+    let mut bytes = Vec::with_capacity(graph6_representation.len());
+    for c in graph6_representation.chars() {
+        // graph6 only uses the printable characters '?' (63) to '~' (126),
+        // which biases every byte into 0..=63.
+        match (c as usize).checked_sub(N) {
+            Some(byte) if byte <= N => bytes.push(byte),
+            _ => return Err(Graph6Error::InvalidCharacter(c)),
+        }
+    }
+
+    let (&first_byte, rest) = bytes.split_first().ok_or(Graph6Error::Empty)?;
 
     let mut order_bytes = vec![];
     let mut adj_matrix_bytes = vec![];
 
-    let first_byte = *bytes.first().unwrap();
     if first_byte == N {
-        order_bytes.extend_from_slice(&bytes[1..=3]);
-        adj_matrix_bytes.extend_from_slice(&bytes[4..]);
+        if rest.first() == Some(&N) {
+            return Err(Graph6Error::UnsupportedOrder);
+        }
+        if rest.len() < 3 {
+            return Err(Graph6Error::TruncatedOrder);
+        }
+        order_bytes.extend_from_slice(&rest[..3]);
+        adj_matrix_bytes.extend_from_slice(&rest[3..]);
     } else {
         order_bytes.push(first_byte);
-        adj_matrix_bytes.extend_from_slice(&bytes[1..]);
+        adj_matrix_bytes.extend_from_slice(rest);
     };
 
-    (order_bytes, adj_matrix_bytes)
+    Ok((order_bytes, adj_matrix_bytes))
 }
 
 // Converts a bytes vector into a bits vector.
@@ -94,10 +159,20 @@ fn get_bits_as_decimal(bits: Vec<u8>) -> usize {
 }
 
 // Get graph edges from its order and bits vector representation of its adjacency matrix.
-fn get_edges<Ix>(order: usize, adj_matrix_bits: Vec<u8>) -> Vec<(Ix, Ix)>
+fn get_edges<Ix>(order: usize, adj_matrix_bits: Vec<u8>) -> Result<Vec<(Ix, Ix)>, Graph6Error>
 where
     Ix: IndexType,
 {
+    // The upper diagonal of an `order` by `order` matrix, computed in u64 so that a declared
+    // order near the 18-bit maximum cannot overflow a 32-bit usize.
+    let expected = (order as u64) * (order.saturating_sub(1) as u64) / 2;
+    if (adj_matrix_bits.len() as u64) < expected {
+        return Err(Graph6Error::TruncatedAdjacencyMatrix {
+            expected: expected as usize,
+            found: adj_matrix_bits.len(),
+        });
+    }
+
     let mut edges = vec![];
 
     let mut i = 0;
@@ -113,12 +188,12 @@ where
         }
     }
 
-    edges
+    Ok(edges)
 }
 
 impl<Ix: IndexType> FromGraph6 for Graph<(), (), Undirected, Ix> {
-    fn from_graph6_string(graph6_string: String) -> Self {
-        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string);
+    fn from_graph6_string(graph6_string: String) -> Result<Self, Graph6Error> {
+        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string)?;
 
         let mut graph: Graph<(), (), Undirected, Ix> = Graph::with_capacity(order, edges.len());
         for _ in 0..order {
@@ -126,14 +201,14 @@ impl<Ix: IndexType> FromGraph6 for Graph<(), (), Undirected, Ix> {
         }
         graph.extend_with_edges(edges);
 
-        graph
+        Ok(graph)
     }
 }
 
 #[cfg(feature = "stable_graph")]
 impl<Ix: IndexType> FromGraph6 for StableGraph<(), (), Undirected, Ix> {
-    fn from_graph6_string(graph6_string: String) -> Self {
-        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string);
+    fn from_graph6_string(graph6_string: String) -> Result<Self, Graph6Error> {
+        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string)?;
 
         let mut graph: StableGraph<(), (), Undirected, Ix> =
             StableUnGraph::with_capacity(order, edges.len());
@@ -142,14 +217,14 @@ impl<Ix: IndexType> FromGraph6 for StableGraph<(), (), Undirected, Ix> {
         }
         graph.extend_with_edges(edges);
 
-        graph
+        Ok(graph)
     }
 }
 
 #[cfg(feature = "graphmap")]
 impl<Ix: IndexType, S: BuildHasher + Default> FromGraph6 for GraphMap<Ix, (), Undirected, S> {
-    fn from_graph6_string(graph6_string: String) -> Self {
-        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string);
+    fn from_graph6_string(graph6_string: String) -> Result<Self, Graph6Error> {
+        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string)?;
 
         let mut graph: GraphMap<Ix, (), Undirected, S> =
             GraphMap::with_capacity(order, edges.len());
@@ -160,7 +235,7 @@ impl<Ix: IndexType, S: BuildHasher + Default> FromGraph6 for GraphMap<Ix, (), Un
             graph.add_edge(a, b, ());
         }
 
-        graph
+        Ok(graph)
     }
 }
 
@@ -171,8 +246,8 @@ where
     Ix: IndexType,
     S: BuildHasher + Default,
 {
-    fn from_graph6_string(graph6_string: String) -> Self {
-        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string);
+    fn from_graph6_string(graph6_string: String) -> Result<Self, Graph6Error> {
+        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string)?;
 
         let mut graph: MatrixGraph<(), (), S, Undirected, Null, Ix> =
             MatrixGraph::with_capacity(order);
@@ -181,13 +256,13 @@ where
         }
         graph.extend_with_edges(edges.iter());
 
-        graph
+        Ok(graph)
     }
 }
 
 impl<Ix: IndexType> FromGraph6 for Csr<(), (), Undirected, Ix> {
-    fn from_graph6_string(graph6_string: String) -> Self {
-        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string);
+    fn from_graph6_string(graph6_string: String) -> Result<Self, Graph6Error> {
+        let (order, edges): (usize, Vec<(Ix, Ix)>) = from_graph6_representation(graph6_string)?;
 
         let mut graph: Csr<(), (), Undirected, Ix> = Csr::new();
         let mut nodes = Vec::new();
@@ -199,6 +274,6 @@ impl<Ix: IndexType> FromGraph6 for Csr<(), (), Undirected, Ix> {
             graph.add_edge(a, b, ());
         }
 
-        graph
+        Ok(graph)
     }
 }

--- a/crates/petgraph/tests/graph6.rs
+++ b/crates/petgraph/tests/graph6.rs
@@ -3,7 +3,9 @@ use petgraph::stable_graph::StableGraph;
 use petgraph::{
     Graph, Undirected,
     csr::Csr,
-    graph6::{FromGraph6, ToGraph6, from_graph6_representation, get_graph6_representation},
+    graph6::{
+        FromGraph6, Graph6Error, ToGraph6, from_graph6_representation, get_graph6_representation,
+    },
 };
 
 #[cfg(all(feature = "std", feature = "graphmap"))]
@@ -53,7 +55,7 @@ fn test_graph6_generic_decoder(
 ) {
     type G = (usize, Vec<(u16, u16)>);
 
-    let (order, mut edges): G = from_graph6_representation(graph6_str.to_string());
+    let (order, mut edges): G = from_graph6_representation(graph6_str.to_string()).unwrap();
     assert_eq!(order, expected_order, "order should be the same");
 
     edges.sort();
@@ -84,7 +86,7 @@ fn test_graph6_for_graph(graph6_str: &str, order: usize, edges: Vec<(u16, u16)>)
     assert_eq!(graph6_string, graph6_str);
 
     // Assert decoded graph properties
-    let decoded_graph = G::from_graph6_string(graph6_string);
+    let decoded_graph = G::from_graph6_string(graph6_string).unwrap();
     assert_eq!(decoded_graph.node_count(), order);
     assert_eq!(decoded_graph.edge_count(), size);
 
@@ -117,7 +119,7 @@ fn test_graph6_for_stable_graph(graph6_str: &str, order: usize, edges: Vec<(u16,
     assert_eq!(graph6_string, graph6_str);
 
     // Assert decoded graph properties
-    let decoded_graph = G::from_graph6_string(graph6_string);
+    let decoded_graph = G::from_graph6_string(graph6_string).unwrap();
     assert_eq!(decoded_graph.node_count(), order);
     assert_eq!(decoded_graph.edge_count(), size);
 
@@ -152,7 +154,7 @@ fn test_graph6_for_graph_map(graph6_str: &str, order: usize, edges: Vec<(u16, u1
     assert_eq!(graph6_string, graph6_str);
 
     // Assert decoded graph properties
-    let decoded_graph = G::from_graph6_string(graph6_string);
+    let decoded_graph = G::from_graph6_string(graph6_string).unwrap();
     assert_eq!(decoded_graph.node_count(), order);
     assert_eq!(decoded_graph.edge_count(), size);
 
@@ -185,7 +187,7 @@ fn test_graph6_for_matrix_graph(graph6_str: &str, order: usize, edges: Vec<(u16,
     assert_eq!(graph6_string, graph6_str);
 
     // Assert decoded graph properties
-    let decoded_graph = G::from_graph6_string(graph6_string);
+    let decoded_graph = G::from_graph6_string(graph6_string).unwrap();
     assert_eq!(decoded_graph.node_count(), order);
     assert_eq!(decoded_graph.edge_count(), size);
 
@@ -220,12 +222,66 @@ fn test_graph6_for_csr(graph6_str: &str, order: usize, edges: Vec<(u16, u16)>) {
     assert_eq!(graph6_string, graph6_str);
 
     // Assert decoded graph properties
-    let decoded_graph = G::from_graph6_string(graph6_string);
+    let decoded_graph = G::from_graph6_string(graph6_string).unwrap();
     assert_eq!(decoded_graph.node_count(), order);
     assert_eq!(decoded_graph.edge_count(), size);
 
     // Assert re-encoded graph6 string is the same
     assert_eq!(decoded_graph.graph6_string(), graph6_str);
+}
+
+#[test]
+fn malformed_graph6_is_an_error() {
+    type G = (usize, Vec<(u16, u16)>);
+
+    let cases: [(&str, Graph6Error); 8] = [
+        // No order byte at all.
+        ("", Graph6Error::Empty),
+        // Below the printable range: '\n' used to underflow the `- 63` bias.
+        ("\n", Graph6Error::InvalidCharacter('\n')),
+        // Above the printable range: 0x7f used to be masked down to a valid byte.
+        ("\u{7f}?", Graph6Error::InvalidCharacter('\u{7f}')),
+        // Long form with none of the three order bytes.
+        ("~", Graph6Error::TruncatedOrder),
+        // Long form with two of the three order bytes.
+        ("~AA", Graph6Error::TruncatedOrder),
+        // The 8-byte order form, which the encoder never emits.
+        ("~~??????", Graph6Error::UnsupportedOrder),
+        // Order 3 needs 3 adjacency bits and gets none.
+        (
+            "B",
+            Graph6Error::TruncatedAdjacencyMatrix {
+                expected: 3,
+                found: 0,
+            },
+        ),
+        // Order 8322 in long form, with no adjacency bytes.
+        (
+            "~AAA",
+            Graph6Error::TruncatedAdjacencyMatrix {
+                expected: 8322 * 8321 / 2,
+                found: 0,
+            },
+        ),
+    ];
+
+    for (graph6_str, expected) in cases {
+        let decoded: Result<G, _> = from_graph6_representation(graph6_str.to_string());
+        assert_eq!(decoded, Err(expected), "input {graph6_str:?}");
+    }
+}
+
+#[test]
+fn malformed_graph6_is_an_error_for_graph() {
+    type G = Graph<(), (), Undirected, u16>;
+
+    assert_eq!(
+        G::from_graph6_string("B".to_string()).unwrap_err(),
+        Graph6Error::TruncatedAdjacencyMatrix {
+            expected: 3,
+            found: 0
+        }
+    );
 }
 
 // Test cases format: (graph order, expected ghaph6 representation, graph edges)


### PR DESCRIPTION
`from_graph6_representation` and `FromGraph6::from_graph6_string` treat their argument as already valid, so a malformed string kills the process instead of returning an error. There are four unchecked spots: `bytes.first().unwrap()` on an empty string, `(c as usize) - N` underflowing for any character below `'?'`, `bytes[1..=3]` when a `~` long-form header is cut short, and `adj_matrix_bits[i]` when the declared order needs more bits than the string carries. Two more inputs don't panic but decode to the wrong graph: a character above `'~'` gets masked down into a valid byte by `get_number_as_bits`, and the 8-byte `~~` order form (which the encoder never emits) is read as if it were the 4-byte `~` form.

graph6 is a file format, so a caller normally decodes lines it did not write. A truncated line taking the whole process down is a rough edge worth closing.

`get_order_bytes_and_adj_matrix_bytes` now checks each character is in `'?'..='~'` before the bias subtraction, checks the three order bytes are actually there before slicing, and rejects `~~` rather than mis-parsing it. `get_edges` computes the `n * (n - 1) / 2` bits the declared order needs and compares that against what it got before indexing anything; that product goes through `u64` so an order near the 18-bit maximum can't wrap a 32-bit `usize`.

I made the existing entry points fallible instead of adding a parallel checked parser next to them. A second `try_` API means the panicking one stays forever, and the caller who doesn't know it panics is exactly the caller who gets bitten by it. `Graph6Error` is shaped like `CsrError` and `GraphError`: a plain enum with `core::error::Error` and `Display`, so it still builds without `std`.

`cargo test --all-features`, `cargo fmt --all -- --check` on nightly, `cargo clippy --all-features --lib --bins --examples --tests -- -D warnings` and `cargo check --no-default-features -p petgraph --target wasm32v1-none --features graphmap,serde-1,stable_graph,matrix_graph,generate,unstable` all pass. The new test in `tests/graph6.rs` covers all six inputs above and every one of them panicked or decoded wrong on master.

BREAKING CHANGE: `from_graph6_representation` now returns `Result<(usize, Vec<(Ix, Ix)>), Graph6Error>` and `FromGraph6::from_graph6_string` returns `Result<Self, Graph6Error>`. Callers that know their input is well formed can add `.expect("valid graph6")`.

Closes #969
