### PR TITLE
fix: reverse adjacency queries on Reversed graphs

### DIFF
--- a/crates/petgraph/src/visit/reversed.rs
+++ b/crates/petgraph/src/visit/reversed.rs
@@ -197,4 +197,15 @@ GraphProp! {delegate_impl [[G], G, Reversed<G>, access0]}
 NodeCount! {delegate_impl [[G], G, Reversed<G>, access0]}
 EdgeCount! {delegate_impl [[G], G, Reversed<G>, access0]}
 EdgeIndexable! {delegate_impl [[G], G, Reversed<G>, access0]}
-GetAdjacencyMatrix! {delegate_impl [[G], G, Reversed<G>, access0]}
+
+impl<G: GetAdjacencyMatrix> GetAdjacencyMatrix for Reversed<G> {
+    type AdjMatrix = G::AdjMatrix;
+
+    fn adjacency_matrix(&self) -> Self::AdjMatrix {
+        self.0.adjacency_matrix()
+    }
+
+    fn is_adjacent(&self, matrix: &Self::AdjMatrix, a: Self::NodeId, b: Self::NodeId) -> bool {
+        self.0.is_adjacent(matrix, b, a)
+    }
+}

--- a/crates/petgraph/tests/adjacency_matrix.rs
+++ b/crates/petgraph/tests/adjacency_matrix.rs
@@ -8,7 +8,9 @@ use petgraph::{
     Directed, EdgeType, Graph, Undirected,
     adj::List,
     csr::Csr,
-    visit::{EdgeRef, GetAdjacencyMatrix, GraphProp, IntoEdgeReferences, IntoNodeIdentifiers},
+    visit::{
+        EdgeRef, GetAdjacencyMatrix, GraphProp, IntoEdgeReferences, IntoNodeIdentifiers, Reversed,
+    },
 };
 
 fn test_adjacency_matrix<G>(g: G)
@@ -54,6 +56,20 @@ fn test_adjacency_matrix_for_graph_directed() {
 #[test]
 fn test_adjacency_matrix_for_graph_undirected() {
     test_adjacency_matrix_for_graph::<Undirected>();
+}
+
+#[test]
+fn test_adjacency_matrix_for_reversed() {
+    for (order, edges) in TEST_CASES {
+        let mut g: Graph<(), (), Directed, u16> = Graph::with_capacity(order, edges.len());
+
+        for _ in 0..order {
+            g.add_node(());
+        }
+        g.extend_with_edges(edges);
+
+        test_adjacency_matrix(Reversed(&g));
+    }
 }
 
 #[cfg(feature = "stable_graph")]

--- a/crates/petgraph/tests/iso.rs
+++ b/crates/petgraph/tests/iso.rs
@@ -9,6 +9,7 @@ use petgraph::{
     },
     graph::{edge_index, node_index},
     prelude::*,
+    visit::Reversed,
 };
 
 /// Petersen A and B are isomorphic
@@ -582,6 +583,30 @@ fn iter_subgraph() {
             .collect::<Vec<_>>(),
         vec![vec![2, 3]]
     );
+}
+
+#[test]
+fn iso_reversed() {
+    // https://github.com/petgraph/petgraph/issues/912
+    let g = DiGraph::<(), ()>::from_edges([(0, 1)]);
+    let rg = Reversed(&g);
+    assert!(is_isomorphic(rg, rg));
+    assert!(is_isomorphic(&g, rg));
+
+    let mut node_match = { |x: &(), y: &()| x == y };
+    let mut edge_match = { |x: &(), y: &()| x == y };
+    assert!(
+        subgraph_isomorphisms_iter(&rg, &rg, &mut node_match, &mut edge_match)
+            .unwrap()
+            .next()
+            .is_some()
+    );
+
+    // Outdegree sequences (2,1,0,0) vs (1,1,1,0): a graph that is not
+    // isomorphic to its transpose.
+    let h = DiGraph::<(), ()>::from_edges([(0, 1), (1, 2), (0, 3)]);
+    assert!(is_isomorphic(Reversed(&h), Reversed(&h)));
+    assert!(!is_isomorphic(&h, Reversed(&h)));
 }
 
 /// Isomorphic pair


### PR DESCRIPTION
`is_isomorphic` and `subgraph_isomorphisms_iter` always fail on a `Reversed` directed graph, including a graph compared with itself:

```
let g = DiGraph::<(), ()>::from_edges([(0, 1)]);
assert!(algo::is_isomorphic(Reversed(&g), Reversed(&g)));
```

VF2 walks neighbors through `IntoNeighborsDirected`, which `Reversed` already flips, then checks those neighbors with `GetAdjacencyMatrix::is_adjacent`. That impl was delegated unchanged, so it still answered in the original orientation. Neighbors of 1 include 0, `is_adjacent(1, 0)` is false, and the mapping is rejected.

Swap the endpoints in `Reversed::is_adjacent`. The stored matrix is still the inner graph's; only the query is transposed. Undirected graphs are unchanged because their matrices are symmetric.

`iso_reversed` is the reported one-edge case, plus a graph that is not isomorphic to its transpose so the adaptor does not just always return true. `test_adjacency_matrix_for_reversed` checks the matrix against `edge_references()` on the adaptor.

`cargo test -p petgraph --all-features` is green.

Fixes #912
