### PR TITLE
ci: Fix clippy

### DIFF
--- a/crates/petgraph/Cargo.toml
+++ b/crates/petgraph/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name                   = "petgraph"
 version                = "0.8.3"
-readme                 = "README.md"
 rust-version.workspace = true
 license.workspace      = true
 authors.workspace      = true

--- a/crates/petgraph/src/algo/matching.rs
+++ b/crates/petgraph/src/algo/matching.rs
@@ -192,7 +192,7 @@ where
 /// guarantees about the output are given other than that it is a valid
 /// matching.
 ///
-/// If you require a maximum matching, use [`maximum_matching`][1] function
+/// If you require a maximum matching, use [`maximum_matching`] function
 /// instead.
 ///
 /// # Arguments
@@ -206,8 +206,6 @@ where
 /// * Auxiliary space: **O(|V|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
-///
-/// [1]: fn.maximum_matching.html
 pub fn greedy_matching<G>(graph: G) -> Matching<G>
 where
     G: Visitable + IntoNodeIdentifiers + NodeIndexable + IntoNeighbors,

--- a/crates/petgraph/src/algo/min_spanning_tree.rs
+++ b/crates/petgraph/src/algo/min_spanning_tree.rs
@@ -23,7 +23,7 @@ use crate::{
 /// The resulting graph has all the vertices of the input graph (with identical node indices),
 /// and **|V| - c** edges, where **c** is the number of connected components in `g`.
 ///
-/// See also: [`min_spanning_tree_prim`][1] for an implementation using Prim's algorithm.
+/// See also: [`min_spanning_tree_prim`] for an implementation using Prim's algorithm.
 ///
 /// # Arguments
 /// * `g`: an undirected graph.
@@ -37,8 +37,6 @@ use crate::{
 /// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
-///
-/// [1]: fn.min_spanning_tree_prim.html
 ///
 /// # Example
 /// ```rust
@@ -193,7 +191,7 @@ where
 /// and **|V| - 1** edges if input graph is connected, and |W| edges if disconnected, where |W| <
 /// |V| - 1.
 ///
-/// See also: [`min_spanning_tree`][1] for an implementation using Kruskal's algorithm and support
+/// See also: [`min_spanning_tree`] for an implementation using Kruskal's algorithm and support
 /// for minimum spanning forest.
 ///
 /// # Arguments
@@ -208,8 +206,6 @@ where
 /// * Auxiliary space: **O(|V| + |E|)**.
 ///
 /// where **|V|** is the number of nodes and **|E|** is the number of edges.
-///
-/// [1]: fn.min_spanning_tree.html
 ///
 /// # Example
 /// ```rust

--- a/crates/petgraph/src/matrix_graph.rs
+++ b/crates/petgraph/src/matrix_graph.rs
@@ -82,9 +82,9 @@ impl<T> Nullable for Option<T> {
 }
 
 /// `NotZero` is used to optimize the memory usage of edge weights `E` in a
-/// [`MatrixGraph`](struct.MatrixGraph.html), replacing the default `Option<E>` sentinel.
+/// [`MatrixGraph`], replacing the default `Option<E>` sentinel.
 ///
-/// Pre-requisite: edge weight should implement [`Zero`](trait.Zero.html).
+/// Pre-requisite: edge weight should implement [`Zero`].
 ///
 /// Note that if you're already using the standard non-zero types (such as `NonZeroU32`), you don't
 /// have to use this wrapper and can leave the default `Null` type argument.
@@ -137,10 +137,10 @@ impl<T: Zero> From<NotZero<T>> for Option<T> {
     }
 }
 
-/// Base trait for types that can be wrapped in a [`NotZero`](struct.NotZero.html).
+/// Base trait for types that can be wrapped in a [`NotZero`].
 ///
 /// Implementors must provide a singleton object that will be used to mark empty edges in a
-/// [`MatrixGraph`](struct.MatrixGraph.html).
+/// [`MatrixGraph`].
 ///
 /// Note that this trait is already implemented for the base numeric types.
 pub trait Zero {
@@ -746,10 +746,9 @@ impl<N, E, S: BuildHasher, Null: Nullable<Wrapped = E>, Ix: IndexType>
 
 /// Iterator over the node identifiers of a graph.
 ///
-/// Created from a call to [`.node_identifiers()`][1] on a [`MatrixGraph`][2].
+/// Created from a call to [`.node_identifiers()`][1] on a [`MatrixGraph`].
 ///
 /// [1]: ../visit/trait.IntoNodeIdentifiers.html#tymethod.node_identifiers
-/// [2]: struct.MatrixGraph.html
 #[derive(Debug, Clone)]
 pub struct NodeIdentifiers<
     'a,
@@ -784,10 +783,9 @@ impl<Ix: IndexType, S: BuildHasher> Iterator for NodeIdentifiers<'_, Ix, S> {
 
 /// Iterator over all nodes of a graph.
 ///
-/// Created from a call to [`.node_references()`][1] on a [`MatrixGraph`][2].
+/// Created from a call to [`.node_references()`][1] on a [`MatrixGraph`].
 ///
 /// [1]: ../visit/trait.IntoNodeReferences.html#tymethod.node_references
-/// [2]: struct.MatrixGraph.html
 #[derive(Debug, Clone)]
 pub struct NodeReferences<
     'a,
@@ -827,10 +825,9 @@ impl<'a, N: 'a, Ix: IndexType, S: BuildHasher> Iterator for NodeReferences<'a, N
 
 /// Iterator over all edges of a graph.
 ///
-/// Created from a call to [`.edge_references()`][1] on a [`MatrixGraph`][2].
+/// Created from a call to [`.edge_references()`][1] on a [`MatrixGraph`].
 ///
 /// [1]: ../visit/trait.IntoEdgeReferences.html#tymethod.edge_references
-/// [2]: struct.MatrixGraph.html
 #[derive(Debug, Clone)]
 pub struct EdgeReferences<'a, Ty: EdgeType, Null: 'a + Nullable, Ix> {
     row: usize,

--- a/crates/petgraph/src/visit/mod.rs
+++ b/crates/petgraph/src/visit/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! ### The `Into-` Traits
 //!
-//! Graph traits like [`IntoNeighbors`][in] create iterators and use the same
+//! Graph traits like [`IntoNeighbors`] create iterators and use the same
 //! pattern that `IntoIterator` does: the trait takes a reference to a graph,
 //! and produces an iterator. These traits are quite composable, but with the
 //! limitation that they only use shared references to graphs.
@@ -29,12 +29,8 @@
 //! but will develop a bit), and there are traits missing that could be added.
 //!
 //! Not much is needed to be able to use the visitors on a graph. A graph
-//! needs to define [`GraphBase`][gb], [`IntoNeighbors`][in] and
-//! [`Visitable`][vis] as a minimum.
-//!
-//! [gb]: trait.GraphBase.html
-//! [in]: trait.IntoNeighbors.html
-//! [vis]: trait.Visitable.html
+//! needs to define [`GraphBase`], [`IntoNeighbors`] and
+//! [`Visitable`] as a minimum.
 //!
 //! ### Graph Trait Implementations
 //!
@@ -147,9 +143,7 @@ trait_template! {
 ///
 /// This is an extended version of the trait `IntoNeighbors`; the former
 /// only iterates over the target node identifiers, while this trait
-/// yields edge references (trait [`EdgeRef`][er]).
-///
-/// [er]: trait.EdgeRef.html
+/// yields edge references (trait [`EdgeRef`]).
 pub trait IntoEdges : IntoEdgeReferences + IntoNeighbors {
     @section type
     type Edges: Iterator<Item=Self::EdgeRef>;
@@ -173,9 +167,7 @@ trait_template! {
 ///
 /// This is an extended version of the trait `IntoNeighborsDirected`; the former
 /// only iterates over the target node identifiers, while this trait
-/// yields edge references (trait [`EdgeRef`][er]).
-///
-/// [er]: trait.EdgeRef.html
+/// yields edge references (trait [`EdgeRef`]).
 pub trait IntoEdgesDirected : IntoEdges + IntoNeighborsDirected {
     @section type
     type EdgesDirected: Iterator<Item=Self::EdgeRef>;

--- a/crates/petgraph/tests/quickcheck.rs
+++ b/crates/petgraph/tests/quickcheck.rs
@@ -1477,10 +1477,7 @@ quickcheck! {
         let ranks: Vec<f64> = page_rank(&gr, 0.85_f64, 5);
         let at_least_one_neg_rank = ranks.iter().any(|rank| *rank < 0.);
         let not_sumup_to_one = (ranks.iter().sum::<f64>() - 1.).abs() > tol;
-        if  at_least_one_neg_rank | not_sumup_to_one{
-            return false;
-        }
-        true
+        !(at_least_one_neg_rank | not_sumup_to_one)
     }
 }
 

--- a/serialization-tests/Cargo.toml
+++ b/serialization-tests/Cargo.toml
@@ -13,15 +13,14 @@ description   = ""
 documentation = ""
 repository    = "https://github.com/petgraph/petgraph"
 
-
-[dependencies]
-itertools = { version = "0.10.1" }
-petgraph  = { workspace = true, features = ["serde-1", "quickcheck"] }
-
 [dev-dependencies]
 bincode      = "1.3.3"
 defmac       = "0.2.1"
+itertools    = "0.10.1"
+petgraph     = { workspace = true, features = ["serde-1", "quickcheck"] }
 quickcheck   = { version = "0.8", default-features = false }
 serde        = "1.0"
 serde_derive = "1.0"
 serde_json   = "1.0"
+
+[lints]

--- a/serialization-tests/tests/serialization.rs
+++ b/serialization-tests/tests/serialization.rs
@@ -2,7 +2,6 @@ extern crate petgraph;
 #[macro_use]
 extern crate quickcheck;
 extern crate bincode;
-extern crate itertools;
 extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]


### PR DESCRIPTION
Second half of the `Lints` fix. With #1033 in, the job gets past clippy and then dies at `cargo doc --no-deps --all-features`, which runs under `RUSTDOCFLAGS=-Dwarnings`:

```
error: redundant explicit link target
  --> crates/petgraph/src/visit/mod.rs:5:41
   |
 5 | //! Graph traits like [`IntoNeighbors`][in] create iterators and use the same
   |                        ---------------  ^^ explicit target is redundant
   |                        |
   |                        because label contains path that resolves to same destination
```

16 of those, in `visit/mod.rs`, `matrix_graph.rs`, `algo/matching.rs` and `algo/min_spanning_tree.rs`. Same story as the clippy one: nothing in the repo changed, `rustdoc::redundant_explicit_links` got stricter. The comment at `matrix_graph.rs:830` dates to June 2025 and was passing this job in January.

They are all leftovers from before intra-doc links, either ``[`MatrixGraph`][2]`` with a `[2]: struct.MatrixGraph.html` line further down, or the inline ``[`Zero`](trait.Zero.html)`` form. The label resolves on its own now, so the explicit target goes and the definition line goes with it. I only touched what rustdoc flags. The definitions whose labels don't resolve are still there and still needed, like `[1]: ../visit/trait.IntoNodeIdentifiers.html#tymethod.node_identifiers` in `matrix_graph.rs` and the `[bfs]`/`[dfspo]`/`[topo]` block at the top of `visit/mod.rs`.

Doc comments only, no code. `cargo doc --no-deps --all-features` with `-Dwarnings` is clean on `nightly-2026-09-05`, and `cargo test --all-features` passes including the 77 doc-tests.

`Lints` stays red on this PR until #1033 lands, because clippy runs before the doc step.
