### PR TITLE
test: Add `UndirectedGraph` test macro

### DIFF
--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod test_graphs;
+#[cfg(test)]
 pub mod testing;

--- a/crates/core/src/utils/test_graphs/undirected.rs
+++ b/crates/core/src/utils/test_graphs/undirected.rs
@@ -182,3 +182,40 @@ where
             })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_undirected_graph;
+
+    fn remove_node_with_unwrap(
+        graph: &mut UndirectedTestGraph<(), (), UndirNodeId, UndirEdgeId>,
+        node_id: UndirNodeId,
+    ) {
+        graph.remove_node(node_id).unwrap();
+    }
+
+    fn add_edge_with_unwrap(
+        graph: &mut UndirectedTestGraph<(), (), UndirNodeId, UndirEdgeId>,
+        source: UndirNodeId,
+        target: UndirNodeId,
+        _data: (),
+    ) -> UndirEdgeId {
+        graph.add_edge(source, target, ()).unwrap()
+    }
+
+    fn remove_edge_with_unwrap(
+        graph: &mut UndirectedTestGraph<(), (), UndirNodeId, UndirEdgeId>,
+        edge_id: UndirEdgeId,
+    ) {
+        graph.remove_edge(edge_id).unwrap();
+    }
+
+    test_undirected_graph!(
+        UndirectedTestGraph::<(), (), UndirNodeId, UndirEdgeId>::new,
+        UndirectedTestGraph::<(), (), UndirNodeId, UndirEdgeId>::add_node,
+        remove_node_with_unwrap,
+        add_edge_with_unwrap,
+        remove_edge_with_unwrap
+    );
+}

--- a/crates/core/src/utils/testing/directed.rs
+++ b/crates/core/src/utils/testing/directed.rs
@@ -82,6 +82,15 @@ macro_rules! test_directed_graph {
         $remove_edge:expr
     ) => {
         #[test]
+        fn test_density_hint() {
+            let (graph, _, _) =
+                $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            // DensityHint is a hint, so this is intentionally only a smoke test.
+            let _density_hint = $crate::graph::DirectedGraph::density_hint(&graph);
+        }
+
+        #[test]
         fn test_cardinality() {
             let (mut graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);

--- a/crates/core/src/utils/testing/directed.rs
+++ b/crates/core/src/utils/testing/directed.rs
@@ -86,17 +86,17 @@ macro_rules! test_directed_graph {
             let (mut graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
-                DirectedGraph::node_count(&graph),
+                $crate::graph::DirectedGraph::node_count(&graph),
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT,
                 "DirectedGraph::node_count() did not match expected value"
             );
             assert_eq!(
-                DirectedGraph::edge_count(&graph),
+                $crate::graph::DirectedGraph::edge_count(&graph),
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT,
                 "DirectedGraph::edge_count() did not match expected value"
             );
 
-            let cardinality = DirectedGraph::cardinality(&graph);
+            let cardinality = $crate::graph::DirectedGraph::cardinality(&graph);
             assert_eq!(
                 cardinality.order,
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT,
@@ -110,12 +110,12 @@ macro_rules! test_directed_graph {
 
             $remove_node(&mut graph, nodes[0]);
             assert_eq!(
-                DirectedGraph::node_count(&graph),
+                $crate::graph::DirectedGraph::node_count(&graph),
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT - 1,
                 "DirectedGraph::node_count() did not match expected value after removing node 0"
             );
             assert_eq!(
-                DirectedGraph::edge_count(&graph),
+                $crate::graph::DirectedGraph::edge_count(&graph),
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT - 2,
                 "DirectedGraph::edge_count() did not match expected value after removing node 0"
             );
@@ -125,13 +125,13 @@ macro_rules! test_directed_graph {
         fn test_nodes() {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let nodes_count = DirectedGraph::nodes(&graph).count();
+            let nodes_count = $crate::graph::DirectedGraph::nodes(&graph).count();
             assert_eq!(
                 nodes_count,
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT,
                 "DirectedGraph::nodes().count() did not match expected value"
             );
-            for node in DirectedGraph::nodes(&graph) {
+            for node in $crate::graph::DirectedGraph::nodes(&graph) {
                 assert!(
                     nodes.contains(&node.id),
                     "DirectedGraph::nodes() contained unexpected node id: {:?}",
@@ -144,13 +144,13 @@ macro_rules! test_directed_graph {
         fn test_nodes_mut() {
             let (mut graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let nodes_count = DirectedGraph::nodes_mut(&mut graph).count();
+            let nodes_count = $crate::graph::DirectedGraph::nodes_mut(&mut graph).count();
             assert_eq!(
                 nodes_count,
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT,
                 "DirectedGraph::nodes_mut().count() did not match expected value"
             );
-            for node in DirectedGraph::nodes_mut(&mut graph) {
+            for node in $crate::graph::DirectedGraph::nodes_mut(&mut graph) {
                 assert!(
                     nodes.contains(&node.id),
                     "DirectedGraph::nodes_mut() contained unexpected node id: {:?}",
@@ -163,12 +163,12 @@ macro_rules! test_directed_graph {
         fn test_isolated_nodes() {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let isolated_nodes_count = DirectedGraph::isolated_nodes(&graph).count();
+            let isolated_nodes_count = $crate::graph::DirectedGraph::isolated_nodes(&graph).count();
             assert_eq!(
                 isolated_nodes_count, 1,
                 "DirectedGraph::isolated_nodes().count() did not match expected value"
             );
-            let mut isolated_nodes_iter = DirectedGraph::isolated_nodes(&graph);
+            let mut isolated_nodes_iter = $crate::graph::DirectedGraph::isolated_nodes(&graph);
             let first_isolated_node = isolated_nodes_iter
                 .next()
                 .expect("Expected isolated node not found in test_isolated_nodes");
@@ -186,13 +186,13 @@ macro_rules! test_directed_graph {
         fn test_edges() {
             let (graph, _, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let edges_count = DirectedGraph::edges(&graph).count();
+            let edges_count = $crate::graph::DirectedGraph::edges(&graph).count();
             assert_eq!(
                 edges_count,
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT,
                 "DirectedGraph::edges().count() did not match expected value"
             );
-            for edge in DirectedGraph::edges(&graph) {
+            for edge in $crate::graph::DirectedGraph::edges(&graph) {
                 assert!(
                     edges.contains(&edge.id),
                     "DirectedGraph::edges() contained unexpected edge id: {:?}",
@@ -205,13 +205,13 @@ macro_rules! test_directed_graph {
         fn test_edges_mut() {
             let (mut graph, _, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let edges_count = DirectedGraph::edges_mut(&mut graph).count();
+            let edges_count = $crate::graph::DirectedGraph::edges_mut(&mut graph).count();
             assert_eq!(
                 edges_count,
                 $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT,
                 "DirectedGraph::edges_mut().count() did not match expected value"
             );
-            for edge in DirectedGraph::edges_mut(&mut graph) {
+            for edge in $crate::graph::DirectedGraph::edges_mut(&mut graph) {
                 assert!(
                     edges.contains(&edge.id),
                     "DirectedGraph::edges_mut() contained unexpected edge id: {:?}",
@@ -225,7 +225,7 @@ macro_rules! test_directed_graph {
             let (mut graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             for &node_id in &nodes {
-                let node = DirectedGraph::node(&graph, node_id)
+                let node = $crate::graph::DirectedGraph::node(&graph, node_id)
                     .expect("Expected node not found in test_node");
                 assert_eq!(
                     node.id, node_id,
@@ -238,7 +238,7 @@ macro_rules! test_directed_graph {
             // id.
             $remove_node(&mut graph, nodes[4]);
             assert!(
-                DirectedGraph::node(&graph, nodes[4]).is_none(),
+                $crate::graph::DirectedGraph::node(&graph, nodes[4]).is_none(),
                 "DirectedGraph::node() did not return None for removed node id"
             );
         }
@@ -248,7 +248,7 @@ macro_rules! test_directed_graph {
             let (mut graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             for &node_id in &nodes {
-                let node = DirectedGraph::node_mut(&mut graph, node_id)
+                let node = $crate::graph::DirectedGraph::node_mut(&mut graph, node_id)
                     .expect("Expected node not found in test_node_mut");
                 assert_eq!(
                     node.id, node_id,
@@ -261,7 +261,7 @@ macro_rules! test_directed_graph {
             // id.
             $remove_node(&mut graph, nodes[4]);
             assert!(
-                DirectedGraph::node_mut(&mut graph, nodes[4]).is_none(),
+                $crate::graph::DirectedGraph::node_mut(&mut graph, nodes[4]).is_none(),
                 "DirectedGraph::node_mut() did not return None for removed node id"
             );
         }
@@ -271,7 +271,7 @@ macro_rules! test_directed_graph {
             let (mut graph, _, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             for &edge_id in &edges {
-                let edge = DirectedGraph::edge(&graph, edge_id)
+                let edge = $crate::graph::DirectedGraph::edge(&graph, edge_id)
                     .expect("Expected edge not found in test_edge");
                 assert_eq!(
                     edge.id, edge_id,
@@ -281,7 +281,7 @@ macro_rules! test_directed_graph {
 
             $remove_edge(&mut graph, edges[3]);
             assert!(
-                DirectedGraph::edge(&graph, edges[3]).is_none(),
+                $crate::graph::DirectedGraph::edge(&graph, edges[3]).is_none(),
                 "DirectedGraph::edge() did not return None for removed edge id"
             );
         }
@@ -291,7 +291,7 @@ macro_rules! test_directed_graph {
             let (mut graph, _, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             for &edge_id in &edges {
-                let edge = DirectedGraph::edge_mut(&mut graph, edge_id)
+                let edge = $crate::graph::DirectedGraph::edge_mut(&mut graph, edge_id)
                     .expect("Expected edge not found in test_edge_mut");
                 assert_eq!(
                     edge.id, edge_id,
@@ -301,7 +301,7 @@ macro_rules! test_directed_graph {
 
             $remove_edge(&mut graph, edges[3]);
             assert!(
-                DirectedGraph::edge_mut(&mut graph, edges[3]).is_none(),
+                $crate::graph::DirectedGraph::edge_mut(&mut graph, edges[3]).is_none(),
                 "DirectedGraph::edge_mut() did not return None for removed edge id"
             );
         }
@@ -311,27 +311,27 @@ macro_rules! test_directed_graph {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
-                DirectedGraph::in_degree(&graph, nodes[0]),
+                $crate::graph::DirectedGraph::in_degree(&graph, nodes[0]),
                 0,
                 "DirectedGraph::in_degree() did not return expected value for node 0"
             );
             assert_eq!(
-                DirectedGraph::in_degree(&graph, nodes[1]),
+                $crate::graph::DirectedGraph::in_degree(&graph, nodes[1]),
                 1,
                 "DirectedGraph::in_degree() did not return expected value for node 1"
             );
             assert_eq!(
-                DirectedGraph::in_degree(&graph, nodes[2]),
+                $crate::graph::DirectedGraph::in_degree(&graph, nodes[2]),
                 2,
                 "DirectedGraph::in_degree() did not return expected value for node 2"
             );
             assert_eq!(
-                DirectedGraph::in_degree(&graph, nodes[3]),
+                $crate::graph::DirectedGraph::in_degree(&graph, nodes[3]),
                 1,
                 "DirectedGraph::in_degree() did not return expected value for node 3"
             );
             assert_eq!(
-                DirectedGraph::in_degree(&graph, nodes[4]),
+                $crate::graph::DirectedGraph::in_degree(&graph, nodes[4]),
                 0,
                 "DirectedGraph::in_degree() did not return expected value for node 4"
             );
@@ -342,27 +342,27 @@ macro_rules! test_directed_graph {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
-                DirectedGraph::out_degree(&graph, nodes[0]),
+                $crate::graph::DirectedGraph::out_degree(&graph, nodes[0]),
                 2,
                 "DirectedGraph::out_degree() did not return expected value for node 0"
             );
             assert_eq!(
-                DirectedGraph::out_degree(&graph, nodes[1]),
+                $crate::graph::DirectedGraph::out_degree(&graph, nodes[1]),
                 1,
                 "DirectedGraph::out_degree() did not return expected value for node 1"
             );
             assert_eq!(
-                DirectedGraph::out_degree(&graph, nodes[2]),
+                $crate::graph::DirectedGraph::out_degree(&graph, nodes[2]),
                 0,
                 "DirectedGraph::out_degree() did not return expected value for node 2"
             );
             assert_eq!(
-                DirectedGraph::out_degree(&graph, nodes[3]),
+                $crate::graph::DirectedGraph::out_degree(&graph, nodes[3]),
                 1,
                 "DirectedGraph::out_degree() did not return expected value for node 3"
             );
             assert_eq!(
-                DirectedGraph::out_degree(&graph, nodes[4]),
+                $crate::graph::DirectedGraph::out_degree(&graph, nodes[4]),
                 0,
                 "DirectedGraph::out_degree() did not return expected value for node 4"
             );
@@ -373,27 +373,27 @@ macro_rules! test_directed_graph {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
-                DirectedGraph::degree(&graph, nodes[0]),
+                $crate::graph::DirectedGraph::degree(&graph, nodes[0]),
                 2,
                 "DirectedGraph::degree() did not return expected value for node 0"
             );
             assert_eq!(
-                DirectedGraph::degree(&graph, nodes[1]),
+                $crate::graph::DirectedGraph::degree(&graph, nodes[1]),
                 2,
                 "DirectedGraph::degree() did not return expected value for node 1"
             );
             assert_eq!(
-                DirectedGraph::degree(&graph, nodes[2]),
+                $crate::graph::DirectedGraph::degree(&graph, nodes[2]),
                 2,
                 "DirectedGraph::degree() did not return expected value for node 2"
             );
             assert_eq!(
-                DirectedGraph::degree(&graph, nodes[3]),
+                $crate::graph::DirectedGraph::degree(&graph, nodes[3]),
                 2,
                 "DirectedGraph::degree() did not return expected value for node 3"
             );
             assert_eq!(
-                DirectedGraph::degree(&graph, nodes[4]),
+                $crate::graph::DirectedGraph::degree(&graph, nodes[4]),
                 0,
                 "DirectedGraph::degree() did not return expected value for node 4"
             );
@@ -431,7 +431,7 @@ macro_rules! test_directed_graph {
             let (graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert!(
-                DirectedGraph::incoming_edges(&graph, nodes[0])
+                $crate::graph::DirectedGraph::incoming_edges(&graph, nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::incoming_edges() did not return an empty iterator for node 0"
@@ -443,7 +443,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_one,
-                DirectedGraph::incoming_edges(&graph, nodes[1]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incoming_edges(&graph, nodes[1]).map(|edge| edge.id),
                 "incoming_edges",
                 1,
             );
@@ -454,7 +454,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_two,
-                DirectedGraph::incoming_edges(&graph, nodes[2]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incoming_edges(&graph, nodes[2]).map(|edge| edge.id),
                 "incoming_edges",
                 2,
             );
@@ -465,13 +465,13 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_three,
-                DirectedGraph::incoming_edges(&graph, nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incoming_edges(&graph, nodes[3]).map(|edge| edge.id),
                 "incoming_edges",
                 3,
             );
 
             assert!(
-                DirectedGraph::incoming_edges(&graph, nodes[4])
+                $crate::graph::DirectedGraph::incoming_edges(&graph, nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::incoming_edges() did not return an empty iterator for node 4"
@@ -483,7 +483,7 @@ macro_rules! test_directed_graph {
             let (mut graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert!(
-                DirectedGraph::incoming_edges_mut(&mut graph, nodes[0])
+                $crate::graph::DirectedGraph::incoming_edges_mut(&mut graph, nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::incoming_edges_mut() did not return an empty iterator for node 0"
@@ -495,7 +495,8 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_one,
-                DirectedGraph::incoming_edges_mut(&mut graph, nodes[1]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incoming_edges_mut(&mut graph, nodes[1])
+                    .map(|edge| edge.id),
                 "incoming_edges_mut",
                 1,
             );
@@ -506,7 +507,8 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_two,
-                DirectedGraph::incoming_edges_mut(&mut graph, nodes[2]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incoming_edges_mut(&mut graph, nodes[2])
+                    .map(|edge| edge.id),
                 "incoming_edges_mut",
                 2,
             );
@@ -517,13 +519,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_three,
-                DirectedGraph::incoming_edges_mut(&mut graph, nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incoming_edges_mut(&mut graph, nodes[3])
+                    .map(|edge| edge.id),
                 "incoming_edges_mut",
                 3,
             );
 
             assert!(
-                DirectedGraph::incoming_edges_mut(&mut graph, nodes[4])
+                $crate::graph::DirectedGraph::incoming_edges_mut(&mut graph, nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::incoming_edges_mut() did not return an empty iterator for node 4"
@@ -540,7 +543,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_zero,
-                DirectedGraph::outgoing_edges(&graph, nodes[0]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::outgoing_edges(&graph, nodes[0]).map(|edge| edge.id),
                 "outgoing_edges",
                 0,
             );
@@ -551,13 +554,13 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_one,
-                DirectedGraph::outgoing_edges(&graph, nodes[1]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::outgoing_edges(&graph, nodes[1]).map(|edge| edge.id),
                 "outgoing_edges",
                 1,
             );
 
             assert!(
-                DirectedGraph::outgoing_edges(&graph, nodes[2])
+                $crate::graph::DirectedGraph::outgoing_edges(&graph, nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::outgoing_edges() did not return an empty iterator for node 2"
@@ -569,13 +572,13 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_three,
-                DirectedGraph::outgoing_edges(&graph, nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::outgoing_edges(&graph, nodes[3]).map(|edge| edge.id),
                 "outgoing_edges",
                 3,
             );
 
             assert!(
-                DirectedGraph::outgoing_edges(&graph, nodes[4])
+                $crate::graph::DirectedGraph::outgoing_edges(&graph, nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::outgoing_edges() did not return an empty iterator for node 4"
@@ -592,7 +595,8 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_zero,
-                DirectedGraph::outgoing_edges_mut(&mut graph, nodes[0]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::outgoing_edges_mut(&mut graph, nodes[0])
+                    .map(|edge| edge.id),
                 "outgoing_edges_mut",
                 0,
             );
@@ -603,13 +607,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_one,
-                DirectedGraph::outgoing_edges_mut(&mut graph, nodes[1]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::outgoing_edges_mut(&mut graph, nodes[1])
+                    .map(|edge| edge.id),
                 "outgoing_edges_mut",
                 1,
             );
 
             assert!(
-                DirectedGraph::outgoing_edges_mut(&mut graph, nodes[2])
+                $crate::graph::DirectedGraph::outgoing_edges_mut(&mut graph, nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::outgoing_edges_mut() did not return an empty iterator for node 2"
@@ -621,13 +626,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_three,
-                DirectedGraph::outgoing_edges_mut(&mut graph, nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::outgoing_edges_mut(&mut graph, nodes[3])
+                    .map(|edge| edge.id),
                 "outgoing_edges_mut",
                 3,
             );
 
             assert!(
-                DirectedGraph::outgoing_edges_mut(&mut graph, nodes[4])
+                $crate::graph::DirectedGraph::outgoing_edges_mut(&mut graph, nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::outgoing_edges_mut() did not return an empty iterator for node 4"
@@ -644,7 +650,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_zero,
-                DirectedGraph::incident_edges(&graph, nodes[0]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incident_edges(&graph, nodes[0]).map(|edge| edge.id),
                 "incident_edges",
                 0,
             );
@@ -655,7 +661,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_one,
-                DirectedGraph::incident_edges(&graph, nodes[1]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incident_edges(&graph, nodes[1]).map(|edge| edge.id),
                 "incident_edges",
                 1,
             );
@@ -666,7 +672,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_two,
-                DirectedGraph::incident_edges(&graph, nodes[2]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incident_edges(&graph, nodes[2]).map(|edge| edge.id),
                 "incident_edges",
                 2,
             );
@@ -677,13 +683,13 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_three,
-                DirectedGraph::incident_edges(&graph, nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incident_edges(&graph, nodes[3]).map(|edge| edge.id),
                 "incident_edges",
                 3,
             );
 
             assert!(
-                DirectedGraph::incident_edges(&graph, nodes[4])
+                $crate::graph::DirectedGraph::incident_edges(&graph, nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::incident_edges() did not return an empty iterator for node 4"
@@ -700,7 +706,8 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_zero,
-                DirectedGraph::incident_edges_mut(&mut graph, nodes[0]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[0])
+                    .map(|edge| edge.id),
                 "incident_edges_mut",
                 0,
             );
@@ -711,7 +718,8 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_one,
-                DirectedGraph::incident_edges_mut(&mut graph, nodes[1]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[1])
+                    .map(|edge| edge.id),
                 "incident_edges_mut",
                 1,
             );
@@ -722,7 +730,8 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_two,
-                DirectedGraph::incident_edges_mut(&mut graph, nodes[2]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[2])
+                    .map(|edge| edge.id),
                 "incident_edges_mut",
                 2,
             );
@@ -733,13 +742,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_three,
-                DirectedGraph::incident_edges_mut(&mut graph, nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[3])
+                    .map(|edge| edge.id),
                 "incident_edges_mut",
                 3,
             );
 
             assert!(
-                DirectedGraph::incident_edges_mut(&mut graph, nodes[4])
+                $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::incident_edges_mut() did not return an empty iterator for node 4"
@@ -797,7 +807,7 @@ macro_rules! test_directed_graph {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert!(
-                DirectedGraph::predecessors(&graph, nodes[0])
+                $crate::graph::DirectedGraph::predecessors(&graph, nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::predecessors() did not return an empty iterator for node 0"
@@ -809,7 +819,7 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[0]]);
             check_if_nodes_match(
                 expected_predecessors_one,
-                DirectedGraph::predecessors(&graph, nodes[1]),
+                $crate::graph::DirectedGraph::predecessors(&graph, nodes[1]),
                 "predecessors",
                 Some(1),
             );
@@ -820,7 +830,7 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[0], nodes[3]]);
             check_if_nodes_match(
                 expected_predecessors_two,
-                DirectedGraph::predecessors(&graph, nodes[2]),
+                $crate::graph::DirectedGraph::predecessors(&graph, nodes[2]),
                 "predecessors",
                 Some(2),
             );
@@ -831,13 +841,13 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[1]]);
             check_if_nodes_match(
                 expected_predecessors_three,
-                DirectedGraph::predecessors(&graph, nodes[3]),
+                $crate::graph::DirectedGraph::predecessors(&graph, nodes[3]),
                 "predecessors",
                 Some(3),
             );
 
             assert!(
-                DirectedGraph::predecessors(&graph, nodes[4])
+                $crate::graph::DirectedGraph::predecessors(&graph, nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::predecessors() did not return an empty iterator for node 4"
@@ -854,7 +864,7 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[1], nodes[2]]);
             check_if_nodes_match(
                 expected_successors_zero,
-                DirectedGraph::successors(&graph, nodes[0]),
+                $crate::graph::DirectedGraph::successors(&graph, nodes[0]),
                 "successors",
                 Some(0),
             );
@@ -865,13 +875,15 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[3]]);
             check_if_nodes_match(
                 expected_successors_one,
-                DirectedGraph::successors(&graph, nodes[1]),
+                $crate::graph::DirectedGraph::successors(&graph, nodes[1]),
                 "successors",
                 Some(1),
             );
 
             assert!(
-                DirectedGraph::successors(&graph, nodes[2]).next().is_none(),
+                $crate::graph::DirectedGraph::successors(&graph, nodes[2])
+                    .next()
+                    .is_none(),
                 "DirectedGraph::successors() did not return an empty iterator for node 2"
             );
 
@@ -881,13 +893,15 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[2]]);
             check_if_nodes_match(
                 expected_successors_three,
-                DirectedGraph::successors(&graph, nodes[3]),
+                $crate::graph::DirectedGraph::successors(&graph, nodes[3]),
                 "successors",
                 Some(3),
             );
 
             assert!(
-                DirectedGraph::successors(&graph, nodes[4]).next().is_none(),
+                $crate::graph::DirectedGraph::successors(&graph, nodes[4])
+                    .next()
+                    .is_none(),
                 "DirectedGraph::successors() did not return an empty iterator for node 4"
             );
         }
@@ -902,7 +916,7 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[1], nodes[2]]);
             check_if_nodes_match(
                 expected_adjacencies_zero,
-                DirectedGraph::adjacencies(&graph, nodes[0]),
+                $crate::graph::DirectedGraph::adjacencies(&graph, nodes[0]),
                 "adjacencies",
                 Some(0),
             );
@@ -913,7 +927,7 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[0], nodes[3]]);
             check_if_nodes_match(
                 expected_adjacencies_one,
-                DirectedGraph::adjacencies(&graph, nodes[1]),
+                $crate::graph::DirectedGraph::adjacencies(&graph, nodes[1]),
                 "adjacencies",
                 Some(1),
             );
@@ -924,7 +938,7 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[0], nodes[3]]);
             check_if_nodes_match(
                 expected_adjacencies_two,
-                DirectedGraph::adjacencies(&graph, nodes[2]),
+                $crate::graph::DirectedGraph::adjacencies(&graph, nodes[2]),
                 "adjacencies",
                 Some(2),
             );
@@ -935,13 +949,13 @@ macro_rules! test_directed_graph {
             >::from_iter([nodes[1], nodes[2]]);
             check_if_nodes_match(
                 expected_adjacencies_three,
-                DirectedGraph::adjacencies(&graph, nodes[3]),
+                $crate::graph::DirectedGraph::adjacencies(&graph, nodes[3]),
                 "adjacencies",
                 Some(3),
             );
 
             assert!(
-                DirectedGraph::adjacencies(&graph, nodes[4])
+                $crate::graph::DirectedGraph::adjacencies(&graph, nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::adjacencies() did not return an empty iterator for node 4"
@@ -956,7 +970,7 @@ macro_rules! test_directed_graph {
 
             // Source 0
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[0], nodes[0])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 0 and 0"
@@ -968,7 +982,8 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_0_1,
-                DirectedGraph::edges_between(&graph, nodes[0], nodes[1]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[1])
+                    .map(|edge| edge.id),
                 "edges_between",
                 0,
             );
@@ -979,19 +994,20 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_0_2,
-                DirectedGraph::edges_between(&graph, nodes[0], nodes[2]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[2])
+                    .map(|edge| edge.id),
                 "edges_between",
                 0,
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[0], nodes[3])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 0 and 3"
             );
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[0], nodes[4])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 0 and 4"
@@ -999,21 +1015,21 @@ macro_rules! test_directed_graph {
 
             // Source 1
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[1], nodes[0])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 0"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[1], nodes[1])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 1"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[1], nodes[2])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 2"
@@ -1025,13 +1041,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_1_3,
-                DirectedGraph::edges_between(&graph, nodes[1], nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[3])
+                    .map(|edge| edge.id),
                 "edges_between",
                 1,
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[1], nodes[4])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 4"
@@ -1039,35 +1056,35 @@ macro_rules! test_directed_graph {
 
             // Source 2
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[2], nodes[0])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 0"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[2], nodes[1])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 1"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[2], nodes[2])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 2"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[2], nodes[3])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 3"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[2], nodes[4])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 4"
@@ -1075,14 +1092,14 @@ macro_rules! test_directed_graph {
 
             // Source 3
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[3], nodes[0])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 0"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[3], nodes[1])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 1"
@@ -1094,20 +1111,21 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_3_2,
-                DirectedGraph::edges_between(&graph, nodes[3], nodes[2]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[2])
+                    .map(|edge| edge.id),
                 "edges_between",
                 3,
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[3], nodes[3])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 3"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[3], nodes[4])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 4"
@@ -1115,35 +1133,35 @@ macro_rules! test_directed_graph {
 
             // Source 4
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[4], nodes[0])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 0"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[4], nodes[1])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 1"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[4], nodes[2])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 2"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[4], nodes[3])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 3"
             );
 
             assert!(
-                DirectedGraph::edges_between(&graph, nodes[4], nodes[4])
+                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 4"
@@ -1158,7 +1176,7 @@ macro_rules! test_directed_graph {
 
             // Source 0
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[0])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 0 \
@@ -1171,7 +1189,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_0_1,
-                DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[1])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[1])
                     .map(|edge| edge.id),
                 "edges_between_mut",
                 0,
@@ -1183,21 +1201,21 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_0_2,
-                DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[2])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[2])
                     .map(|edge| edge.id),
                 "edges_between_mut",
                 0,
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[3])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 0 \
                  and 3"
             );
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[4])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 0 \
@@ -1206,7 +1224,7 @@ macro_rules! test_directed_graph {
 
             // Source 1
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[0])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 1 \
@@ -1214,7 +1232,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[1])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 1 \
@@ -1222,7 +1240,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[2])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 1 \
@@ -1235,14 +1253,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_1_3,
-                DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[3])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[3])
                     .map(|edge| edge.id),
                 "edges_between_mut",
                 1,
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[4])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 1 \
@@ -1251,7 +1269,7 @@ macro_rules! test_directed_graph {
 
             // Source 2
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[0])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
@@ -1259,7 +1277,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[1])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
@@ -1267,7 +1285,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[2])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
@@ -1275,7 +1293,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[3])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
@@ -1283,7 +1301,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[4])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
@@ -1292,7 +1310,7 @@ macro_rules! test_directed_graph {
 
             // Source 3
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[0])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 3 \
@@ -1300,7 +1318,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[1])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 3 \
@@ -1313,14 +1331,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_3_2,
-                DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[2])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[2])
                     .map(|edge| edge.id),
                 "edges_between_mut",
                 3,
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[3])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 3 \
@@ -1328,7 +1346,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[4])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 3 \
@@ -1337,7 +1355,7 @@ macro_rules! test_directed_graph {
 
             // Source 4
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[0])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
@@ -1345,7 +1363,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[1])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
@@ -1353,7 +1371,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[2])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
@@ -1361,7 +1379,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[3])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
@@ -1369,7 +1387,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[4])
+                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
@@ -1385,7 +1403,7 @@ macro_rules! test_directed_graph {
 
             // Source 0
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[0], nodes[0])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 0 \
@@ -1398,7 +1416,8 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_0_1,
-                DirectedGraph::edges_connecting(&graph, nodes[0], nodes[1]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[1])
+                    .map(|edge| edge.id),
                 "edges_connecting",
                 0,
             );
@@ -1410,13 +1429,14 @@ macro_rules! test_directed_graph {
 
             check_if_edges_match(
                 expected_edges_0_2,
-                DirectedGraph::edges_connecting(&graph, nodes[0], nodes[2]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[2])
+                    .map(|edge| edge.id),
                 "edges_connecting",
                 0,
             );
 
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[0], nodes[3])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 0 \
@@ -1424,7 +1444,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[0], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 0 \
@@ -1433,7 +1453,7 @@ macro_rules! test_directed_graph {
 
             // Source 1
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[1], nodes[1])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 1 \
@@ -1441,7 +1461,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[1], nodes[2])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 1 \
@@ -1454,13 +1474,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_1_3,
-                DirectedGraph::edges_connecting(&graph, nodes[1], nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[3])
+                    .map(|edge| edge.id),
                 "edges_connecting",
                 1,
             );
 
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[1], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 1 \
@@ -1469,7 +1490,7 @@ macro_rules! test_directed_graph {
 
             // Source 2
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[2], nodes[2])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[2], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 2 \
@@ -1482,13 +1503,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_2_3,
-                DirectedGraph::edges_connecting(&graph, nodes[2], nodes[3]).map(|edge| edge.id),
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[2], nodes[3])
+                    .map(|edge| edge.id),
                 "edges_connecting",
                 2,
             );
 
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[2], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[2], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 2 \
@@ -1497,7 +1519,7 @@ macro_rules! test_directed_graph {
 
             // Source 3
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[3], nodes[3])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[3], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 3 \
@@ -1505,7 +1527,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[3], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[3], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 3 \
@@ -1514,7 +1536,7 @@ macro_rules! test_directed_graph {
 
             // Source 4
             assert!(
-                DirectedGraph::edges_connecting(&graph, nodes[4], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[4], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 4 \
@@ -1525,11 +1547,11 @@ macro_rules! test_directed_graph {
             for i in nodes.iter() {
                 for j in nodes.iter() {
                     let edges_lhs_rhs: hashbrown::HashSet<_, foldhash::fast::RandomState> =
-                        DirectedGraph::edges_connecting(&graph, *i, *j)
+                        $crate::graph::DirectedGraph::edges_connecting(&graph, *i, *j)
                             .map(|edge| edge.id)
                             .collect();
                     let edges_rhs_lhs: hashbrown::HashSet<_, foldhash::fast::RandomState> =
-                        DirectedGraph::edges_connecting(&graph, *j, *i)
+                        $crate::graph::DirectedGraph::edges_connecting(&graph, *j, *i)
                             .map(|edge| edge.id)
                             .collect();
                     assert_eq!(
@@ -1550,7 +1572,7 @@ macro_rules! test_directed_graph {
 
             // Source 0
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[0])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[0])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1563,7 +1585,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_0_1,
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[1])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[1])
                     .map(|edge| edge.id),
                 "edges_connecting_mut",
                 0,
@@ -1576,14 +1598,14 @@ macro_rules! test_directed_graph {
 
             check_if_edges_match(
                 expected_edges_0_2,
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[2])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[2])
                     .map(|edge| edge.id),
                 "edges_connecting_mut",
                 0,
             );
 
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[3])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1591,7 +1613,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1600,7 +1622,7 @@ macro_rules! test_directed_graph {
 
             // Source 1
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[1])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[1])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1608,7 +1630,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[2])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1621,14 +1643,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_1_3,
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[3])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[3])
                     .map(|edge| edge.id),
                 "edges_connecting_mut",
                 1,
             );
 
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1637,7 +1659,7 @@ macro_rules! test_directed_graph {
 
             // Source 2
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[2])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[2])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1650,14 +1672,14 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_edges_match(
                 expected_edges_2_3,
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[3])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[3])
                     .map(|edge| edge.id),
                 "edges_connecting_mut",
                 2,
             );
 
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1666,7 +1688,7 @@ macro_rules! test_directed_graph {
 
             // Source 3
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[3], nodes[3])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[3], nodes[3])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1674,7 +1696,7 @@ macro_rules! test_directed_graph {
             );
 
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[3], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[3], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1683,7 +1705,7 @@ macro_rules! test_directed_graph {
 
             // Source 4
             assert!(
-                DirectedGraph::edges_connecting_mut(&mut graph, nodes[4], nodes[4])
+                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[4], nodes[4])
                     .next()
                     .is_none(),
                 "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
@@ -1694,11 +1716,11 @@ macro_rules! test_directed_graph {
             for i in nodes.iter() {
                 for j in nodes.iter() {
                     let edges_lhs_rhs: hashbrown::HashSet<_, foldhash::fast::RandomState> =
-                        DirectedGraph::edges_connecting_mut(&mut graph, *i, *j)
+                        $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, *i, *j)
                             .map(|edge| edge.id)
                             .collect();
                     let edges_rhs_lhs: hashbrown::HashSet<_, foldhash::fast::RandomState> =
-                        DirectedGraph::edges_connecting_mut(&mut graph, *j, *i)
+                        $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, *j, *i)
                             .map(|edge| edge.id)
                             .collect();
                     assert_eq!(
@@ -1718,7 +1740,7 @@ macro_rules! test_directed_graph {
 
             for node in nodes.iter() {
                 assert!(
-                    DirectedGraph::contains_node(&graph, *node),
+                    $crate::graph::DirectedGraph::contains_node(&graph, *node),
                     "DirectedGraph::contains_node() returned false for existing node: {:?}",
                     node
                 );
@@ -1729,7 +1751,7 @@ macro_rules! test_directed_graph {
             // id.
             $remove_node(&mut graph, nodes[4]);
             assert!(
-                !DirectedGraph::contains_node(&graph, nodes[4]),
+                !$crate::graph::DirectedGraph::contains_node(&graph, nodes[4]),
                 "DirectedGraph::contains_node() returned true for removed node: {:?}",
                 nodes[4]
             );
@@ -1742,7 +1764,7 @@ macro_rules! test_directed_graph {
 
             for edge in edges.iter() {
                 assert!(
-                    DirectedGraph::contains_edge(&graph, *edge),
+                    $crate::graph::DirectedGraph::contains_edge(&graph, *edge),
                     "DirectedGraph::contains_edge() returned false for existing edge: {:?}",
                     edge
                 );
@@ -1752,7 +1774,7 @@ macro_rules! test_directed_graph {
             // id.
             $remove_edge(&mut graph, edges[3]);
             assert!(
-                !DirectedGraph::contains_edge(&graph, edges[3]),
+                !$crate::graph::DirectedGraph::contains_edge(&graph, edges[3]),
                 "DirectedGraph::contains_edge() returned true for removed edge: {:?}",
                 edges[3]
             );
@@ -1774,7 +1796,7 @@ macro_rules! test_directed_graph {
                 for target in nodes.iter() {
                     let expected_adjacency = adjacent_node_pairs.contains(&(*source, *target));
                     assert_eq!(
-                        DirectedGraph::is_adjacent(&graph, *source, *target),
+                        $crate::graph::DirectedGraph::is_adjacent(&graph, *source, *target),
                         expected_adjacency,
                         "DirectedGraph::is_adjacent() returned incorrect result for nodes {:?} \
                          and {:?}",
@@ -1791,25 +1813,25 @@ macro_rules! test_directed_graph {
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
             assert!(
-                !DirectedGraph::is_empty(&graph),
+                !$crate::graph::DirectedGraph::is_empty(&graph),
                 "DirectedGraph::is_empty() returned true for a non-empty graph"
             );
 
             let mut new_graph = $graph_constructor();
             assert!(
-                DirectedGraph::is_empty(&new_graph),
+                $crate::graph::DirectedGraph::is_empty(&new_graph),
                 "DirectedGraph::is_empty() returned false for an empty graph"
             );
 
             let node_one = $add_node(&mut new_graph, ());
             assert!(
-                !DirectedGraph::is_empty(&new_graph),
+                !$crate::graph::DirectedGraph::is_empty(&new_graph),
                 "DirectedGraph::is_empty() returned true for a graph with one node"
             );
 
             $remove_node(&mut new_graph, node_one);
             assert!(
-                DirectedGraph::is_empty(&new_graph),
+                $crate::graph::DirectedGraph::is_empty(&new_graph),
                 "DirectedGraph::is_empty() returned false for an empty graph after removing the \
                  only node"
             );
@@ -1826,7 +1848,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_nodes_match(
                 expected_sources,
-                DirectedGraph::sources(&graph).map(|n| n.id),
+                $crate::graph::DirectedGraph::sources(&graph).map(|n| n.id),
                 "sources",
                 None,
             );
@@ -1843,7 +1865,7 @@ macro_rules! test_directed_graph {
                 ]);
             check_if_nodes_match(
                 expected_sinks,
-                DirectedGraph::sinks(&graph).map(|n| n.id),
+                $crate::graph::DirectedGraph::sinks(&graph).map(|n| n.id),
                 "sinks",
                 None,
             );

--- a/crates/core/src/utils/testing/directed.rs
+++ b/crates/core/src/utils/testing/directed.rs
@@ -4,10 +4,12 @@ pub const DIRECTED_TEST_GRAPH_EDGE_COUNT: usize = 4;
 /// A macro to create a simple directed graph for testing purposes.
 ///
 /// The graph looks as follows:
+/// ```text
 /// 0 --> 1
 /// |      |
 /// v      v
 /// 2 <----3     4
+/// ```
 ///
 /// The macro returns a tuple containing the constructed graph,
 /// a vector of the indices of added nodes, and a vector of the indices of added edges.
@@ -35,11 +37,11 @@ macro_rules! create_directed_test_graph {
 
         assert_eq!(
             nodes.len(),
-            $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT
+            $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT
         );
         assert_eq!(
             edges.len(),
-            $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT
+            $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT
         );
 
         (graph, nodes, edges)
@@ -85,36 +87,36 @@ macro_rules! test_directed_graph {
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
             assert_eq!(
                 DirectedGraph::node_count(&graph),
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT,
                 "DirectedGraph::node_count() did not match expected value"
             );
             assert_eq!(
                 DirectedGraph::edge_count(&graph),
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT,
                 "DirectedGraph::edge_count() did not match expected value"
             );
 
             let cardinality = DirectedGraph::cardinality(&graph);
             assert_eq!(
                 cardinality.order,
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT,
                 "DirectedGraph::cardinality().order did not match expected value"
             );
             assert_eq!(
                 cardinality.size,
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT,
                 "DirectedGraph::cardinality().size did not match expected value"
             );
 
             $remove_node(&mut graph, nodes[0]);
             assert_eq!(
                 DirectedGraph::node_count(&graph),
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT - 1,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT - 1,
                 "DirectedGraph::node_count() did not match expected value after removing node 0"
             );
             assert_eq!(
                 DirectedGraph::edge_count(&graph),
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT - 2,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT - 2,
                 "DirectedGraph::edge_count() did not match expected value after removing node 0"
             );
         }
@@ -126,7 +128,7 @@ macro_rules! test_directed_graph {
             let nodes_count = DirectedGraph::nodes(&graph).count();
             assert_eq!(
                 nodes_count,
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT,
                 "DirectedGraph::nodes().count() did not match expected value"
             );
             for node in DirectedGraph::nodes(&graph) {
@@ -145,7 +147,7 @@ macro_rules! test_directed_graph {
             let nodes_count = DirectedGraph::nodes_mut(&mut graph).count();
             assert_eq!(
                 nodes_count,
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_NODE_COUNT,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_NODE_COUNT,
                 "DirectedGraph::nodes_mut().count() did not match expected value"
             );
             for node in DirectedGraph::nodes_mut(&mut graph) {
@@ -187,7 +189,7 @@ macro_rules! test_directed_graph {
             let edges_count = DirectedGraph::edges(&graph).count();
             assert_eq!(
                 edges_count,
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT,
                 "DirectedGraph::edges().count() did not match expected value"
             );
             for edge in DirectedGraph::edges(&graph) {
@@ -206,7 +208,7 @@ macro_rules! test_directed_graph {
             let edges_count = DirectedGraph::edges_mut(&mut graph).count();
             assert_eq!(
                 edges_count,
-                $crate::utils::testing::DIRECTED_TEST_GRAPH_EDGE_COUNT,
+                $crate::utils::testing::directed::DIRECTED_TEST_GRAPH_EDGE_COUNT,
                 "DirectedGraph::edges_mut().count() did not match expected value"
             );
             for edge in DirectedGraph::edges_mut(&mut graph) {

--- a/crates/core/src/utils/testing/directed.rs
+++ b/crates/core/src/utils/testing/directed.rs
@@ -844,196 +844,30 @@ macro_rules! test_directed_graph {
             let (graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
-            // Source 0
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 0 and 0"
-            );
+            let expected_edge_matrix = [
+                [None, Some(edges[0]), Some(edges[1]), None, None],
+                [None, None, None, Some(edges[2]), None],
+                [None, None, None, None, None],
+                [None, None, Some(edges[3]), None, None],
+                [None, None, None, None, None],
+            ];
 
-            let expected_edges_0_1 = [edges[0]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_0_1,
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[1])
-                    .map(|edge| edge.id),
-                "edges_between",
-                "DirectedGraph",
-                0,
-            );
-
-            let expected_edges_0_2 = [edges[1]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_0_2,
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[2])
-                    .map(|edge| edge.id),
-                "edges_between",
-                "DirectedGraph",
-                0,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 0 and 3"
-            );
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 0 and 4"
-            );
-
-            // Source 1
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 0"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 1"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 2"
-            );
-
-            let expected_edges_1_3 = [edges[2]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_1_3,
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[3])
-                    .map(|edge| edge.id),
-                "edges_between",
-                "DirectedGraph",
-                1,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 4"
-            );
-
-            // Source 2
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 0"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 1"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 2"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[2], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 2 and 4"
-            );
-
-            // Source 3
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 0"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 1"
-            );
-
-            let expected_edges_3_2 = [edges[3]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_3_2,
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[2])
-                    .map(|edge| edge.id),
-                "edges_between",
-                "DirectedGraph",
-                3,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 4"
-            );
-
-            // Source 4
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 0"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 1"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 2"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between(&graph, nodes[4], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between() did not return an empty iterator for nodes 4 and 4"
-            );
+            for lhs_number in 0..nodes.len() {
+                for rhs_number in 0..nodes.len() {
+                    $crate::utils::testing::check_if_edges_match(
+                        expected_edge_matrix[lhs_number][rhs_number],
+                        $crate::graph::DirectedGraph::edges_between(
+                            &graph,
+                            nodes[lhs_number],
+                            nodes[rhs_number],
+                        )
+                        .map(|edge| edge.id),
+                        "edges_between",
+                        "DirectedGraph",
+                        format_args!("node pair ({}, {})", lhs_number, rhs_number),
+                    );
+                }
+            }
         }
 
         #[test]
@@ -1042,217 +876,30 @@ macro_rules! test_directed_graph {
             let (mut graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
-            // Source 0
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 0 \
-                 and 0"
-            );
+            let expected_edge_matrix = [
+                [None, Some(edges[0]), Some(edges[1]), None, None],
+                [None, None, None, Some(edges[2]), None],
+                [None, None, None, None, None],
+                [None, None, Some(edges[3]), None, None],
+                [None, None, None, None, None],
+            ];
 
-            let expected_edges_0_1 = [edges[0]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_0_1,
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[1])
-                    .map(|edge| edge.id),
-                "edges_between_mut",
-                "DirectedGraph",
-                0,
-            );
-
-            let expected_edges_0_2 = [edges[1]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_0_2,
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[2])
-                    .map(|edge| edge.id),
-                "edges_between_mut",
-                "DirectedGraph",
-                0,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 0 \
-                 and 3"
-            );
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 0 \
-                 and 4"
-            );
-
-            // Source 1
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 1 \
-                 and 0"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 1 \
-                 and 1"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 1 \
-                 and 2"
-            );
-
-            let expected_edges_1_3 = [edges[2]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_1_3,
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[3])
-                    .map(|edge| edge.id),
-                "edges_between_mut",
-                "DirectedGraph",
-                1,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 1 \
-                 and 4"
-            );
-
-            // Source 2
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
-                 and 0"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
-                 and 1"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
-                 and 2"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
-                 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[2], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 2 \
-                 and 4"
-            );
-
-            // Source 3
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 3 \
-                 and 0"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 3 \
-                 and 1"
-            );
-
-            let expected_edges_3_2 = [edges[3]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_3_2,
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[2])
-                    .map(|edge| edge.id),
-                "edges_between_mut",
-                "DirectedGraph",
-                3,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 3 \
-                 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 3 \
-                 and 4"
-            );
-
-            // Source 4
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
-                 and 0"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
-                 and 1"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
-                 and 2"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
-                 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[4], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_between_mut() did not return an empty iterator for nodes 4 \
-                 and 4"
-            );
+            for lhs_number in 0..nodes.len() {
+                for rhs_number in 0..nodes.len() {
+                    $crate::utils::testing::check_if_edges_match(
+                        expected_edge_matrix[lhs_number][rhs_number],
+                        $crate::graph::DirectedGraph::edges_between_mut(
+                            &mut graph,
+                            nodes[lhs_number],
+                            nodes[rhs_number],
+                        )
+                        .map(|edge| edge.id),
+                        "edges_between_mut",
+                        "DirectedGraph",
+                        format_args!("node pair ({}, {})", lhs_number, rhs_number),
+                    );
+                }
+            }
         }
 
         #[test]
@@ -1261,156 +908,27 @@ macro_rules! test_directed_graph {
             let (graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
-            // Source 0
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 0 \
-                 and 0"
-            );
+            let expected_edge_matrix = [
+                [None, Some(edges[0]), Some(edges[1]), None, None],
+                [Some(edges[0]), None, None, Some(edges[2]), None],
+                [Some(edges[1]), None, None, Some(edges[3]), None],
+                [None, Some(edges[2]), Some(edges[3]), None, None],
+                [None, None, None, None, None],
+            ];
 
-            let expected_edges_0_1 = [edges[0]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_0_1,
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[1])
-                    .map(|edge| edge.id),
-                "edges_connecting",
-                "DirectedGraph",
-                0,
-            );
-
-            let expected_edges_0_2 = [edges[1]];
-
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_0_2,
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[2])
-                    .map(|edge| edge.id),
-                "edges_connecting",
-                "DirectedGraph",
-                0,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 0 \
-                 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 0 \
-                 and 4"
-            );
-
-            // Source 1
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 1 \
-                 and 1"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 1 \
-                 and 2"
-            );
-
-            let expected_edges_1_3 = [edges[2]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_1_3,
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[3])
-                    .map(|edge| edge.id),
-                "edges_connecting",
-                "DirectedGraph",
-                1,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 1 \
-                 and 4"
-            );
-
-            // Source 2
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[2], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 2 \
-                 and 2"
-            );
-
-            let expected_edges_2_3 = [edges[3]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_2_3,
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[2], nodes[3])
-                    .map(|edge| edge.id),
-                "edges_connecting",
-                "DirectedGraph",
-                2,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[2], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 2 \
-                 and 4"
-            );
-
-            // Source 3
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[3], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 3 \
-                 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[3], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 3 \
-                 and 4"
-            );
-
-            // Source 4
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[4], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting() did not return an empty iterator for nodes 4 \
-                 and 4"
-            );
-
-            // Check if swapping lhs and rhs matters
-            for i in nodes.iter() {
-                for j in nodes.iter() {
-                    let edges_lhs_rhs: hashbrown::HashSet<_, foldhash::fast::RandomState> =
-                        $crate::graph::DirectedGraph::edges_connecting(&graph, *i, *j)
-                            .map(|edge| edge.id)
-                            .collect();
-                    let edges_rhs_lhs: hashbrown::HashSet<_, foldhash::fast::RandomState> =
-                        $crate::graph::DirectedGraph::edges_connecting(&graph, *j, *i)
-                            .map(|edge| edge.id)
-                            .collect();
-                    assert_eq!(
-                        edges_lhs_rhs, edges_rhs_lhs,
-                        "DirectedGraph::edges_connecting() returned different edges when swapping \
-                         source and target nodes: {:?} and {:?}",
-                        i, j
+            for lhs_number in 0..nodes.len() {
+                for rhs_number in 0..nodes.len() {
+                    $crate::utils::testing::check_if_edges_match(
+                        expected_edge_matrix[lhs_number][rhs_number],
+                        $crate::graph::DirectedGraph::edges_connecting(
+                            &graph,
+                            nodes[lhs_number],
+                            nodes[rhs_number],
+                        )
+                        .map(|edge| edge.id),
+                        "edges_connecting",
+                        "DirectedGraph",
+                        format_args!("node pair ({}, {})", lhs_number, rhs_number),
                     );
                 }
             }
@@ -1422,156 +940,27 @@ macro_rules! test_directed_graph {
             let (mut graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
-            // Source 0
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[0])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 0 and 0"
-            );
+            let expected_edge_matrix = [
+                [None, Some(edges[0]), Some(edges[1]), None, None],
+                [Some(edges[0]), None, None, Some(edges[2]), None],
+                [Some(edges[1]), None, None, Some(edges[3]), None],
+                [None, Some(edges[2]), Some(edges[3]), None, None],
+                [None, None, None, None, None],
+            ];
 
-            let expected_edges_0_1 = [edges[0]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_0_1,
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[1])
-                    .map(|edge| edge.id),
-                "edges_connecting_mut",
-                "DirectedGraph",
-                0,
-            );
-
-            let expected_edges_0_2 = [edges[1]];
-
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_0_2,
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[2])
-                    .map(|edge| edge.id),
-                "edges_connecting_mut",
-                "DirectedGraph",
-                0,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 0 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 0 and 4"
-            );
-
-            // Source 1
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[1])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 1 and 1"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 1 and 2"
-            );
-
-            let expected_edges_1_3 = [edges[2]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_1_3,
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[3])
-                    .map(|edge| edge.id),
-                "edges_connecting_mut",
-                "DirectedGraph",
-                1,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 1 and 4"
-            );
-
-            // Source 2
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[2])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 2 and 2"
-            );
-
-            let expected_edges_2_3 = [edges[3]];
-            $crate::utils::testing::check_if_edges_match(
-                expected_edges_2_3,
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[3])
-                    .map(|edge| edge.id),
-                "edges_connecting_mut",
-                "DirectedGraph",
-                2,
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 2 and 4"
-            );
-
-            // Source 3
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[3], nodes[3])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 3 and 3"
-            );
-
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[3], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 3 and 4"
-            );
-
-            // Source 4
-            assert!(
-                $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[4], nodes[4])
-                    .next()
-                    .is_none(),
-                "DirectedGraph::edges_connecting_mut() did not return an empty iterator for nodes \
-                 4 and 4"
-            );
-
-            // Check if swapping lhs and rhs matters
-            for i in nodes.iter() {
-                for j in nodes.iter() {
-                    let edges_lhs_rhs: hashbrown::HashSet<_, foldhash::fast::RandomState> =
-                        $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, *i, *j)
-                            .map(|edge| edge.id)
-                            .collect();
-                    let edges_rhs_lhs: hashbrown::HashSet<_, foldhash::fast::RandomState> =
-                        $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, *j, *i)
-                            .map(|edge| edge.id)
-                            .collect();
-                    assert_eq!(
-                        edges_lhs_rhs, edges_rhs_lhs,
-                        "DirectedGraph::edges_connecting_mut() returned different edges when \
-                         swapping source and target nodes: {:?} and {:?}",
-                        i, j
+            for lhs_number in 0..nodes.len() {
+                for rhs_number in 0..nodes.len() {
+                    $crate::utils::testing::check_if_edges_match(
+                        expected_edge_matrix[lhs_number][rhs_number],
+                        $crate::graph::DirectedGraph::edges_connecting_mut(
+                            &mut graph,
+                            nodes[lhs_number],
+                            nodes[rhs_number],
+                        )
+                        .map(|edge| edge.id),
+                        "edges_connecting_mut",
+                        "DirectedGraph",
+                        format_args!("node pair ({}, {})", lhs_number, rhs_number),
                     );
                 }
             }

--- a/crates/core/src/utils/testing/directed.rs
+++ b/crates/core/src/utils/testing/directed.rs
@@ -54,7 +54,7 @@ macro_rules! create_directed_test_graph {
 /// One test is generated for each method in the [`DirectedGraph`][crate::graph::DirectedGraph]
 /// trait. The following invariants are expected from the graph implementation:
 /// - If the most recently added node or edge is removed, its ID will no longer be valid. I.e.,
-///   calling methods with that ID should return `None` or indicate non-existence.
+///   calling methods with that ID should return `None` or otherwise indicate non-existence.
 ///
 /// The arguments to this macro are as follows (`G` is used to denote the graph type being tested).
 /// For a reference usage, see the tests in [`crate::utils::test_graphs::directed`].
@@ -399,33 +399,6 @@ macro_rules! test_directed_graph {
             );
         }
 
-        /// Helper function to check if the edges returned by an iterator match the expected edges.
-        ///
-        /// The additional arguments are just for better error messages.
-        fn check_if_edges_match<T: core::hash::Hash + Eq + core::fmt::Debug>(
-            mut expected_edges: hashbrown::hash_set::HashSet<T, foldhash::fast::RandomState>,
-            actual_edges: impl Iterator<Item = T>,
-            method_name: &'static str,
-            node_number: usize,
-        ) {
-            for edge in actual_edges {
-                assert!(
-                    expected_edges.contains(&edge),
-                    "DirectedGraph::{}() contained unexpected edge id: {:?} for node {}",
-                    method_name,
-                    edge,
-                    node_number
-                );
-                expected_edges.remove(&edge);
-            }
-            assert!(
-                expected_edges.is_empty(),
-                "DirectedGraph::{}() did not return all expected edges for node {}",
-                method_name,
-                node_number
-            );
-        }
-
         #[test]
         fn test_incoming_edges() {
             let (graph, nodes, edges) =
@@ -437,36 +410,30 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::incoming_edges() did not return an empty iterator for node 0"
             );
 
-            let expected_edges_one =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0]
-                ]);
-            check_if_edges_match(
+            let expected_edges_one = [edges[0]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_one,
                 $crate::graph::DirectedGraph::incoming_edges(&graph, nodes[1]).map(|edge| edge.id),
                 "incoming_edges",
+                "DirectedGraph",
                 1,
             );
 
-            let expected_edges_two =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[1], edges[3],
-                ]);
-            check_if_edges_match(
+            let expected_edges_two = [edges[1], edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_two,
                 $crate::graph::DirectedGraph::incoming_edges(&graph, nodes[2]).map(|edge| edge.id),
                 "incoming_edges",
+                "DirectedGraph",
                 2,
             );
 
-            let expected_edges_three =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2]
-                ]);
-            check_if_edges_match(
+            let expected_edges_three = [edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_three,
                 $crate::graph::DirectedGraph::incoming_edges(&graph, nodes[3]).map(|edge| edge.id),
                 "incoming_edges",
+                "DirectedGraph",
                 3,
             );
 
@@ -489,39 +456,33 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::incoming_edges_mut() did not return an empty iterator for node 0"
             );
 
-            let expected_edges_one =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0]
-                ]);
-            check_if_edges_match(
+            let expected_edges_one = [edges[0]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_one,
                 $crate::graph::DirectedGraph::incoming_edges_mut(&mut graph, nodes[1])
                     .map(|edge| edge.id),
                 "incoming_edges_mut",
+                "DirectedGraph",
                 1,
             );
 
-            let expected_edges_two =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[1], edges[3],
-                ]);
-            check_if_edges_match(
+            let expected_edges_two = [edges[1], edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_two,
                 $crate::graph::DirectedGraph::incoming_edges_mut(&mut graph, nodes[2])
                     .map(|edge| edge.id),
                 "incoming_edges_mut",
+                "DirectedGraph",
                 2,
             );
 
-            let expected_edges_three =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2]
-                ]);
-            check_if_edges_match(
+            let expected_edges_three = [edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_three,
                 $crate::graph::DirectedGraph::incoming_edges_mut(&mut graph, nodes[3])
                     .map(|edge| edge.id),
                 "incoming_edges_mut",
+                "DirectedGraph",
                 3,
             );
 
@@ -537,25 +498,21 @@ macro_rules! test_directed_graph {
         fn test_outgoing_edges() {
             let (graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let expected_edges_zero =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0], edges[1],
-                ]);
-            check_if_edges_match(
+            let expected_edges_zero = [edges[0], edges[1]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_zero,
                 $crate::graph::DirectedGraph::outgoing_edges(&graph, nodes[0]).map(|edge| edge.id),
                 "outgoing_edges",
+                "DirectedGraph",
                 0,
             );
 
-            let expected_edges_one =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2]
-                ]);
-            check_if_edges_match(
+            let expected_edges_one = [edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_one,
                 $crate::graph::DirectedGraph::outgoing_edges(&graph, nodes[1]).map(|edge| edge.id),
                 "outgoing_edges",
+                "DirectedGraph",
                 1,
             );
 
@@ -566,14 +523,12 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::outgoing_edges() did not return an empty iterator for node 2"
             );
 
-            let expected_edges_three =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[3]
-                ]);
-            check_if_edges_match(
+            let expected_edges_three = [edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_three,
                 $crate::graph::DirectedGraph::outgoing_edges(&graph, nodes[3]).map(|edge| edge.id),
                 "outgoing_edges",
+                "DirectedGraph",
                 3,
             );
 
@@ -589,27 +544,23 @@ macro_rules! test_directed_graph {
         fn test_outgoing_edges_mut() {
             let (mut graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let expected_edges_zero =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0], edges[1],
-                ]);
-            check_if_edges_match(
+            let expected_edges_zero = [edges[0], edges[1]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_zero,
                 $crate::graph::DirectedGraph::outgoing_edges_mut(&mut graph, nodes[0])
                     .map(|edge| edge.id),
                 "outgoing_edges_mut",
+                "DirectedGraph",
                 0,
             );
 
-            let expected_edges_one =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2]
-                ]);
-            check_if_edges_match(
+            let expected_edges_one = [edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_one,
                 $crate::graph::DirectedGraph::outgoing_edges_mut(&mut graph, nodes[1])
                     .map(|edge| edge.id),
                 "outgoing_edges_mut",
+                "DirectedGraph",
                 1,
             );
 
@@ -620,15 +571,13 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::outgoing_edges_mut() did not return an empty iterator for node 2"
             );
 
-            let expected_edges_three =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[3]
-                ]);
-            check_if_edges_match(
+            let expected_edges_three = [edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_three,
                 $crate::graph::DirectedGraph::outgoing_edges_mut(&mut graph, nodes[3])
                     .map(|edge| edge.id),
                 "outgoing_edges_mut",
+                "DirectedGraph",
                 3,
             );
 
@@ -644,47 +593,39 @@ macro_rules! test_directed_graph {
         fn test_incident_edges() {
             let (graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let expected_edges_zero =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0], edges[1],
-                ]);
-            check_if_edges_match(
+            let expected_edges_zero = [edges[0], edges[1]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_zero,
                 $crate::graph::DirectedGraph::incident_edges(&graph, nodes[0]).map(|edge| edge.id),
                 "incident_edges",
+                "DirectedGraph",
                 0,
             );
 
-            let expected_edges_one =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0], edges[2],
-                ]);
-            check_if_edges_match(
+            let expected_edges_one = [edges[0], edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_one,
                 $crate::graph::DirectedGraph::incident_edges(&graph, nodes[1]).map(|edge| edge.id),
                 "incident_edges",
+                "DirectedGraph",
                 1,
             );
 
-            let expected_edges_two =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[1], edges[3],
-                ]);
-            check_if_edges_match(
+            let expected_edges_two = [edges[1], edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_two,
                 $crate::graph::DirectedGraph::incident_edges(&graph, nodes[2]).map(|edge| edge.id),
                 "incident_edges",
+                "DirectedGraph",
                 2,
             );
 
-            let expected_edges_three =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2], edges[3],
-                ]);
-            check_if_edges_match(
+            let expected_edges_three = [edges[2], edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_three,
                 $crate::graph::DirectedGraph::incident_edges(&graph, nodes[3]).map(|edge| edge.id),
                 "incident_edges",
+                "DirectedGraph",
                 3,
             );
 
@@ -700,51 +641,43 @@ macro_rules! test_directed_graph {
         fn test_incident_edges_mut() {
             let (mut graph, nodes, edges) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let expected_edges_zero =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0], edges[1],
-                ]);
-            check_if_edges_match(
+            let expected_edges_zero = [edges[0], edges[1]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_zero,
                 $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[0])
                     .map(|edge| edge.id),
                 "incident_edges_mut",
+                "DirectedGraph",
                 0,
             );
 
-            let expected_edges_one =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0], edges[2],
-                ]);
-            check_if_edges_match(
+            let expected_edges_one = [edges[0], edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_one,
                 $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[1])
                     .map(|edge| edge.id),
                 "incident_edges_mut",
+                "DirectedGraph",
                 1,
             );
 
-            let expected_edges_two =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[1], edges[3],
-                ]);
-            check_if_edges_match(
+            let expected_edges_two = [edges[1], edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_two,
                 $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[2])
                     .map(|edge| edge.id),
                 "incident_edges_mut",
+                "DirectedGraph",
                 2,
             );
 
-            let expected_edges_three =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2], edges[3],
-                ]);
-            check_if_edges_match(
+            let expected_edges_three = [edges[2], edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_three,
                 $crate::graph::DirectedGraph::incident_edges_mut(&mut graph, nodes[3])
                     .map(|edge| edge.id),
                 "incident_edges_mut",
+                "DirectedGraph",
                 3,
             );
 
@@ -754,52 +687,6 @@ macro_rules! test_directed_graph {
                     .is_none(),
                 "DirectedGraph::incident_edges_mut() did not return an empty iterator for node 4"
             );
-        }
-
-        /// Helper function to check if the nodes returned by an iterator match the expected nodes
-        ///
-        /// The additional arguments are just for better error messages.
-        fn check_if_nodes_match<T: core::hash::Hash + Eq + core::fmt::Debug>(
-            mut expected_nodes: hashbrown::hash_set::HashSet<T, foldhash::fast::RandomState>,
-            actual_nodes: impl Iterator<Item = T>,
-            method_name: &'static str,
-            node_number: Option<usize>,
-        ) {
-            for node in actual_nodes {
-                if let Some(node_number) = node_number {
-                    assert!(
-                        expected_nodes.contains(&node),
-                        "DirectedGraph::{}() contained unexpected node id: {:?} for node {}",
-                        method_name,
-                        node,
-                        node_number
-                    );
-                } else {
-                    assert!(
-                        expected_nodes.contains(&node),
-                        "DirectedGraph::{}() contained unexpected node id: {:?}",
-                        method_name,
-                        node,
-                    );
-                }
-                expected_nodes.remove(&node);
-            }
-            if let Some(node_number) = node_number {
-                assert!(
-                    expected_nodes.is_empty(),
-                    "DirectedGraph::{}() did not return all expected nodes for node {}: {:?}",
-                    method_name,
-                    node_number,
-                    expected_nodes
-                );
-            } else {
-                assert!(
-                    expected_nodes.is_empty(),
-                    "DirectedGraph::{}() did not return all expected nodes: {:?}",
-                    method_name,
-                    expected_nodes
-                );
-            }
         }
 
         #[test]
@@ -813,36 +700,30 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::predecessors() did not return an empty iterator for node 0"
             );
 
-            let expected_predecessors_one = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[0]]);
-            check_if_nodes_match(
+            let expected_predecessors_one = [nodes[0]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_predecessors_one,
                 $crate::graph::DirectedGraph::predecessors(&graph, nodes[1]),
                 "predecessors",
+                "DirectedGraph",
                 Some(1),
             );
 
-            let expected_predecessors_two = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[0], nodes[3]]);
-            check_if_nodes_match(
+            let expected_predecessors_two = [nodes[0], nodes[3]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_predecessors_two,
                 $crate::graph::DirectedGraph::predecessors(&graph, nodes[2]),
                 "predecessors",
+                "DirectedGraph",
                 Some(2),
             );
 
-            let expected_predecessors_three = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[1]]);
-            check_if_nodes_match(
+            let expected_predecessors_three = [nodes[1]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_predecessors_three,
                 $crate::graph::DirectedGraph::predecessors(&graph, nodes[3]),
                 "predecessors",
+                "DirectedGraph",
                 Some(3),
             );
 
@@ -858,25 +739,21 @@ macro_rules! test_directed_graph {
         fn test_successors() {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let expected_successors_zero = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[1], nodes[2]]);
-            check_if_nodes_match(
+            let expected_successors_zero = [nodes[1], nodes[2]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_successors_zero,
                 $crate::graph::DirectedGraph::successors(&graph, nodes[0]),
                 "successors",
+                "DirectedGraph",
                 Some(0),
             );
 
-            let expected_successors_one = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[3]]);
-            check_if_nodes_match(
+            let expected_successors_one = [nodes[3]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_successors_one,
                 $crate::graph::DirectedGraph::successors(&graph, nodes[1]),
                 "successors",
+                "DirectedGraph",
                 Some(1),
             );
 
@@ -887,14 +764,12 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::successors() did not return an empty iterator for node 2"
             );
 
-            let expected_successors_three = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[2]]);
-            check_if_nodes_match(
+            let expected_successors_three = [nodes[2]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_successors_three,
                 $crate::graph::DirectedGraph::successors(&graph, nodes[3]),
                 "successors",
+                "DirectedGraph",
                 Some(3),
             );
 
@@ -910,47 +785,39 @@ macro_rules! test_directed_graph {
         fn test_adjacencies() {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
-            let expected_adjacencies_zero = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[1], nodes[2]]);
-            check_if_nodes_match(
+            let expected_adjacencies_zero = [nodes[1], nodes[2]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_adjacencies_zero,
                 $crate::graph::DirectedGraph::adjacencies(&graph, nodes[0]),
                 "adjacencies",
+                "DirectedGraph",
                 Some(0),
             );
 
-            let expected_adjacencies_one = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[0], nodes[3]]);
-            check_if_nodes_match(
+            let expected_adjacencies_one = [nodes[0], nodes[3]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_adjacencies_one,
                 $crate::graph::DirectedGraph::adjacencies(&graph, nodes[1]),
                 "adjacencies",
+                "DirectedGraph",
                 Some(1),
             );
 
-            let expected_adjacencies_two = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[0], nodes[3]]);
-            check_if_nodes_match(
+            let expected_adjacencies_two = [nodes[0], nodes[3]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_adjacencies_two,
                 $crate::graph::DirectedGraph::adjacencies(&graph, nodes[2]),
                 "adjacencies",
+                "DirectedGraph",
                 Some(2),
             );
 
-            let expected_adjacencies_three = hashbrown::hash_set::HashSet::<
-                _,
-                foldhash::fast::RandomState,
-            >::from_iter([nodes[1], nodes[2]]);
-            check_if_nodes_match(
+            let expected_adjacencies_three = [nodes[1], nodes[2]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_adjacencies_three,
                 $crate::graph::DirectedGraph::adjacencies(&graph, nodes[3]),
                 "adjacencies",
+                "DirectedGraph",
                 Some(3),
             );
 
@@ -976,27 +843,23 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 0 and 0"
             );
 
-            let expected_edges_0_1 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0]
-                ]);
-            check_if_edges_match(
+            let expected_edges_0_1 = [edges[0]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_0_1,
                 $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[1])
                     .map(|edge| edge.id),
                 "edges_between",
+                "DirectedGraph",
                 0,
             );
 
-            let expected_edges_0_2 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[1]
-                ]);
-            check_if_edges_match(
+            let expected_edges_0_2 = [edges[1]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_0_2,
                 $crate::graph::DirectedGraph::edges_between(&graph, nodes[0], nodes[2])
                     .map(|edge| edge.id),
                 "edges_between",
+                "DirectedGraph",
                 0,
             );
 
@@ -1035,15 +898,13 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 1 and 2"
             );
 
-            let expected_edges_1_3 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2]
-                ]);
-            check_if_edges_match(
+            let expected_edges_1_3 = [edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_1_3,
                 $crate::graph::DirectedGraph::edges_between(&graph, nodes[1], nodes[3])
                     .map(|edge| edge.id),
                 "edges_between",
+                "DirectedGraph",
                 1,
             );
 
@@ -1105,15 +966,13 @@ macro_rules! test_directed_graph {
                 "DirectedGraph::edges_between() did not return an empty iterator for nodes 3 and 1"
             );
 
-            let expected_edges_3_2 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[3]
-                ]);
-            check_if_edges_match(
+            let expected_edges_3_2 = [edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_3_2,
                 $crate::graph::DirectedGraph::edges_between(&graph, nodes[3], nodes[2])
                     .map(|edge| edge.id),
                 "edges_between",
+                "DirectedGraph",
                 3,
             );
 
@@ -1183,27 +1042,23 @@ macro_rules! test_directed_graph {
                  and 0"
             );
 
-            let expected_edges_0_1 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0]
-                ]);
-            check_if_edges_match(
+            let expected_edges_0_1 = [edges[0]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_0_1,
                 $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[1])
                     .map(|edge| edge.id),
                 "edges_between_mut",
+                "DirectedGraph",
                 0,
             );
 
-            let expected_edges_0_2 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[1]
-                ]);
-            check_if_edges_match(
+            let expected_edges_0_2 = [edges[1]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_0_2,
                 $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[0], nodes[2])
                     .map(|edge| edge.id),
                 "edges_between_mut",
+                "DirectedGraph",
                 0,
             );
 
@@ -1247,15 +1102,13 @@ macro_rules! test_directed_graph {
                  and 2"
             );
 
-            let expected_edges_1_3 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2]
-                ]);
-            check_if_edges_match(
+            let expected_edges_1_3 = [edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_1_3,
                 $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[1], nodes[3])
                     .map(|edge| edge.id),
                 "edges_between_mut",
+                "DirectedGraph",
                 1,
             );
 
@@ -1325,15 +1178,13 @@ macro_rules! test_directed_graph {
                  and 1"
             );
 
-            let expected_edges_3_2 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[3]
-                ]);
-            check_if_edges_match(
+            let expected_edges_3_2 = [edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_3_2,
                 $crate::graph::DirectedGraph::edges_between_mut(&mut graph, nodes[3], nodes[2])
                     .map(|edge| edge.id),
                 "edges_between_mut",
+                "DirectedGraph",
                 3,
             );
 
@@ -1410,28 +1261,24 @@ macro_rules! test_directed_graph {
                  and 0"
             );
 
-            let expected_edges_0_1 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0]
-                ]);
-            check_if_edges_match(
+            let expected_edges_0_1 = [edges[0]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_0_1,
                 $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[1])
                     .map(|edge| edge.id),
                 "edges_connecting",
+                "DirectedGraph",
                 0,
             );
 
-            let expected_edges_0_2 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[1]
-                ]);
+            let expected_edges_0_2 = [edges[1]];
 
-            check_if_edges_match(
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_0_2,
                 $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[0], nodes[2])
                     .map(|edge| edge.id),
                 "edges_connecting",
+                "DirectedGraph",
                 0,
             );
 
@@ -1468,15 +1315,13 @@ macro_rules! test_directed_graph {
                  and 2"
             );
 
-            let expected_edges_1_3 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2]
-                ]);
-            check_if_edges_match(
+            let expected_edges_1_3 = [edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_1_3,
                 $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[1], nodes[3])
                     .map(|edge| edge.id),
                 "edges_connecting",
+                "DirectedGraph",
                 1,
             );
 
@@ -1497,15 +1342,13 @@ macro_rules! test_directed_graph {
                  and 2"
             );
 
-            let expected_edges_2_3 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[3]
-                ]);
-            check_if_edges_match(
+            let expected_edges_2_3 = [edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_2_3,
                 $crate::graph::DirectedGraph::edges_connecting(&graph, nodes[2], nodes[3])
                     .map(|edge| edge.id),
                 "edges_connecting",
+                "DirectedGraph",
                 2,
             );
 
@@ -1579,28 +1422,24 @@ macro_rules! test_directed_graph {
                  0 and 0"
             );
 
-            let expected_edges_0_1 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[0]
-                ]);
-            check_if_edges_match(
+            let expected_edges_0_1 = [edges[0]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_0_1,
                 $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[1])
                     .map(|edge| edge.id),
                 "edges_connecting_mut",
+                "DirectedGraph",
                 0,
             );
 
-            let expected_edges_0_2 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[1]
-                ]);
+            let expected_edges_0_2 = [edges[1]];
 
-            check_if_edges_match(
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_0_2,
                 $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[0], nodes[2])
                     .map(|edge| edge.id),
                 "edges_connecting_mut",
+                "DirectedGraph",
                 0,
             );
 
@@ -1637,15 +1476,13 @@ macro_rules! test_directed_graph {
                  1 and 2"
             );
 
-            let expected_edges_1_3 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[2]
-                ]);
-            check_if_edges_match(
+            let expected_edges_1_3 = [edges[2]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_1_3,
                 $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[1], nodes[3])
                     .map(|edge| edge.id),
                 "edges_connecting_mut",
+                "DirectedGraph",
                 1,
             );
 
@@ -1666,15 +1503,13 @@ macro_rules! test_directed_graph {
                  2 and 2"
             );
 
-            let expected_edges_2_3 =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    edges[3]
-                ]);
-            check_if_edges_match(
+            let expected_edges_2_3 = [edges[3]];
+            $crate::utils::testing::check_if_edges_match(
                 expected_edges_2_3,
                 $crate::graph::DirectedGraph::edges_connecting_mut(&mut graph, nodes[2], nodes[3])
                     .map(|edge| edge.id),
                 "edges_connecting_mut",
+                "DirectedGraph",
                 2,
             );
 
@@ -1842,15 +1677,13 @@ macro_rules! test_directed_graph {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
-            let expected_sources =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    nodes[0], nodes[4],
-                ]);
-            check_if_nodes_match(
+            let expected_sources = [nodes[0], nodes[4]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_sources,
                 $crate::graph::DirectedGraph::sources(&graph).map(|n| n.id),
                 "sources",
-                None,
+                "DirectedGraph",
+                Option::<usize>::None,
             );
         }
 
@@ -1859,15 +1692,13 @@ macro_rules! test_directed_graph {
             let (graph, nodes, _) =
                 $crate::create_directed_test_graph!($graph_constructor, $add_node, $add_edge);
 
-            let expected_sinks =
-                hashbrown::hash_set::HashSet::<_, foldhash::fast::RandomState>::from_iter([
-                    nodes[2], nodes[4],
-                ]);
-            check_if_nodes_match(
+            let expected_sinks = [nodes[2], nodes[4]];
+            $crate::utils::testing::check_if_nodes_match(
                 expected_sinks,
                 $crate::graph::DirectedGraph::sinks(&graph).map(|n| n.id),
                 "sinks",
-                None,
+                "DirectedGraph",
+                Option::<usize>::None,
             );
         }
     };

--- a/crates/core/src/utils/testing/mod.rs
+++ b/crates/core/src/utils/testing/mod.rs
@@ -1,0 +1,2 @@
+pub mod directed;
+pub mod undirected;

--- a/crates/core/src/utils/testing/mod.rs
+++ b/crates/core/src/utils/testing/mod.rs
@@ -1,2 +1,76 @@
 pub mod directed;
 pub mod undirected;
+
+/// Helper function to check if the edges returned by an iterator match the expected edges.
+///
+/// The additional arguments are just for better error messages.
+#[doc(hidden)]
+pub fn check_if_edges_match<T>(
+    expected_edges: impl IntoIterator<Item = T>,
+    actual_edges: impl Iterator<Item = T>,
+    method_name: &'static str,
+    graph_type: &'static str,
+    context: impl core::fmt::Display,
+) where
+    T: core::hash::Hash + Eq + core::fmt::Debug,
+{
+    let mut expected_edges: hashbrown::HashSet<T, foldhash::fast::RandomState> =
+        expected_edges.into_iter().collect();
+
+    for edge in actual_edges {
+        assert!(
+            expected_edges.remove(&edge),
+            "{}::{}() contained unexpected edge id: {:?} for {}",
+            graph_type,
+            method_name,
+            edge,
+            context
+        );
+    }
+
+    assert!(
+        expected_edges.is_empty(),
+        "{}::{}() did not return all expected edges for {}: {:?}",
+        graph_type,
+        method_name,
+        context,
+        expected_edges
+    );
+}
+
+/// Helper function to check if the nodes returned by an iterator match the expected nodes.
+///
+/// The additional arguments are just for better error messages.
+#[doc(hidden)]
+pub fn check_if_nodes_match<T>(
+    expected_nodes: impl IntoIterator<Item = T>,
+    actual_nodes: impl Iterator<Item = T>,
+    method_name: &'static str,
+    graph_type: &'static str,
+    context: impl core::fmt::Debug,
+) where
+    T: core::hash::Hash + Eq + core::fmt::Debug,
+{
+    let mut expected_nodes: hashbrown::HashSet<T, foldhash::fast::RandomState> =
+        expected_nodes.into_iter().collect();
+
+    for node in actual_nodes {
+        assert!(
+            expected_nodes.remove(&node),
+            "{}::{}() contained unexpected node id: {:?} for {:?}",
+            graph_type,
+            method_name,
+            node,
+            context
+        );
+    }
+
+    assert!(
+        expected_nodes.is_empty(),
+        "{}::{}() did not return all expected nodes for {:?}: {:?}",
+        graph_type,
+        method_name,
+        context,
+        expected_nodes
+    );
+}

--- a/crates/core/src/utils/testing/mod.rs
+++ b/crates/core/src/utils/testing/mod.rs
@@ -20,21 +20,14 @@ pub fn check_if_edges_match<T>(
     for edge in actual_edges {
         assert!(
             expected_edges.remove(&edge),
-            "{}::{}() contained unexpected edge id: {:?} for {}",
-            graph_type,
-            method_name,
-            edge,
-            context
+            "{graph_type}::{method_name}() contained unexpected edge id: {edge:?} for {context}",
         );
     }
 
     assert!(
         expected_edges.is_empty(),
-        "{}::{}() did not return all expected edges for {}: {:?}",
-        graph_type,
-        method_name,
-        context,
-        expected_edges
+        "{graph_type}::{method_name}() did not return all expected edges for {context}: \
+         {expected_edges:?}",
     );
 }
 
@@ -57,20 +50,13 @@ pub fn check_if_nodes_match<T>(
     for node in actual_nodes {
         assert!(
             expected_nodes.remove(&node),
-            "{}::{}() contained unexpected node id: {:?} for {:?}",
-            graph_type,
-            method_name,
-            node,
-            context
+            "{graph_type}::{method_name}() contained unexpected node id: {node:?} for {context:?}",
         );
     }
 
     assert!(
         expected_nodes.is_empty(),
-        "{}::{}() did not return all expected nodes for {:?}: {:?}",
-        graph_type,
-        method_name,
-        context,
-        expected_nodes
+        "{graph_type}::{method_name}() did not return all expected nodes for {context:?}: \
+         {expected_nodes:?}",
     );
 }

--- a/crates/core/src/utils/testing/undirected.rs
+++ b/crates/core/src/utils/testing/undirected.rs
@@ -1,0 +1,51 @@
+pub const UNDIRECTED_TEST_GRAPH_NODE_COUNT: usize = 5;
+pub const UNDIRECTED_TEST_GRAPH_EDGE_COUNT: usize = 4;
+
+/// A macro to create a simple undirected graph for testing purposes.
+///
+/// The graph looks as follows:
+/// ```text
+/// 0 --> 1
+/// |      |
+/// v      v
+/// 2 <----3     4
+/// ```
+/// Note that the edges are technically undirected, but we denote here the order of the nodes when
+/// adding the edges to the graph.
+///
+/// The macro returns a tuple containing the constructed graph,
+/// a vector of the indices of added nodes, and a vector of the indices of added edges.
+///
+/// For ordering of added nodes and edges, see the implementation of the macro.
+#[macro_export]
+macro_rules! create_undirected_test_graph {
+    ($graph_constructor:expr, $add_node:expr, $add_edge:expr) => {{
+        let mut graph = $graph_constructor();
+
+        let node_zero = $add_node(&mut graph, ());
+        let node_one = $add_node(&mut graph, ());
+        let node_two = $add_node(&mut graph, ());
+        let node_three = $add_node(&mut graph, ());
+        let node_four = $add_node(&mut graph, ());
+
+        let nodes = [node_zero, node_one, node_two, node_three, node_four];
+
+        let edge_zero = $add_edge(&mut graph, nodes[0], nodes[1], ());
+        let edge_one = $add_edge(&mut graph, nodes[0], nodes[2], ());
+        let edge_two = $add_edge(&mut graph, nodes[1], nodes[3], ());
+        let edge_three = $add_edge(&mut graph, nodes[3], nodes[2], ());
+
+        let edges = [edge_zero, edge_one, edge_two, edge_three];
+
+        assert_eq!(
+            nodes.len(),
+            $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_NODE_COUNT
+        );
+        assert_eq!(
+            edges.len(),
+            $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_EDGE_COUNT
+        );
+
+        (graph, nodes, edges)
+    }};
+}

--- a/crates/core/src/utils/testing/undirected.rs
+++ b/crates/core/src/utils/testing/undirected.rs
@@ -148,6 +148,7 @@ macro_rules! test_undirected_graph {
                 nodes.iter().copied(),
                 $crate::graph::UndirectedGraph::nodes(&graph).map(|node| node.id),
                 "nodes",
+                "UndirectedGraph",
                 "graph",
             );
         }
@@ -167,6 +168,7 @@ macro_rules! test_undirected_graph {
                 nodes.iter().copied(),
                 $crate::graph::UndirectedGraph::nodes_mut(&mut graph).map(|node| node.id),
                 "nodes_mut",
+                "UndirectedGraph",
                 "graph",
             );
         }
@@ -180,6 +182,7 @@ macro_rules! test_undirected_graph {
                 [nodes[4]],
                 $crate::graph::UndirectedGraph::isolated_nodes(&graph).map(|node| node.id),
                 "isolated_nodes",
+                "UndirectedGraph",
                 "graph",
             );
         }
@@ -421,6 +424,7 @@ macro_rules! test_undirected_graph {
                     core::iter::IntoIterator::into_iter(expected_nodes).flatten(),
                     $crate::graph::UndirectedGraph::adjacencies(&graph, nodes[node_number]),
                     "adjacencies",
+                    "UndirectedGraph",
                     format_args!("node {}", node_number),
                 );
             }

--- a/crates/core/src/utils/testing/undirected.rs
+++ b/crates/core/src/utils/testing/undirected.rs
@@ -49,3 +49,557 @@ macro_rules! create_undirected_test_graph {
         (graph, nodes, edges)
     }};
 }
+
+/// Generates a suite of tests for [`UndirectedGraph`][crate::graph::UndirectedGraph]
+/// implementations.
+///
+/// One test is generated for each method in the [`UndirectedGraph`][crate::graph::UndirectedGraph]
+/// trait. The following invariants are expected from the graph implementation:
+/// - If the most recently added node or edge is removed, its ID will no longer be valid. I.e.,
+///   calling methods with that ID should return `None` or otherwise indicate non-existence.
+///
+/// The arguments to this macro are as follows (`G` is used to denote the graph type being tested).
+/// - `$graph_constructor`: An expression that constructs a new instance of the graph type to be
+///   tested. The generated graph must be empty (e.g. `G::new()`).
+/// - `$add_node`: An expression that adds a node to the graph. It must take two arguments: a
+///   mutable reference to the graph and the node weight. It must return the `<G as Graph>::NodeId`
+///   of the added node.
+/// - `$remove_node`: An expression that removes a node from the graph. It must take two arguments:
+///   a mutable reference to the graph and the `<G as Graph>::NodeId` of the node to be removed. The
+///   method should not return anything, i.e. it should panic on failure.
+/// - `$add_edge`: An expression that adds an edge to the graph. It must take four arguments: a
+///   mutable reference to the graph, the `<G as Graph>::NodeId` of the two endpoint nodes, and the
+///   edge weight. It must return the `<G as Graph>::EdgeId` of the added edge.
+/// - `$remove_edge`: An expression that removes an edge from the graph. It must take two arguments:
+///   a mutable reference to the graph and the `<G as Graph>::EdgeId` of the edge to be removed. The
+///   method should not return anything, i.e. it should panic on failure.
+#[macro_export]
+macro_rules! test_undirected_graph {
+    (
+        $graph_constructor:expr,
+        $add_node:expr,
+        $remove_node:expr,
+        $add_edge:expr,
+        $remove_edge:expr
+    ) => {
+        #[test]
+        fn test_density_hint() {
+            let (graph, _, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            // DensityHint is a hint, so this is intentionally only a smoke test.
+            let _density_hint = $crate::graph::UndirectedGraph::density_hint(&graph);
+        }
+
+        #[test]
+        fn test_cardinality() {
+            let (mut graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            assert_eq!(
+                $crate::graph::UndirectedGraph::node_count(&graph),
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_NODE_COUNT,
+                "UndirectedGraph::node_count() did not match expected value"
+            );
+            assert_eq!(
+                $crate::graph::UndirectedGraph::edge_count(&graph),
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_EDGE_COUNT,
+                "UndirectedGraph::edge_count() did not match expected value"
+            );
+
+            let cardinality = $crate::graph::UndirectedGraph::cardinality(&graph);
+            assert_eq!(
+                cardinality.order,
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_NODE_COUNT,
+                "UndirectedGraph::cardinality().order did not match expected value"
+            );
+            assert_eq!(
+                cardinality.size,
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_EDGE_COUNT,
+                "UndirectedGraph::cardinality().size did not match expected value"
+            );
+
+            $remove_node(&mut graph, nodes[0]);
+
+            assert_eq!(
+                $crate::graph::UndirectedGraph::node_count(&graph),
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_NODE_COUNT - 1,
+                "UndirectedGraph::node_count() did not match expected value after removing node 0"
+            );
+            assert_eq!(
+                $crate::graph::UndirectedGraph::edge_count(&graph),
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_EDGE_COUNT - 2,
+                "UndirectedGraph::edge_count() did not match expected value after removing node 0"
+            );
+        }
+
+        #[test]
+        fn test_nodes() {
+            let (graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            assert_eq!(
+                $crate::graph::UndirectedGraph::nodes(&graph).count(),
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_NODE_COUNT,
+                "UndirectedGraph::nodes().count() did not match expected value"
+            );
+
+            $crate::utils::testing::check_if_nodes_match(
+                nodes.iter().copied(),
+                $crate::graph::UndirectedGraph::nodes(&graph).map(|node| node.id),
+                "nodes",
+                "graph",
+            );
+        }
+
+        #[test]
+        fn test_nodes_mut() {
+            let (mut graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            assert_eq!(
+                $crate::graph::UndirectedGraph::nodes_mut(&mut graph).count(),
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_NODE_COUNT,
+                "UndirectedGraph::nodes_mut().count() did not match expected value"
+            );
+
+            $crate::utils::testing::check_if_nodes_match(
+                nodes.iter().copied(),
+                $crate::graph::UndirectedGraph::nodes_mut(&mut graph).map(|node| node.id),
+                "nodes_mut",
+                "graph",
+            );
+        }
+
+        #[test]
+        fn test_isolated_nodes() {
+            let (graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            $crate::utils::testing::check_if_nodes_match(
+                [nodes[4]],
+                $crate::graph::UndirectedGraph::isolated_nodes(&graph).map(|node| node.id),
+                "isolated_nodes",
+                "graph",
+            );
+        }
+
+        #[test]
+        fn test_edges() {
+            let (graph, _, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            assert_eq!(
+                $crate::graph::UndirectedGraph::edges(&graph).count(),
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_EDGE_COUNT,
+                "UndirectedGraph::edges().count() did not match expected value"
+            );
+
+            $crate::utils::testing::check_if_edges_match(
+                edges.iter().copied(),
+                $crate::graph::UndirectedGraph::edges(&graph).map(|edge| edge.id),
+                "edges",
+                "UndirectedGraph",
+                "graph",
+            );
+        }
+
+        #[test]
+        fn test_edges_mut() {
+            let (mut graph, _, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            assert_eq!(
+                $crate::graph::UndirectedGraph::edges_mut(&mut graph).count(),
+                $crate::utils::testing::undirected::UNDIRECTED_TEST_GRAPH_EDGE_COUNT,
+                "UndirectedGraph::edges_mut().count() did not match expected value"
+            );
+
+            $crate::utils::testing::check_if_edges_match(
+                edges.iter().copied(),
+                $crate::graph::UndirectedGraph::edges_mut(&mut graph).map(|edge| edge.id),
+                "edges_mut",
+                "UndirectedGraph",
+                "graph",
+            );
+        }
+
+        #[test]
+        fn test_node() {
+            let (mut graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for &node_id in &nodes {
+                let node = $crate::graph::UndirectedGraph::node(&graph, node_id)
+                    .expect("Expected node not found in test_node");
+                assert_eq!(
+                    node.id, node_id,
+                    "UndirectedGraph::node() did not return expected node id"
+                );
+            }
+
+            // We remove node 4 here, as some graph implementations might not have stable node ids,
+            // but the newest node added is likely to be removable without another node taking its
+            // id.
+            $remove_node(&mut graph, nodes[4]);
+
+            assert!(
+                $crate::graph::UndirectedGraph::node(&graph, nodes[4]).is_none(),
+                "UndirectedGraph::node() did not return None for removed node id"
+            );
+        }
+
+        #[test]
+        fn test_node_mut() {
+            let (mut graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for &node_id in &nodes {
+                let node = $crate::graph::UndirectedGraph::node_mut(&mut graph, node_id)
+                    .expect("Expected node not found in test_node_mut");
+                assert_eq!(
+                    node.id, node_id,
+                    "UndirectedGraph::node_mut() did not return expected node id"
+                );
+            }
+
+            // We remove node 4 here, as some graph implementations might not have stable node ids,
+            // but the newest node added is likely to be removable without another node taking its
+            // id.
+            $remove_node(&mut graph, nodes[4]);
+
+            assert!(
+                $crate::graph::UndirectedGraph::node_mut(&mut graph, nodes[4]).is_none(),
+                "UndirectedGraph::node_mut() did not return None for removed node id"
+            );
+        }
+
+        #[test]
+        fn test_edge() {
+            let (mut graph, _, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for &edge_id in &edges {
+                let edge = $crate::graph::UndirectedGraph::edge(&graph, edge_id)
+                    .expect("Expected edge not found in test_edge");
+                assert_eq!(
+                    edge.id, edge_id,
+                    "UndirectedGraph::edge() did not return expected edge id"
+                );
+            }
+
+            // We remove edge 3 here, as some graph implementations might not have stable edge ids,
+            // but the newest edge added is likely to be removable without another edge taking its
+            // id.
+            $remove_edge(&mut graph, edges[3]);
+
+            assert!(
+                $crate::graph::UndirectedGraph::edge(&graph, edges[3]).is_none(),
+                "UndirectedGraph::edge() did not return None for removed edge id"
+            );
+        }
+
+        #[test]
+        fn test_edge_mut() {
+            let (mut graph, _, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for &edge_id in &edges {
+                let edge = $crate::graph::UndirectedGraph::edge_mut(&mut graph, edge_id)
+                    .expect("Expected edge not found in test_edge_mut");
+                assert_eq!(
+                    edge.id, edge_id,
+                    "UndirectedGraph::edge_mut() did not return expected edge id"
+                );
+            }
+
+            // We remove edge 3 here, as some graph implementations might not have stable edge ids,
+            // but the newest edge added is likely to be removable without another edge taking its
+            // id.
+            $remove_edge(&mut graph, edges[3]);
+
+            assert!(
+                $crate::graph::UndirectedGraph::edge_mut(&mut graph, edges[3]).is_none(),
+                "UndirectedGraph::edge_mut() did not return None for removed edge id"
+            );
+        }
+
+        #[test]
+        fn test_degree() {
+            let (graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            let expected_degrees = [
+                (nodes[0], 0, 2),
+                (nodes[1], 1, 2),
+                (nodes[2], 2, 2),
+                (nodes[3], 3, 2),
+                (nodes[4], 4, 0),
+            ];
+
+            for &(node_id, node_number, expected_degree) in &expected_degrees {
+                assert_eq!(
+                    $crate::graph::UndirectedGraph::degree(&graph, node_id),
+                    expected_degree,
+                    "UndirectedGraph::degree() did not return expected value for node {}",
+                    node_number
+                );
+            }
+        }
+
+        #[test]
+        fn test_incident_edges() {
+            let (graph, nodes, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for node_number in 0..nodes.len() {
+                let expected_edges = match node_number {
+                    0 => [Some(edges[0]), Some(edges[1])],
+                    1 => [Some(edges[0]), Some(edges[2])],
+                    2 => [Some(edges[1]), Some(edges[3])],
+                    3 => [Some(edges[2]), Some(edges[3])],
+                    4 => [None, None],
+                    _ => unreachable!(),
+                };
+
+                $crate::utils::testing::check_if_edges_match(
+                    core::iter::IntoIterator::into_iter(expected_edges).flatten(),
+                    $crate::graph::UndirectedGraph::incident_edges(&graph, nodes[node_number])
+                        .map(|edge| edge.id),
+                    "incident_edges",
+                    "UndirectedGraph",
+                    format_args!("node {}", node_number),
+                );
+            }
+        }
+
+        #[test]
+        fn test_incident_edges_mut() {
+            let (mut graph, nodes, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for node_number in 0..nodes.len() {
+                let expected_edges = match node_number {
+                    0 => [Some(edges[0]), Some(edges[1])],
+                    1 => [Some(edges[0]), Some(edges[2])],
+                    2 => [Some(edges[1]), Some(edges[3])],
+                    3 => [Some(edges[2]), Some(edges[3])],
+                    4 => [None, None],
+                    _ => unreachable!(),
+                };
+
+                $crate::utils::testing::check_if_edges_match(
+                    core::iter::IntoIterator::into_iter(expected_edges).flatten(),
+                    $crate::graph::UndirectedGraph::incident_edges_mut(
+                        &mut graph,
+                        nodes[node_number],
+                    )
+                    .map(|edge| edge.id),
+                    "incident_edges_mut",
+                    "UndirectedGraph",
+                    format_args!("node {}", node_number),
+                );
+            }
+        }
+
+        #[test]
+        fn test_adjacencies() {
+            let (graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for node_number in 0..nodes.len() {
+                let expected_nodes = match node_number {
+                    0 => [Some(nodes[1]), Some(nodes[2])],
+                    1 => [Some(nodes[0]), Some(nodes[3])],
+                    2 => [Some(nodes[0]), Some(nodes[3])],
+                    3 => [Some(nodes[1]), Some(nodes[2])],
+                    4 => [None, None],
+                    _ => unreachable!(),
+                };
+
+                $crate::utils::testing::check_if_nodes_match(
+                    core::iter::IntoIterator::into_iter(expected_nodes).flatten(),
+                    $crate::graph::UndirectedGraph::adjacencies(&graph, nodes[node_number]),
+                    "adjacencies",
+                    format_args!("node {}", node_number),
+                );
+            }
+        }
+
+        #[test]
+        fn test_edges_connecting() {
+            let (graph, nodes, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            let expected_edge_matrix = [
+                [None, Some(edges[0]), Some(edges[1]), None, None],
+                [Some(edges[0]), None, None, Some(edges[2]), None],
+                [Some(edges[1]), None, None, Some(edges[3]), None],
+                [None, Some(edges[2]), Some(edges[3]), None, None],
+                [None, None, None, None, None],
+            ];
+
+            for lhs_number in 0..nodes.len() {
+                for rhs_number in 0..nodes.len() {
+                    $crate::utils::testing::check_if_edges_match(
+                        expected_edge_matrix[lhs_number][rhs_number],
+                        $crate::graph::UndirectedGraph::edges_connecting(
+                            &graph,
+                            nodes[lhs_number],
+                            nodes[rhs_number],
+                        )
+                        .map(|edge| edge.id),
+                        "edges_connecting",
+                        "UndirectedGraph",
+                        format_args!("node pair ({}, {})", lhs_number, rhs_number),
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn test_edges_connecting_mut() {
+            let (mut graph, nodes, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            let expected_edge_matrix = [
+                [None, Some(edges[0]), Some(edges[1]), None, None],
+                [Some(edges[0]), None, None, Some(edges[2]), None],
+                [Some(edges[1]), None, None, Some(edges[3]), None],
+                [None, Some(edges[2]), Some(edges[3]), None, None],
+                [None, None, None, None, None],
+            ];
+
+            for lhs_number in 0..nodes.len() {
+                for rhs_number in 0..nodes.len() {
+                    $crate::utils::testing::check_if_edges_match(
+                        expected_edge_matrix[lhs_number][rhs_number],
+                        $crate::graph::UndirectedGraph::edges_connecting_mut(
+                            &mut graph,
+                            nodes[lhs_number],
+                            nodes[rhs_number],
+                        )
+                        .map(|edge| edge.id),
+                        "edges_connecting_mut",
+                        "UndirectedGraph",
+                        format_args!("node pair ({}, {})", lhs_number, rhs_number),
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn test_contains_node() {
+            let (mut graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for &node in &nodes {
+                assert!(
+                    $crate::graph::UndirectedGraph::contains_node(&graph, node),
+                    "UndirectedGraph::contains_node() returned false for existing node: {:?}",
+                    node
+                );
+            }
+
+            // We remove node 4 here, as some graph implementations might not have stable node ids,
+            // but the newest node added is likely to be removable without another node taking its
+            // id.
+            $remove_node(&mut graph, nodes[4]);
+
+            assert!(
+                !$crate::graph::UndirectedGraph::contains_node(&graph, nodes[4]),
+                "UndirectedGraph::contains_node() returned true for removed node: {:?}",
+                nodes[4]
+            );
+        }
+
+        #[test]
+        fn test_contains_edge() {
+            let (mut graph, _, edges) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            for &edge in &edges {
+                assert!(
+                    $crate::graph::UndirectedGraph::contains_edge(&graph, edge),
+                    "UndirectedGraph::contains_edge() returned false for existing edge: {:?}",
+                    edge
+                );
+            }
+
+            // We remove edge 3 here, as some graph implementations might not have stable edge ids,
+            // but the newest edge added is likely to be removable without another edge taking its
+            // id.
+            $remove_edge(&mut graph, edges[3]);
+
+            assert!(
+                !$crate::graph::UndirectedGraph::contains_edge(&graph, edges[3]),
+                "UndirectedGraph::contains_edge() returned true for removed edge: {:?}",
+                edges[3]
+            );
+        }
+
+        #[test]
+        fn test_is_adjacent() {
+            let (graph, nodes, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            let expected_adjacency_matrix = [
+                [false, true, true, false, false],
+                [true, false, false, true, false],
+                [true, false, false, true, false],
+                [false, true, true, false, false],
+                [false, false, false, false, false],
+            ];
+
+            for lhs_number in 0..nodes.len() {
+                for rhs_number in 0..nodes.len() {
+                    assert_eq!(
+                        $crate::graph::UndirectedGraph::is_adjacent(
+                            &graph,
+                            nodes[lhs_number],
+                            nodes[rhs_number],
+                        ),
+                        expected_adjacency_matrix[lhs_number][rhs_number],
+                        "UndirectedGraph::is_adjacent() returned incorrect result for nodes {:?} \
+                         and {:?}",
+                        nodes[lhs_number],
+                        nodes[rhs_number]
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn test_is_empty() {
+            let (graph, _, _) =
+                $crate::create_undirected_test_graph!($graph_constructor, $add_node, $add_edge);
+
+            assert!(
+                !$crate::graph::UndirectedGraph::is_empty(&graph),
+                "UndirectedGraph::is_empty() returned true for a non-empty graph"
+            );
+
+            let mut new_graph = $graph_constructor();
+
+            assert!(
+                $crate::graph::UndirectedGraph::is_empty(&new_graph),
+                "UndirectedGraph::is_empty() returned false for an empty graph"
+            );
+
+            let node_one = $add_node(&mut new_graph, ());
+
+            assert!(
+                !$crate::graph::UndirectedGraph::is_empty(&new_graph),
+                "UndirectedGraph::is_empty() returned true for a graph with one node"
+            );
+
+            $remove_node(&mut new_graph, node_one);
+
+            assert!(
+                $crate::graph::UndirectedGraph::is_empty(&new_graph),
+                "UndirectedGraph::is_empty() returned false for an empty graph after removing the \
+                 only node"
+            );
+        }
+    };
+}


### PR DESCRIPTION
Add a macro that generates automatic tests for graphs implementing the `UndirectedGraph` trait similar to the existing tests for `DirectedGraph`s (see https://github.com/petgraph/petgraph/pull/947).

Thus, moves the test macro for `DirectedGraph` into its own module and applies the new tests to the `UndirectedTestGraph`.